### PR TITLE
Use set-and-wait gcode for set_bed_temperature instead of just set.

### DIFF
--- a/lib/Slic3r/GUI/Tab.pm
+++ b/lib/Slic3r/GUI/Tab.pm
@@ -995,11 +995,11 @@ sub build {
         serial_port serial_speed
         octoprint_host octoprint_apikey
         use_firmware_retraction pressure_advance vibration_limit
-        use_volumetric_e
+        use_volumetric_e set_and_wait_temperatures
         start_gcode end_gcode before_layer_gcode layer_gcode toolchange_gcode
         nozzle_diameter extruder_offset
         retract_length retract_lift retract_speed retract_restart_extra retract_before_travel retract_layer_change wipe
-        retract_length_toolchange retract_restart_extra_toolchange
+        retract_length_toolchange retract_restart_extra_toolchange 
     ));
     $self->{config}->set('printer_settings_id', '');
     
@@ -1190,6 +1190,7 @@ sub build {
             $optgroup->append_single_option_line('use_volumetric_e');
             $optgroup->append_single_option_line('pressure_advance');
             $optgroup->append_single_option_line('vibration_limit');
+            $optgroup->append_single_option_line('set_and_wait_temperatures');
         }
     }
     {

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -374,7 +374,7 @@ sub process_layer {
             $gcode .= $self->_gcodegen->writer->set_temperature($temperature, 0, $extruder->id)
                 if $temperature && $temperature != $self->config->get_at('first_layer_temperature', $extruder->id);
         }
-        $gcode .= $self->_gcodegen->writer->set_bed_temperature($self->print->config->bed_temperature, 1)
+        $gcode .= $self->_gcodegen->writer->set_bed_temperature($self->print->config->bed_temperature, $self->print->config->set_and_wait_temperatures)
             if $self->print->config->bed_temperature && $self->print->config->bed_temperature != $self->print->config->first_layer_bed_temperature;
         $self->_second_layer_things_done(1);
     }

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -374,7 +374,7 @@ sub process_layer {
             $gcode .= $self->_gcodegen->writer->set_temperature($temperature, 0, $extruder->id)
                 if $temperature && $temperature != $self->config->get_at('first_layer_temperature', $extruder->id);
         }
-        $gcode .= $self->_gcodegen->writer->set_bed_temperature($self->print->config->bed_temperature)
+        $gcode .= $self->_gcodegen->writer->set_bed_temperature($self->print->config->bed_temperature, 1)
             if $self->print->config->bed_temperature && $self->print->config->bed_temperature != $self->print->config->first_layer_bed_temperature;
         $self->_second_layer_things_done(1);
     }

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -301,6 +301,7 @@ $j
     --use-relative-e-distances Enable this to get relative E values (default: no)
     --use-firmware-retraction  Enable firmware-controlled retraction using G10/G11 (default: no)
     --use-volumetric-e  Express E in cubic millimeters and prepend M200 (default: no)
+    --set-and-wait-temperatures Use M190 instead of M140 for temperature changes past the first (default: no)
     --gcode-arcs        Use G2/G3 commands for native arcs (experimental, not supported
                         by all firmwares)
     --gcode-comments    Make G-code verbose by adding comments (default: no)

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1271,6 +1271,12 @@ PrintConfigDef::PrintConfigDef()
     def->cli = "use-volumetric-e!";
     def->default_value = new ConfigOptionBool(false);
 
+    def = this->add("set_and_wait_temperatures", coBool);
+    def->label = "Use Set and Wait for changing bed temperatures";
+    def->tooltip = "Check this to change gcode for temperature changes from not waiting (usually M140) to waiting (usually M190). Only necessary if you have a slow-to-heat bed and the first layer bed temp is lower than the other layers.";
+    def->cli = "set-and-wait-temperatures!";
+    def->default_value = new ConfigOptionBool(false);
+
     def = this->add("vibration_limit", coFloat);
     def->label = "Vibration limit (deprecated)";
     def->tooltip = "This experimental option will slow down those moves hitting the configured frequency limit. The purpose of limiting vibrations is to avoid mechanical resonance. Set zero to disable.";

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -266,6 +266,7 @@ class GCodeConfig : public virtual StaticPrintConfig
     ConfigOptionBool                use_firmware_retraction;
     ConfigOptionBool                use_relative_e_distances;
     ConfigOptionBool                use_volumetric_e;
+    ConfigOptionBool                set_and_wait_temperatures;
     
     GCodeConfig() : StaticPrintConfig() {
         this->set_defaults();
@@ -297,6 +298,7 @@ class GCodeConfig : public virtual StaticPrintConfig
         OPT_PTR(use_firmware_retraction);
         OPT_PTR(use_relative_e_distances);
         OPT_PTR(use_volumetric_e);
+        OPT_PTR(set_and_wait_temperatures);
         
         return NULL;
     };


### PR DESCRIPTION
Addresses #3268.
The default behavior doesn't play nice with a couple use cases (including the one referenced) and the set-and-wait shouldn't have any downsides for current users. 

There is a configuration option for this now; I'd be happy to move the configuration somewhere else. If it's preferred to just change the default behavior instead of config options I can revert the earlier config. 
