### PR TITLE
Fix octoprint ssl

### DIFF
--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -1400,10 +1400,6 @@ sub send_gcode {
     
     $self->statusbar->StartBusy;
     
-    use Net::SSL;
-    $ENV{HTTPS_VERSION} = 3;
-    $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0;
-
     my $ua = LWP::UserAgent->new;
     $ua->timeout(180);
     


### PR DESCRIPTION
This is my attempt to fix #3203.

For me it was necessary to disable the hostname check, no matter what I did perl was not able to verify the hostname, not even if I specify the path to the certificates... maybe someone can take a look at this part.

Next was to remove the hard coded http:// and replace it with a regex check, so basically I check if the url starts with http if not http:// will be appended.
But now you can add a https:// in front of the url so that it now gets recognized as a secure connection.

