### PR TITLE
emit M200 D0 on disabled volumetric extrusion

### DIFF
--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -61,6 +61,10 @@ GCodeWriter::preamble()
             gcode << "M82 ; use absolute distances for extrusion\n";
         }
         gcode << this->reset_e(true);
+
+        if (!this->config.use_volumetric_e) {
+            gcode << "M200 D0 ; reset filament diameter (due to disabled volumetric extrusion)\n";
+        }
     }
     
     return gcode.str();


### PR DESCRIPTION
This fixes an issues that was haunting me for hours trying to fix my seemingly random under/over-extrusion issues which were caused by volumetric extrusion enabled in firmware (from prior attempts to use it) but not in Slic3r.

After I've disabled volumetric in firmware everything went back to normal.

This is quite suboptimal as there are two places where you have to disable volumetric to actually disable it and may cause headaches for people unaware of it.
