### PR TITLE
M140 S0 (Bed cooldown) integration into Custom G-code End Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,10 @@ The author of the Silk icon set is Mark James.
         --solid-fill-pattern Pattern to use to fill solid layers (default: rectilinear)
         --start-gcode       Load initial G-code from the supplied file. This will overwrite
                             the default command (home all axes [G28]).
-        --end-gcode         Load final G-code from the supplied file. This will overwrite
-                            the default commands (turn off temperature [M104 S0],
-                            home X axis [G28 X], disable motors [M84]).
+    --end-gcode         Load final G-code from the supplied file. This will overwrite 
+                        the default commands (turn off temperature for hotend [M104 S0],
+                        turn off temperature for bed [M140 S0] home X axis [G28 X],
+                        disable motors [M84]).
         --layer-gcode       Load layer-change G-code from the supplied file (default: nothing).
         --toolchange-gcode  Load tool-change G-code from the supplied file (default: nothing).
         --seam-position     Position of loop starting points (random/nearest/aligned, default: aligned).

--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ The author of the Silk icon set is Mark James.
         --solid-fill-pattern Pattern to use to fill solid layers (default: rectilinear)
         --start-gcode       Load initial G-code from the supplied file. This will overwrite
                             the default command (home all axes [G28]).
-    --end-gcode         Load final G-code from the supplied file. This will overwrite 
-                        the default commands (turn off temperature for hotend [M104 S0],
-                        turn off temperature for bed [M140 S0] home X axis [G28 X],
-                        disable motors [M84]).
+        --end-gcode         Load final G-code from the supplied file. This will overwrite 
+                            the default commands (turn off temperature for hotend [M104 S0],
+                            turn off temperature for bed [M140 S0] home X axis [G28 X],
+                            disable motors [M84]).
         --layer-gcode       Load layer-change G-code from the supplied file (default: nothing).
         --toolchange-gcode  Load tool-change G-code from the supplied file (default: nothing).
         --seam-position     Position of loop starting points (random/nearest/aligned, default: aligned).

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -368,8 +368,9 @@ $j
     --start-gcode       Load initial G-code from the supplied file. This will overwrite
                         the default command (home all axes [G28]).
     --end-gcode         Load final G-code from the supplied file. This will overwrite 
-                        the default commands (turn off temperature [M104 S0],
-                        home X axis [G28 X], disable motors [M84]).
+                        the default commands (turn off temperature for hotend [M104 S0],
+                        turn off temperature for bed [M140 S0] home X axis [G28 X],
+                        disable motors [M84]).
     --layer-gcode       Load layer-change G-code from the supplied file (default: nothing).
     --toolchange-gcode  Load tool-change G-code from the supplied file (default: nothing).
     --seam-position     Position of loop starting points (random/nearest/aligned, default: $config->{seam_position}).

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -460,7 +460,7 @@ class PrintConfig : public GCodeConfig
         this->default_acceleration.value                         = 0;
         this->disable_fan_first_layers.value                     = 1;
         this->duplicate_distance.value                           = 6;
-        this->end_gcode.value                                    = "M104 S0 ; turn off temperature\nG28 X0  ; home X axis\nM84     ; disable motors\n";
+        this->end_gcode.value                                    = "M104 S0 ; turn off temperature for hotend\nM140 S0; turn off temperature for bed\nG28 X0  ; home X axis\nM84     ; disable motors\n";
         this->extruder_clearance_height.value                    = 20;
         this->extruder_clearance_radius.value                    = 20;
         this->extruder_offset.values.resize(1);


### PR DESCRIPTION
The change that I made in this pull request is to set "turn off the bed once the print is done" (M140 S0) into the default Slic3r Custom G-code End Commands.

When printing, I find it helpful to shut off the bed once the print is done, so that the parts can be removed. I added this command into my setup of Slic3r and find it useful, which is why I think it should be a default command.

Comments and thoughts appreciated.

blue-ice
