### PR TITLE
Fix temperature setting on multiple extruders, fixes #3101

### DIFF
--- a/t/custom_gcode.t
+++ b/t/custom_gcode.t
@@ -77,16 +77,16 @@ use Slic3r::Test;
     {
         my $print = Slic3r::Test::init_print('20mm_cube', config => $config);
         my $gcode = Slic3r::Test::gcode($print);
-        ok $gcode =~ /M104 S205 T1/, 'temperature set correctly for non-zero yet single extruder';
-        ok $gcode !~ /M104 S\d+ T0/, 'unused extruder correctly ignored';
+        ok $gcode =~ /T1\nM104 S205/, 'temperature set correctly for non-zero yet single extruder';
+        ok $gcode !~ /T0\nM104 S\d+/m, 'unused extruder correctly ignored' . substr($gcode, 0, 400);
     }
     
     $config->set('infill_extruder', 1);
     {
         my $print = Slic3r::Test::init_print('20mm_cube', config => $config);
         my $gcode = Slic3r::Test::gcode($print);
-        ok $gcode =~ /M104 S200 T0/, 'temperature set correctly for first extruder';
-        ok $gcode =~ /M104 S205 T1/, 'temperature set correctly for second extruder';
+        ok $gcode =~ /T0\nM104 S200/m, 'temperature set correctly for first extruder';
+        ok $gcode =~ /T1\nM104 S205/m, 'temperature set correctly for second extruder';
     }
     
     $config->set('start_gcode', qq!

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -90,7 +90,14 @@ GCodeWriter::set_temperature(unsigned int temperature, bool wait, int tool)
         comment = "set temperature";
     }
     
+    int original_extruder;
     std::ostringstream gcode;
+
+    if(tool != -1 && this->multiple_extruders && FLAVOR_IS(gcfRepRap)) {
+        original_extruder = this->_extruder->id;
+        gcode << this->set_extruder(tool);
+    }
+
     gcode << code << " ";
     if (FLAVOR_IS(gcfMach3) || FLAVOR_IS(gcfMachinekit)) {
         gcode << "P";
@@ -98,13 +105,17 @@ GCodeWriter::set_temperature(unsigned int temperature, bool wait, int tool)
         gcode << "S";
     }
     gcode << temperature;
-    if (tool != -1 && (this->multiple_extruders || FLAVOR_IS(gcfMakerWare) || FLAVOR_IS(gcfSailfish))) {
+    if (tool != -1 && (this->multiple_extruders || FLAVOR_IS(gcfMakerWare) || FLAVOR_IS(gcfSailfish)) && FLAVOR_IS_NOT(gcfRepRap)) {
         gcode << " T" << tool;
     }
     gcode << " ; " << comment << "\n";
     
     if (FLAVOR_IS(gcfTeacup) && wait)
         gcode << "M116 ; wait for temperature to be reached\n";
+
+    if(tool != -1 && this->multiple_extruders && FLAVOR_IS(gcfRepRap)) {
+        gcode << this->set_extruder(original_extruder);
+    }
     
     return gcode.str();
 }

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -90,11 +90,13 @@ GCodeWriter::set_temperature(unsigned int temperature, bool wait, int tool)
         comment = "set temperature";
     }
     
-    int original_extruder;
+    int restore_extruder = -1;
     std::ostringstream gcode;
 
     if(tool != -1 && this->multiple_extruders && FLAVOR_IS(gcfRepRap)) {
-        original_extruder = this->_extruder->id;
+        if(this->_extruder != NULL) {
+            restore_extruder = this->_extruder->id;
+        }
         gcode << this->set_extruder(tool);
     }
 
@@ -113,8 +115,8 @@ GCodeWriter::set_temperature(unsigned int temperature, bool wait, int tool)
     if (FLAVOR_IS(gcfTeacup) && wait)
         gcode << "M116 ; wait for temperature to be reached\n";
 
-    if(tool != -1 && this->multiple_extruders && FLAVOR_IS(gcfRepRap)) {
-        gcode << this->set_extruder(original_extruder);
+    if(restore_extruder != -1) {
+        gcode << this->set_extruder(restore_extruder);
     }
     
     return gcode.str();

--- a/xs/src/libslic3r/GCodeWriter.hpp
+++ b/xs/src/libslic3r/GCodeWriter.hpp
@@ -58,6 +58,7 @@ class GCodeWriter {
     
     std::string _travel_to_z(double z, const std::string &comment);
     std::string _retract(double length, double restart_extra, const std::string &comment);
+    std::string _toolchange(unsigned int extruder_id, bool reset_e);
 };
 
 }


### PR DESCRIPTION
By [0], repraps does not support toolhead "T%d" parameter M104.
This is indeed the case for Smoothie. It interpretes "M104 Snnn Tn" as
M104 Snnn
Tn
so it may cause unwanted toolhead change.
[0] http://reprap.org/wiki/G-code#M104:_Set_Extruder_Temperature
