### PR TITLE
Added translation string markers to libslic3r PrintConfig text.

### DIFF
--- a/translation/de_DE.po
+++ b/translation/de_DE.po
@@ -1,0 +1,2110 @@
+# Nathan Hellweg <nate-slic3r@pedantic.org>, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: Slic3r\n"
+"POT-Creation-Date: 2017-03-29 00:02-0600\n"
+"PO-Revision-Date: 2017-04-26 18:18-0700\n"
+"Last-Translator: Nathan Hellweg <nate-slic3r@pedantic.org>\n"
+"Language-Team: ok\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal 0.7.1\n"
+"X-Poedit-Basepath: ../\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __TRANS;__\n"
+"X-Poedit-SearchPath-0: xs/src/libslic3r\n"
+"X-Poedit-SearchPath-1: xs/xrc/slic3r/GUI\n"
+"X-Poedit-SearchPath-2: xs/xrc/slic3r\n"
+
+#: xs/src/libslic3r/PrintConfig.cpp:18
+msgid "Rectilinear"
+msgstr "Rechtwinkelig"
+
+#: xs/src/libslic3r/PrintConfig.cpp:19
+msgid "Concentric"
+msgstr "Konzentrisch"
+
+#: xs/src/libslic3r/PrintConfig.cpp:20
+msgid "Hilbert Curve"
+msgstr "Hilbert Kurve"
+
+#: xs/src/libslic3r/PrintConfig.cpp:21
+msgid "Archimedean Chords"
+msgstr "Archimedische Sehnen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:22
+msgid "Octagram Spiral"
+msgstr "Octagramspirale\t"
+
+#: xs/src/libslic3r/PrintConfig.cpp:27
+msgid "Avoid crossing perimeters"
+msgstr "Vermeide Umfangüberquerungen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:28 xs/src/libslic3r/PrintConfig.cpp:77
+#: xs/src/libslic3r/PrintConfig.cpp:252 xs/src/libslic3r/PrintConfig.cpp:259
+#: xs/src/libslic3r/PrintConfig.cpp:544 xs/src/libslic3r/PrintConfig.cpp:712
+#: xs/src/libslic3r/PrintConfig.cpp:726 xs/src/libslic3r/PrintConfig.cpp:820
+#: xs/src/libslic3r/PrintConfig.cpp:842 xs/src/libslic3r/PrintConfig.cpp:900
+#: xs/src/libslic3r/PrintConfig.cpp:1080 xs/src/libslic3r/PrintConfig.cpp:1230
+#: xs/src/libslic3r/PrintConfig.cpp:1442 xs/src/libslic3r/PrintConfig.cpp:1503
+msgid "Layers and Perimeters"
+msgstr "Schichten und Umfänge"
+
+#: xs/src/libslic3r/PrintConfig.cpp:29
+msgid ""
+"Optimize travel moves in order to minimize the crossing of perimeters. This "
+"is mostly useful with Bowden extruders which suffer from oozing. This "
+"feature slows down both the print and the G-code generation."
+msgstr ""
+"Optimire bewegungen um Umfangüberquerungen zu vermeiden.  Das ist "
+"hauptsächlich nützlich mit sickernden Bowden Extrudern.  Dass verlangsamt "
+"das Drucken und auch die G-Codegenerierung."
+
+#: xs/src/libslic3r/PrintConfig.cpp:34
+msgid "Bed shape"
+msgstr "Druckbrettprofil"
+
+#: xs/src/libslic3r/PrintConfig.cpp:44
+msgid "Has heated bed"
+msgstr "Hat Druckbrettheizung"
+
+#: xs/src/libslic3r/PrintConfig.cpp:45
+msgid ""
+"Unselecting this will suppress automatic generation of bed heating gcode."
+msgstr "Deaktivirung schaltet Generierung von druckbrett heizungs G-Code aus."
+
+#: xs/src/libslic3r/PrintConfig.cpp:50 xs/src/libslic3r/PrintConfig.cpp:1428
+msgid "Other layers"
+msgstr "Andere Schichten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:51
+msgid "Bed temperature for layers after the first one."
+msgstr "Druckbrettemperatur für Schichten nach der Ersten."
+
+#: xs/src/libslic3r/PrintConfig.cpp:53
+msgid "Bed temperature"
+msgstr "Druckbrettemperatur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:59
+msgid "Before layer change G-code"
+msgstr "Vorschichtwechsel G-Code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:60
+msgid ""
+"This custom code is inserted at every layer change, right before the Z move. "
+"Note that you can use placeholder variables for all Slic3r settings as well "
+"as [layer_num] and [layer_z]."
+msgstr ""
+"Dieser G-Code wird bei jedem Schichtwechsel gerade vor der Z Bewegung "
+"eingefügt.  Man kann Platzhalter für alle Slic3r Einstellugnen, sowie auch "
+"[layer_num] und [layer_z] benutzen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:68 xs/src/libslic3r/PrintConfig.cpp:76
+msgid "Bottom"
+msgstr "Boden"
+
+#: xs/src/libslic3r/PrintConfig.cpp:69
+msgid "Bottom infill pattern"
+msgstr "Boden Infill Muster"
+
+#: xs/src/libslic3r/PrintConfig.cpp:70 xs/src/libslic3r/PrintConfig.cpp:216
+#: xs/src/libslic3r/PrintConfig.cpp:425 xs/src/libslic3r/PrintConfig.cpp:437
+#: xs/src/libslic3r/PrintConfig.cpp:475 xs/src/libslic3r/PrintConfig.cpp:482
+#: xs/src/libslic3r/PrintConfig.cpp:624 xs/src/libslic3r/PrintConfig.cpp:634
+#: xs/src/libslic3r/PrintConfig.cpp:651 xs/src/libslic3r/PrintConfig.cpp:664
+#: xs/src/libslic3r/PrintConfig.cpp:671 xs/src/libslic3r/PrintConfig.cpp:686
+#: xs/src/libslic3r/PrintConfig.cpp:1168 xs/src/libslic3r/PrintConfig.cpp:1185
+#: xs/src/libslic3r/PrintConfig.cpp:1482
+msgid "Infill"
+msgstr "Infill"
+
+#: xs/src/libslic3r/PrintConfig.cpp:71
+msgid ""
+"Infill pattern for bottom layers. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+msgstr ""
+"Infill Muster für die Bodenschichten. Diese Einstellung betrifft nur die "
+"äusere sichtbare Schicht, und nicht den Rand nebenan."
+
+#: xs/src/libslic3r/PrintConfig.cpp:78
+msgid "Number of solid layers to generate on bottom surfaces."
+msgstr "Zahl der dichten Schichten die an den Unterseiten zu generieren ist."
+
+#: xs/src/libslic3r/PrintConfig.cpp:80
+msgid "Bottom solid layers"
+msgstr "Dichte Bodenschichten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:85
+msgid "Bridge"
+msgstr "Brücke"
+
+#: xs/src/libslic3r/PrintConfig.cpp:86 xs/src/libslic3r/PrintConfig.cpp:160
+#: xs/src/libslic3r/PrintConfig.cpp:514 xs/src/libslic3r/PrintConfig.cpp:625
+#: xs/src/libslic3r/PrintConfig.cpp:857
+msgid "Speed > Acceleration"
+msgstr "Geschwindigkeit > Beschleunigung"
+
+#: xs/src/libslic3r/PrintConfig.cpp:87
+msgid ""
+"This is the acceleration your printer will use for bridges. Set zero to "
+"disable acceleration control for bridges."
+msgstr ""
+"Dies ist die Beschleunigung die der Drucker bei Brücken einsätzen wird.  Auf "
+"Null stellen um Brückenbeschleunigungskontrolle zu deaktivieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:94
+msgid "Bridges fan speed"
+msgstr "Brückenventilatorgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:95
+msgid "This fan speed is enforced during all bridges and overhangs."
+msgstr ""
+"Diese Ventilatorgeschwindigkeit wird bei Brückungen und Überhängen benutzt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:103
+msgid "Bridge flow ratio"
+msgstr "Brückenflussverhältnis"
+
+#: xs/src/libslic3r/PrintConfig.cpp:104 xs/src/libslic3r/PrintConfig.cpp:147
+#: xs/src/libslic3r/PrintConfig.cpp:678 xs/src/libslic3r/PrintConfig.cpp:1559
+msgid "Advanced"
+msgstr "Erweiterte Einstellungen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:105
+msgid ""
+"This factor affects the amount of plastic for bridging. You can decrease it "
+"slightly to pull the extrudates and prevent sagging, although default "
+"settings are usually good and you should experiment with cooling (use a fan) "
+"before tweaking this."
+msgstr ""
+"Dieser faktor ändert die Plastikmenge bei Brücken.  Man kann ihn verringern "
+"um die Extrudate ein Bisschen zu ziehen um Senkung zu vermeiden, obwohl die "
+"standard Einstellungen normalerweise gut sind, und man vor Änderung dieser "
+"stellung mit Kühlung (d. h. Ventilator) experimentieren sollte."
+
+#: xs/src/libslic3r/PrintConfig.cpp:111
+msgid "Bridges"
+msgstr "Brücken"
+
+#: xs/src/libslic3r/PrintConfig.cpp:113 xs/src/libslic3r/PrintConfig.cpp:240
+#: xs/src/libslic3r/PrintConfig.cpp:553 xs/src/libslic3r/PrintConfig.cpp:576
+#: xs/src/libslic3r/PrintConfig.cpp:688 xs/src/libslic3r/PrintConfig.cpp:744
+#: xs/src/libslic3r/PrintConfig.cpp:753 xs/src/libslic3r/PrintConfig.cpp:888
+#: xs/src/libslic3r/PrintConfig.cpp:1067 xs/src/libslic3r/PrintConfig.cpp:1105
+#: xs/src/libslic3r/PrintConfig.cpp:1156 xs/src/libslic3r/PrintConfig.cpp:1209
+#: xs/src/libslic3r/PrintConfig.cpp:1491 xs/src/libslic3r/PrintConfig.cpp:1512
+msgid "Speed"
+msgstr "Geschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:114
+msgid "Speed for printing bridges."
+msgstr "Brückendruckgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:124
+msgid "Brim connections width"
+msgstr "Krempenanschlussbreite"
+
+#: xs/src/libslic3r/PrintConfig.cpp:125 xs/src/libslic3r/PrintConfig.cpp:134
+#: xs/src/libslic3r/PrintConfig.cpp:701 xs/src/libslic3r/PrintConfig.cpp:779
+#: xs/src/libslic3r/PrintConfig.cpp:1118 xs/src/libslic3r/PrintConfig.cpp:1127
+#: xs/src/libslic3r/PrintConfig.cpp:1135
+msgid "Skirt and brim"
+msgstr "Zarge und Krempel"
+
+#: xs/src/libslic3r/PrintConfig.cpp:126
+msgid ""
+"If set to a positive value, straight connections will be built on the first "
+"layer between adjacent objects."
+msgstr ""
+"Wenn diese Stellung positiv ist dann werden gerade Anschlüsse zwischen "
+"anliegenden Gengeständen genderiert."
+
+#: xs/src/libslic3r/PrintConfig.cpp:133
+msgid "Exterior brim width"
+msgstr "Ausenkrempelbreite"
+
+#: xs/src/libslic3r/PrintConfig.cpp:135
+msgid ""
+"Horizontal width of the brim that will be printed around each object on the "
+"first layer."
+msgstr ""
+"Horizontalbreite der krempe die um jedes Objekt bei der Bodenschicht "
+"gedruckt wird."
+
+#: xs/src/libslic3r/PrintConfig.cpp:142
+msgid "Compatible printers"
+msgstr "Kompatibele Drucker"
+
+#: xs/src/libslic3r/PrintConfig.cpp:146
+msgid "Complete individual objects"
+msgstr "Kompatibele Einzelobjekte."
+
+#: xs/src/libslic3r/PrintConfig.cpp:148
+msgid ""
+"When printing multiple objects or copies, this feature will complete each "
+"object before moving onto next one (and starting it from its bottom layer). "
+"This feature is useful to avoid the risk of ruined prints. Slic3r should "
+"warn and prevent you from extruder collisions, but beware."
+msgstr ""
+"Wenn mehrere Objekte oder Kopien gedruckt werden wird bei dieser Stellung "
+"jedes einzelne Objekt komplett gedruckt vorde, das drucken des Nächsten (von "
+"der Bodenschicht) angefängt.\n"
+" Diese stellung kann das Risko von völlig ruinierten Druckversuchen "
+"verringern.  Slic3r sollte von Extruder aufprall vorwarnen und vermeiden, "
+"aber man sollte Acht nehmen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:153
+msgid "Enable auto cooling"
+msgstr "Automatische Kühlung Aktivieren"
+
+#: xs/src/libslic3r/PrintConfig.cpp:154
+msgid ""
+"This flag enables the automatic cooling logic that adjusts print speed and "
+"fan speed according to layer printing time."
+msgstr ""
+"Diese Einstellung aktiviert the Logik die die Druckgeschwindigkeit und "
+"Ventilatorgeschwindigkeit automatisch gemäß der Schichtdruckzeit regelt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:159
+msgid "Default"
+msgstr "Standard"
+
+#: xs/src/libslic3r/PrintConfig.cpp:161
+msgid ""
+"This is the acceleration your printer will be reset to after the role-"
+"specific acceleration values are used (perimeter/infill). Set zero to "
+"prevent resetting acceleration at all."
+msgstr ""
+"Nach der Zwecksbeschleunigung für Rand oder Infill wird der Drucker auf "
+"diese Beschleunigung zurückgestelt.  Auf Null stellen um the "
+"Beschleunigungszurückstellung auszuschalten."
+
+#: xs/src/libslic3r/PrintConfig.cpp:168
+msgid "Disable fan for the first"
+msgstr "Ventilator für die Ersten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:169
+msgid ""
+"This disables the fan completely for the first N layers "
+"to aid in the adhesion of media to the bed. (default 3)"
+msgstr ""
+"Schaltet den Ventilator für die ersten N Schichten aus um der Befestigung an "
+"das Druckbrett zu helfen. (Standardeinstellung 3)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:170
+msgid "layers"
+msgstr "Schichten ausschalten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:177
+msgid "Don't support bridges"
+msgstr "Brücken nicht unterstützen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:178 xs/src/libslic3r/PrintConfig.cpp:933
+#: xs/src/libslic3r/PrintConfig.cpp:942 xs/src/libslic3r/PrintConfig.cpp:1270
+#: xs/src/libslic3r/PrintConfig.cpp:1277 xs/src/libslic3r/PrintConfig.cpp:1287
+#: xs/src/libslic3r/PrintConfig.cpp:1295 xs/src/libslic3r/PrintConfig.cpp:1308
+#: xs/src/libslic3r/PrintConfig.cpp:1325 xs/src/libslic3r/PrintConfig.cpp:1346
+#: xs/src/libslic3r/PrintConfig.cpp:1355 xs/src/libslic3r/PrintConfig.cpp:1367
+#: xs/src/libslic3r/PrintConfig.cpp:1379 xs/src/libslic3r/PrintConfig.cpp:1395
+#: xs/src/libslic3r/PrintConfig.cpp:1406 xs/src/libslic3r/PrintConfig.cpp:1408
+#: xs/src/libslic3r/PrintConfig.cpp:1419
+msgid "Support material"
+msgstr "Unterstützungsmaterial"
+
+#: xs/src/libslic3r/PrintConfig.cpp:179
+msgid ""
+"Experimental option for preventing support material from being generated "
+"under bridged areas."
+msgstr ""
+"Experimentalstellung dass kein Unterstützungsmaterial unter Brücken "
+"generiert wird."
+
+#: xs/src/libslic3r/PrintConfig.cpp:184
+msgid "Distance between copies"
+msgstr "Distanz Zwischen Kopien"
+
+#: xs/src/libslic3r/PrintConfig.cpp:185
+msgid "Distance used for the auto-arrange feature of the plater."
+msgstr "Distanz für die auto-arrange Funktion des Platers."
+
+#: xs/src/libslic3r/PrintConfig.cpp:193 xs/src/libslic3r/PrintConfig.cpp:202
+msgid "End G-code"
+msgstr "Ende G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:194
+msgid ""
+"This end procedure is inserted at the end of the output file. Note that you "
+"can use placeholder variables for all Slic3r settings."
+msgstr ""
+"Dieser G-code wird dem Ende der Outputdatei angehängt.  Man kann in diesem "
+"Code Platzhalter anwenden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:203
+msgid ""
+"This end procedure is inserted at the end of the output file, before the "
+"printer end gcode. Note that you can use placeholder variables for all "
+"Slic3r settings. If you have multiple extruders, the gcode is processed in "
+"extruder order."
+msgstr ""
+"Dieser G-code wird dem Ende der Outputdatei angehängt.  Man kann in diesem "
+"Code Platzhalter anwenden.  Bei mehrfachen Extrudern wird der Code in "
+"Extruderreinfolge angehängt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:215
+msgid "Top/bottom fill pattern"
+msgstr "Boden- und Deckenfüllmuster"
+
+#: xs/src/libslic3r/PrintConfig.cpp:217
+msgid ""
+"Fill pattern for top/bottom infill. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+msgstr ""
+"Füllmuster für die Boden- und Deckenschicht.  Diese Einstellung betrifft nur "
+"the sichtbaren Schichten, und nicht den Rände nebenan."
+
+#: xs/src/libslic3r/PrintConfig.cpp:224 xs/src/libslic3r/PrintConfig.cpp:237
+msgid "↳ external"
+msgstr "↳ Außen- "
+
+#: xs/src/libslic3r/PrintConfig.cpp:225
+msgid "External perimeters extrusion width"
+msgstr "Außenumfangsextrusionsbreite"
+
+#: xs/src/libslic3r/PrintConfig.cpp:227 xs/src/libslic3r/PrintConfig.cpp:323
+#: xs/src/libslic3r/PrintConfig.cpp:532 xs/src/libslic3r/PrintConfig.cpp:653
+#: xs/src/libslic3r/PrintConfig.cpp:875 xs/src/libslic3r/PrintConfig.cpp:1196
+#: xs/src/libslic3r/PrintConfig.cpp:1327 xs/src/libslic3r/PrintConfig.cpp:1470
+msgid "Extrusion Width"
+msgstr "Extrusionbreite"
+
+#: xs/src/libslic3r/PrintConfig.cpp:228
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for external "
+"perimeters. If auto is chosen, a value will be used that maximizes accuracy "
+"of the external visible surfaces. If expressed as percentage (for example "
+"200%) it will be computed over layer height."
+msgstr ""
+"Wenn diese Stellung nicht Null ist dann bestimmt sie die Extrusionsbreite "
+"der äuseren Umfänge.  Wenn die Stellung \"auto\" ist, dan wird ein Wert "
+"benutzt der die Präzision der sichtbaren Oberflächen optimiert.  Also "
+"Prozent eingegeben (z. B. 200%) wird sie relativ der Schichtendicke "
+"ausgerechnet. "
+
+#: xs/src/libslic3r/PrintConfig.cpp:238
+msgid "External perimeters speed"
+msgstr "Außenumfangsgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:241
+msgid ""
+"This separate setting will affect the speed of external perimeters (the "
+"visible ones). If expressed as percentage (for example: 80%) it will be "
+"calculated on the perimeters speed setting above."
+msgstr ""
+"Diese getrennte Stellung wird bestimmt die Geschwindigkeit des Druckens der "
+"(sichtbaren) Ausenumfänge.  Als Prozent eingegeben (z. B. 80%) wird sie "
+"relativ der Außenumfangsgeschwindigkeitstellung oben ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:251
+msgid "External perimeters first"
+msgstr "Außenumfänge erst Drucken"
+
+#: xs/src/libslic3r/PrintConfig.cpp:253
+msgid ""
+"Print contour perimeters from the outermost one to the innermost one instead "
+"of the default inverse order."
+msgstr ""
+"Drucke die Umfänge von Außen nach innen, stat der umgekehrten Standardfolge."
+
+#: xs/src/libslic3r/PrintConfig.cpp:258
+msgid "Extra perimeters if needed"
+msgstr "Extra Umfänge wenn Notwendig"
+
+#: xs/src/libslic3r/PrintConfig.cpp:260
+msgid "Add more perimeters when needed for avoiding gaps in sloping walls."
+msgstr ""
+"Meh Umfänge druken wenn es notwendig ist um Spalten in schrägen Oberflächen "
+"zu vermeiden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:266 xs/src/libslic3r/PrintConfig.cpp:925
+msgid "Extruder"
+msgstr "Extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:267 xs/src/libslic3r/PrintConfig.cpp:644
+#: xs/src/libslic3r/PrintConfig.cpp:828 xs/src/libslic3r/PrintConfig.cpp:865
+#: xs/src/libslic3r/PrintConfig.cpp:1177 xs/src/libslic3r/PrintConfig.cpp:1238
+#: xs/src/libslic3r/PrintConfig.cpp:1318 xs/src/libslic3r/PrintConfig.cpp:1338
+msgid "Extruders"
+msgstr "Extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:268
+msgid ""
+"The extruder to use (unless more specific extruder settings are specified)."
+msgstr ""
+"Extruder der zu benutzen ist (es sei denn es spezifischere "
+"Extruderstellungen gibt)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:278
+msgid "Height"
+msgstr "Höhe"
+
+#: xs/src/libslic3r/PrintConfig.cpp:279
+#, fuzzy
+msgid ""
+"Set this to the vertical distance between your nozzle tip and (usually) the "
+"X carriage rods. In other words, this is the height of the clearance "
+"cylinder around your extruder, and it represents the maximum depth the "
+"extruder can peek before colliding with other printed objects."
+msgstr ""
+"Stelle diese zahl auf the Vertikaldistanz zwischen der Düsenspitze und "
+"(typischerweise) den X-Schlittenstangen.  In anderen Worten, die Höhe des "
+"Umfangszylinders um den Extruder, und sie repräsentiert die maximaltiefe die "
+"der Extruder ergründen kann ohne auf gedruckte Objecte aufzuprallen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:286
+msgid "Radius"
+msgstr "Radius"
+
+#: xs/src/libslic3r/PrintConfig.cpp:287
+msgid ""
+"Set this to the clearance radius around your extruder. If the extruder is "
+"not centered, choose the largest value for safety. This setting is used to "
+"check for collisions and to display the graphical preview in the plater."
+msgstr ""
+"Stelle diese Zahl auf den Umfangsradius um den Extruder.  Wenn der Extruder "
+"nicht Zentriet ist, stelle die Zahl auf den Maximalradius.  Diese stellung "
+"wird benutzt um nach Aufprall zu prüfen, und wenn der Gravphical Preview im "
+"Plater gezeigt wird."
+
+#: xs/src/libslic3r/PrintConfig.cpp:294
+msgid "Extruder offset"
+msgstr "Extruder Verschiebung"
+
+#: xs/src/libslic3r/PrintConfig.cpp:295
+msgid ""
+"If your firmware doesn't handle the extruder displacement you need the G-"
+"code to take it into account. This option lets you specify the displacement "
+"of each extruder with respect to the first one. It expects positive "
+"coordinates (they will be subtracted from the XY coordinate)."
+msgstr ""
+"Wenn die Firmware die Extruderverschiebung nicht ausgleicht muss das im G-"
+"code passieren.   Diese stellung berschreibt die Verschiebung der Extruder "
+"relativ dem Ersten.  Sie wird im G-code von den XY-Koordinaten abegzogen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:305
+msgid "Extrusion axis"
+msgstr "Extrusionsachse"
+
+#: xs/src/libslic3r/PrintConfig.cpp:306
+msgid ""
+"Use this option to set the axis letter associated to your printer's extruder "
+"(usually E but some printers use A)."
+msgstr ""
+"Diese stellung ist der Buchstabe die bei dem Drucker die Extrusionsachse "
+"ist.  (Typisch E doch bei manchen Drukern A.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:311
+msgid "Extrusion multiplier"
+msgstr "Extrusionfaktor"
+
+#: xs/src/libslic3r/PrintConfig.cpp:312
+msgid ""
+"This factor changes the amount of flow proportionally. You may need to tweak "
+"this setting to get nice surface finish and correct single wall widths. "
+"Usual values are between 0.9 and 1.1. If you think you need to change this "
+"more, check filament diameter and your firmware E steps."
+msgstr ""
+"Dieser faktor ändert proportional die Extrusionsmenge. Es kann notwending "
+"sein diese Stellung zu optimieren um gute Obeflächen zu drucken order "
+"Wandbreiten zu korigieren. Typische stellungen sind zwischen 0,9 und 1,1.  "
+"Wenn grösere oder kleinere werte notwendig scheinen, erst den "
+"Fialmentdurchmesser und the Extrusionsschritte in der firmware nachchecken."
+
+#: xs/src/libslic3r/PrintConfig.cpp:321
+msgid "Default extrusion width"
+msgstr "Standardextrusionsbreite"
+
+#: xs/src/libslic3r/PrintConfig.cpp:324
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width. If expressed "
+"as percentage (for example: 230%) it will be computed over layer height."
+msgstr ""
+"Wenn diese stellung nicht Null ist dann bestimmt sie die Extrusionsbreite.  "
+"Als Prozent eingegeben (z. B. 230%) wird sie relativ der Schichtdicke "
+"ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:333
+msgid "Keep fan always on"
+msgstr "Ventilator ständig laufen lassen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:334
+msgid ""
+"If this is enabled, fan will never be disabled and will be kept running at "
+"least at its minimum speed. Useful for PLA, harmful for ABS."
+msgstr ""
+"Wenn diese Stellung Aktiviert ist, wird der Ventilator nicht ausgeschaltet, "
+"und wird mindestens bei seiner Mindestgeschwindigkeit laufen.  Nützlich für "
+"PLA, shädlich für ABS."
+
+#: xs/src/libslic3r/PrintConfig.cpp:339
+msgid "Enable fan if layer print time is below"
+msgstr "Ventilator anschalten wenn die Schichtdruckzeit weniger als ___ ist"
+
+#: xs/src/libslic3r/PrintConfig.cpp:340
+msgid ""
+"If layer print time is estimated below this number of seconds, fan will be "
+"enabled and its speed will be calculated by interpolating the minimum and "
+"maximum speeds."
+msgstr ""
+"Wenn die Schichtendruckzeit kürzer als diese Zahl von Sekunden eingeschätzt "
+"ist wird der Vetilator angschaltet und the Ventilatorgeschwindigkeit wird "
+"durch Interpolierung der Maximal- und Minmalventilatorgeschwindigkeiten "
+"ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:349
+msgid "Color"
+msgstr "Farbe"
+
+#: xs/src/libslic3r/PrintConfig.cpp:350
+msgid "This is only used in the Slic3r interface as a visual help."
+msgstr "Nur im Slic3r Interface benutzt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:360
+msgid "Filament notes"
+msgstr "Filament Notizen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:361
+msgid "You can put your notes regarding the filament here."
+msgstr "Man kann Filament Notizen hier eingeben"
+
+#: xs/src/libslic3r/PrintConfig.cpp:373 xs/src/libslic3r/PrintConfig.cpp:752
+msgid "Max volumetric speed"
+msgstr "Maximale Volumgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:374
+msgid ""
+"Maximum volumetric speed allowed for this filament. Limits the maximum "
+"volumetric speed of a print to the minimum of print and filament volumetric "
+"speed. Set to zero for no limit."
+msgstr ""
+"Maximalvolumgeschwindigkeit die mit diesem Filament erlaubt ist.  Scränkt "
+"die Maximalvolumgeschwindigkeit auf das Minimum von Druck- und "
+"Filamentmaximalvolumgeschwindigkeit ein.  Auf Null stellen um "
+"Volumgeschwindigkeit nicht einzuschränken."
+
+#: xs/src/libslic3r/PrintConfig.cpp:385
+msgid "Diameter"
+msgstr "Durchmesser"
+
+#: xs/src/libslic3r/PrintConfig.cpp:386
+msgid ""
+"Enter your filament diameter here. Good precision is required, so use a "
+"caliper and do multiple measurements along the filament, then compute the "
+"average."
+msgstr ""
+"Filamentdurchmesser hier eingeben.  Präzision is wichtig also eine "
+"Messschieber benutzen, mehrmals an verscheiden Orten messen, und den "
+"Durchschnitt ausrechnen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:397
+msgid "Density"
+msgstr "Dichte"
+
+#: xs/src/libslic3r/PrintConfig.cpp:398
+msgid ""
+"Enter your filament density here. This is only for statistical information. "
+"A decent way is to weigh a known length of filament and compute the ratio of "
+"the length to volume. Better is to calculate the volume directly through "
+"displacement."
+msgstr "Filamentdichte hier eingeben.  Nur für Statistik benutzt. "
+
+#: xs/src/libslic3r/PrintConfig.cpp:409
+msgid "Cost"
+msgstr "Preis"
+
+#: xs/src/libslic3r/PrintConfig.cpp:410
+msgid ""
+"Enter your filament cost per kg here. This is only for statistical "
+"information."
+msgstr "Filamentpreis pro kg hier eingeben.  Nur für Statistik benutzt. "
+
+# Set this to be the local currency symbol.
+#: xs/src/libslic3r/PrintConfig.cpp:411
+msgid "money/kg"
+msgstr "Geld/kg"
+
+#: xs/src/libslic3r/PrintConfig.cpp:424
+msgid "Fill angle"
+msgstr "Füllwinkel"
+
+#: xs/src/libslic3r/PrintConfig.cpp:426
+msgid ""
+"Default base angle for infill orientation. Cross-hatching will be applied to "
+"this. Bridges will be infilled using the best direction Slic3r can detect, "
+"so this setting does not affect them."
+msgstr ""
+"Standardwinkel für Infill Richtung.  Kreuzschraffur wird daran bezogen.  "
+"Brücken werden mit der besten Richtung die Slic3r finden kann Ingefillt, "
+"also sind sie von dieser Einstellung unabhängig."
+
+#: xs/src/libslic3r/PrintConfig.cpp:436
+msgid "Fill density"
+msgstr "Filldichte"
+
+#: xs/src/libslic3r/PrintConfig.cpp:438
+msgid "Density of internal infill, expressed in the range 0% - 100%."
+msgstr "Infilldichte.  Als Prozentwert 0% - 100% ausgedrückt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:474
+msgid "Fill gaps"
+msgstr "Spalten Füllen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:476
+msgid ""
+"If this is enabled, gaps will be filled with single passes. Enable this for "
+"better quality, disable it for shorter printing times."
+msgstr ""
+"Wenn diese Stellung Aktiviert ist wereden Spalten mit einer Durchfahrt "
+"gefüllt.  Für bessere Qualität anschalten, für schnelleres Drucken "
+"ausschalten."
+
+#: xs/src/libslic3r/PrintConfig.cpp:481
+msgid "Fill pattern"
+msgstr "Füllmuster"
+
+#: xs/src/libslic3r/PrintConfig.cpp:483
+msgid "Fill pattern for general low-density infill."
+msgstr "Füllmuster für Infill von geringer Dichte."
+
+#: xs/src/libslic3r/PrintConfig.cpp:513 xs/src/libslic3r/PrintConfig.cpp:522
+#: xs/src/libslic3r/PrintConfig.cpp:530 xs/src/libslic3r/PrintConfig.cpp:561
+msgid "First layer"
+msgstr "Erste Schicht"
+
+#: xs/src/libslic3r/PrintConfig.cpp:515
+msgid ""
+"This is the acceleration your printer will use for first layer. Set zero to "
+"disable acceleration control for first layer."
+msgstr ""
+"Die Beschleunigung die ihr Drucker bei der ersten Schicht benutzt.  Auf Null "
+"stellen um Beschleunigungskontrolle bei der ersten Schicht einzustellen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:523
+msgid ""
+"Heated build plate temperature for the first layer. Set this to zero to "
+"disable bed temperature control commands in the output."
+msgstr ""
+"Druckbretttemperatur für die erste Schicht.  Auf Null stellen um "
+"Temperaturkontrollkode im Output zu deaktivieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:533
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for first "
+"layer. You can use this to force fatter extrudates for better adhesion. If "
+"expressed as percentage (for example 120%) it will be computed over first "
+"layer height."
+msgstr ""
+"Auf nicht-null stellen um manuell Extrusionsbreite bei der ersten Schicht zu "
+"stellen.  Man kann diese stellung benutzen um fettere Extrudate zu zwingen "
+"und Adhäsion zu bessern.  Als prozent ausgedrückt (z.b. 120%) wird is "
+"relativ der ersten Schicht höhe ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:543
+msgid "First layer height"
+msgstr "Höhe der ersten Schicht"
+
+#: xs/src/libslic3r/PrintConfig.cpp:545
+msgid ""
+"When printing with very low layer heights, you might still want to print a "
+"thicker bottom layer to improve adhesion and tolerance for non perfect build "
+"plates. This can be expressed as an absolute value or as a percentage (for "
+"example: 150%) over the default layer height."
+msgstr ""
+"Wenn man with kleinen Schichtdicken druckt möchte mann trotzdem manchmal "
+"eine dickere Bodenschicht drucken um bessere Klebfestigkeit und Toleranz für "
+"Druckplatten zu haben.  Das kann als Absolutwert oder als Prozent (z.b.: "
+"150%) der Standardschichtdicke eigegeben werden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:552
+msgid "First layer speed"
+msgstr "Druckgeschwindigkeit der ersten Schicht"
+
+#: xs/src/libslic3r/PrintConfig.cpp:554
+msgid ""
+"If expressed as absolute value in mm/s, this speed will be applied to all "
+"the print moves of the first layer, regardless of their type. If expressed "
+"as a percentage (for example: 40%) it will scale the default speeds."
+msgstr ""
+"Als Absolutwert in mm/s, bestimmt diese Stellung die Druckgeschwindigkeit "
+"der ersten Schicht.   Als Prozent eigegeben (z.b.: 40%) wird sie relativ der "
+"Standardschichtdicke ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:562
+msgid ""
+"Extruder temperature for first layer. If you want to control temperature "
+"manually during print, set this to zero to disable temperature control "
+"commands in the output file."
+msgstr ""
+"Extrudertemperatur für die erste Schicht.  Für Temperaturhandkontrolle auf "
+"Null stellen, dann wird die Outputdatei ohne Temparaturkontrolcode generiert."
+
+#: xs/src/libslic3r/PrintConfig.cpp:573
+msgid "↳ gaps"
+msgstr "↳ spalten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:577
+msgid ""
+"Speed for filling gaps. Since these are usually single lines you might want "
+"to use a low speed for better sticking. If expressed as percentage (for "
+"example: 80%) it will be calculated on the infill speed setting above."
+msgstr ""
+"Geschwindigkeit für Spaltenfüllung. Da diese typisch einzelne Faden sind "
+"könnte langsameres Drucken für bessere Haftung angewiesen sein. Als Prozent "
+"eigegeben (z.b.: 80%) wird sie relativ der Infillgeschwindingkeitsstellung "
+"ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:587
+msgid "Use native G-code arcs"
+msgstr "Eingebaute G-code Kurven Benutzen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:588
+msgid ""
+"This experimental feature tries to detect arcs from segments and generates "
+"G2/G3 arc commands instead of multiple straight G1 commands."
+msgstr ""
+"Diese Experimentalstellung versucht Kurven anzuerkennen und G2/G3 "
+"Kurvenbefehle stat mehreren G1 Befehlen in dem Output zu Generieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:593
+msgid "Verbose G-code"
+msgstr "Ausführlicher G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:594
+msgid ""
+"Enable this to get a commented G-code file, with each line explained by a "
+"descriptive text. If you print from SD card, the additional weight of the "
+"file could make your firmware slow down."
+msgstr ""
+"Diese Stellung aktiviert Anmerkungen die jede Zeile der G-code Datei "
+"beschreiben.  Wenn sie von einder SD-karte drucken, könnte das die Firmware "
+"des Druckers verlangsamen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:599
+msgid "G-code flavor"
+msgstr "G-code Typ"
+
+#: xs/src/libslic3r/PrintConfig.cpp:600
+msgid ""
+"Some G/M-code commands, including temperature control and others, are not "
+"universal. Set this option to your printer's firmware to get a compatible "
+"output. The \"No extrusion\" flavor prevents Slic3r from exporting any "
+"extrusion value at all."
+msgstr ""
+"Einige G/M-code Befehle, zum Beispiel Temperaturkontrolle sind nicht "
+"universal.  Diese stellung soll der Druckerfirmware angepasst sein um "
+"kompatiblen Output zu generieren.  Der \"No extrusion\" Typ generiert G-code "
+"ohne Extrusion."
+
+#: xs/src/libslic3r/PrintConfig.cpp:626
+msgid ""
+"This is the acceleration your printer will use for infill. Set zero to "
+"disable acceleration control for infill."
+msgstr ""
+"Diese Stellung bestimmt die Beschleunigung des Druckers für Infill.  Auf "
+"Null stellen um Beschleunigungskontrolle für Infill zu deaktivieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:633
+msgid "Combine infill every"
+msgstr "Jede __ Schichten Infill combinieren"
+
+#: xs/src/libslic3r/PrintConfig.cpp:635
+#, fuzzy
+msgid ""
+"This feature allows to combine infill and speed up your print by extruding "
+"thicker infill layers while preserving thin perimeters, thus accuracy."
+msgstr ""
+"Wenn diese Stellung aktiviert ist dan wird Infill in dicken Schichten "
+"gedruckt während die Umfänge in dünnen Schichten gedruckt werden.  So kann "
+"man schneller doch trotzdem präzise drucken."
+
+#: xs/src/libslic3r/PrintConfig.cpp:643
+msgid "Infill extruder"
+msgstr "Infill Extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:645
+msgid "The extruder to use when printing infill."
+msgstr "Extruder der bei Infill zu benutzen ist."
+
+#: xs/src/libslic3r/PrintConfig.cpp:654
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill. You "
+"may want to use fatter extrudates to speed up the infill and make your parts "
+"stronger. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+msgstr ""
+"Wenn diese Stellung nicht Null ist dan bestimmt sie die Extrudsionsbreite "
+"des Infills.  Fettere Extrudate beim Infill drucken schneller und können "
+"fester sein.  Als Prozent eingegeben (z.B.: 90%) wird es relativ der "
+"Shichtendicke ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:663
+msgid "Infill before perimeters"
+msgstr "Infill vor Umfang"
+
+#: xs/src/libslic3r/PrintConfig.cpp:665
+msgid ""
+"This option will switch the print order of perimeters and infill, making the "
+"latter first."
+msgstr ""
+"Diese stellung wendet die druckfolge von Umfang und Infill, so das Infill "
+"erst gedruckt wird."
+
+#: xs/src/libslic3r/PrintConfig.cpp:670
+msgid "Only infill where needed"
+msgstr "Infill nur wo Notwendig drucken"
+
+#: xs/src/libslic3r/PrintConfig.cpp:672
+msgid ""
+"This option will limit infill to the areas actually needed for supporting "
+"ceilings (it will act as internal support material). If enabled, slows down "
+"the G-code generation due to the multiple checks involved."
+msgstr ""
+"Diese stellung wird Infill in die Volumen wo er notwendig ist um Decken zu "
+"unterstützen.  (Der Infill wird as internes Unterstützungsmaterial wirken.)  "
+"Wenn aktiviert, verlangsamt sie die G-code generierung."
+
+#: xs/src/libslic3r/PrintConfig.cpp:677
+msgid "Infill/perimeters overlap"
+msgstr "Infill/Umfang Überlappung"
+
+#: xs/src/libslic3r/PrintConfig.cpp:679
+msgid ""
+"This setting applies an additional overlap between infill and perimeters for "
+"better bonding. Theoretically this shouldn't be needed, but backlash might "
+"cause gaps. If expressed as percentage (example: 15%) it is calculated over "
+"perimeter extrusion width."
+msgstr ""
+"Diese stellung setzt eine Überlappung zwischen Umfang und Infill ein um eine "
+"bessere Verbindung zu formen.  Theoretisch sollte das nicht notwendig sein, "
+"doch Getriebespiel könnte Spalten zeugen.  Als Prozent eingegeben (z.B: 15%) "
+"wird sie relativ der Umfangsextrusionsbreite ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:689
+msgid "Speed for printing the internal fill."
+msgstr "Internfilldruckgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:700
+msgid "Interior brim width"
+msgstr "Internkrempenbreite"
+
+#: xs/src/libslic3r/PrintConfig.cpp:702
+msgid ""
+"Horizontal width of the brim that will be printed inside object holes on the "
+"first layer."
+msgstr ""
+"Horizontalbreite der Krempe die in Löchern in der ersten Schicht gedruckt "
+"wird."
+
+#: xs/src/libslic3r/PrintConfig.cpp:709
+msgid "Interface shells"
+msgstr "Verbindungschichten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:710
+msgid ""
+"Force the generation of solid shells between adjacent materials/volumes. "
+"Useful for multi-extruder prints with translucent materials or manual "
+"soluble support material."
+msgstr ""
+"Generiert dichte Schichten zwischen angrenzenden Materiellen/Volumen.  "
+"Nützlich bei multi-Extruder druken mit durchsichtigem Material, oder "
+"lösbarem Unterstützungsmaterial."
+
+#: xs/src/libslic3r/PrintConfig.cpp:716
+msgid "After layer change G-code"
+msgstr "Schicht ende G-Code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:717
+msgid ""
+"This custom code is inserted at every layer change, right after the Z move "
+"and before the extruder moves to the first layer point. Note that you can "
+"use placeholder variables for all Slic3r settings as well as [layer_num] and "
+"[layer_z]."
+msgstr ""
+"Dieser Code wird am ende jeder Schicht (nach der Z Bewegung und vor der "
+"Bewegum zum ersten punkt der nächsten Schicht) dem G-code beigetragen.  "
+"Platzhalter für alle Slic3r Einstellung sowie [layer_num] und [layer_z] "
+"können hier benutzt werden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:725
+msgid "Layer height"
+msgstr "Schichtdicke"
+
+#: xs/src/libslic3r/PrintConfig.cpp:727
+msgid ""
+"This setting controls the height (and thus the total number) of the slices/"
+"layers. Thinner layers give better accuracy but take more time to print."
+msgstr ""
+"Diese Stellung bestimmt die Dicke (und dadurch auch die Zahl) der Scheiben/"
+"Schichten.  Dünnere Schichten drucken präziser doch langsamer."
+
+#: xs/src/libslic3r/PrintConfig.cpp:734
+msgid "Max"
+msgstr "Max"
+
+#: xs/src/libslic3r/PrintConfig.cpp:735
+msgid "This setting represents the maximum speed of your fan."
+msgstr "Diese Stellung Bestimmt die Maximalgeschwindigkeit des Ventilators."
+
+#: xs/src/libslic3r/PrintConfig.cpp:743
+msgid "Max print speed"
+msgstr "Maximaldruckgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:745
+#, fuzzy
+msgid ""
+"When setting other speed settings to 0 Slic3r will autocalculate the optimal "
+"speed in order to keep constant extruder pressure. This experimental setting "
+"is used to set the highest print speed you want to allow."
+msgstr ""
+"Wenn andere Geschwindigkeitstellungen 0 sind wird Slic3r automatisch die "
+"Optimalgeschwindigikeit ausrechnen um Düsendruck gleichmäßig zu halten.  "
+"Diese Experimentalstellung bestimmt die maximal erlaubte "
+"Druckgeschwindigkeit."
+
+#: xs/src/libslic3r/PrintConfig.cpp:754
+msgid ""
+"This experimental setting is used to set the maximum volumetric speed your "
+"extruder supports."
+msgstr ""
+"Diese Experimentalstellung beschreibt die Maximalvolumgeschwindigkeit des "
+"Extruders."
+
+#: xs/src/libslic3r/PrintConfig.cpp:761
+msgid "Min"
+msgstr "Min"
+
+#: xs/src/libslic3r/PrintConfig.cpp:762
+msgid "This setting represents the minimum PWM your fan needs to work."
+msgstr "Diese stellung ist die minimale PWM für den Ventilator."
+
+#: xs/src/libslic3r/PrintConfig.cpp:770
+msgid "Min print speed"
+msgstr "Minimaldruckgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:771
+msgid "Slic3r will not scale speed down below this speed."
+msgstr "Slic3r nicht unter diese Geschwindigkeit skalieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:778
+msgid "Minimum extrusion length"
+msgstr "Minimalextrusionslänge"
+
+#: xs/src/libslic3r/PrintConfig.cpp:780
+msgid ""
+"Generate no less than the number of skirt loops required to consume the "
+"specified amount of filament on the bottom layer. For multi-extruder "
+"machines, this minimum applies to each extruder."
+msgstr ""
+"Mindestzahl der Schaufen notwendig um die angegebene Menge Filament am Boden "
+"zu verbrauchen.  Bei Multi-extruder Druckern gilt diese Mindestzahl für alle "
+"Extruder."
+
+#: xs/src/libslic3r/PrintConfig.cpp:787
+msgid "Configuration notes"
+msgstr "Konfigurationsnotizen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:788
+msgid ""
+"You can put here your personal notes. This text will be added to the G-code "
+"header comments."
+msgstr ""
+"Man kann Notizen hier eingeben.  Der Text wird dem G-code Header beigetragen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:796
+msgid "Nozzle diameter"
+msgstr "Düsenduchmesser"
+
+#: xs/src/libslic3r/PrintConfig.cpp:797
+msgid ""
+"This is the diameter of your extruder nozzle (for example: 0.5, 0.35 etc.)"
+msgstr "Durchmesser der Extruderdüse (z.B.: 0.5, 0.35 usw.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:807
+msgid "API Key"
+msgstr "API Key"
+
+#: xs/src/libslic3r/PrintConfig.cpp:808
+msgid ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"API Key required for authentication."
+msgstr ""
+"Slic3r kann G-code Dateien bei OctoPrint Hochladen. Diese stellung ist der "
+"API Key für Authentifikation."
+
+#: xs/src/libslic3r/PrintConfig.cpp:813
+msgid "Host or IP"
+msgstr "Host or IP"
+
+#: xs/src/libslic3r/PrintConfig.cpp:814
+msgid ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"hostname or IP address of the OctoPrint instance."
+msgstr ""
+"Slic3r kann G-code Dateien bei OctoPrint Hochladen. Diese Stellung ist der "
+"Hostname oder die IP address von OctoPrint."
+
+#: xs/src/libslic3r/PrintConfig.cpp:819
+msgid "Only retract when crossing perimeters"
+msgstr "Nur bei Umfangsüberquerungen einziehen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:821
+msgid ""
+"Disables retraction when the travel path does not exceed the upper layer's "
+"perimeters (and thus any ooze will be probably invisible)."
+msgstr ""
+"Deaktiviert einziehen wenn der Extruderweg nicht die Umgfänge der "
+"Oberschicht überschreitet (so das jegliches Sickern warscheinlich unsichtbar "
+"ist.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:826
+msgid "Enable"
+msgstr "Aktivieren"
+
+#: xs/src/libslic3r/PrintConfig.cpp:829
+msgid ""
+"During multi-extruder prints, this option will drop the temperature of the "
+"inactive extruders to prevent oozing. It will enable a tall skirt "
+"automatically and move extruders outside such skirt when changing "
+"temperatures."
+msgstr ""
+"Bei multi-Extruder Drucken wird diese Stelling die Teperatur der nicht "
+"aktiven Extruder fallen lassen um Sickern zu vermeiden.   Sie aktiviert "
+"automatisch eine große Zarge und hält die extruder bei Temperaturwechel "
+"auserhalb dieser Zarge."
+
+#: xs/src/libslic3r/PrintConfig.cpp:834
+msgid "Output filename format"
+msgstr "Output Dateinamen Format"
+
+#: xs/src/libslic3r/PrintConfig.cpp:835
+msgid ""
+"You can use all configuration options as variables inside this template. For "
+"example: [layer_height], [fill_density] etc. You can also use [timestamp], "
+"[year], [month], [day], [hour], [minute], [second], [version], "
+"[input_filename], [input_filename_base]."
+msgstr ""
+"Man kann alle Konfigurationsoptionen als Variable in dieser Vorlage "
+"benutzen.   Zum Beispiel: [layer_height], [fill_density] usw. Man kann auch "
+"[timestamp], [year], [month], [day], [hour], [minute], [second], [version], "
+"[input_filename], und [input_filename_base] benutzen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:841
+msgid "Detect bridging perimeters"
+msgstr "Umfangbrücken entdecken"
+
+#: xs/src/libslic3r/PrintConfig.cpp:843
+msgid ""
+"Experimental option to adjust flow for overhangs (bridge flow will be used), "
+"to apply bridge speed to them and enable fan."
+msgstr ""
+"Experimentalstellung die Plastikfluss bei Überhang druken ändert, indem die "
+"Brücken stellungen angewendet und der Ventilator eingeschaltet werden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:848
+msgid "Overridable options"
+msgstr "Überbrückbare Einstellungen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:856 xs/src/libslic3r/PrintConfig.cpp:873
+#: xs/src/libslic3r/PrintConfig.cpp:886 xs/src/libslic3r/PrintConfig.cpp:899
+msgid "Perimeters"
+msgstr "Umfänge"
+
+#: xs/src/libslic3r/PrintConfig.cpp:858
+msgid ""
+"This is the acceleration your printer will use for perimeters. A high value "
+"like 9000 usually gives good results if your hardware is up to the job. Set "
+"zero to disable acceleration control for perimeters."
+msgstr ""
+"Die Beschleunigung die der Drucker bei Umfängen benutzt. Eine große stelling "
+"wie 9000 funktioniert norwalerwise gut.  Auf Null stellen um "
+"Beschleunigungskontrolle bei Umfängen auszuschalten."
+
+#: xs/src/libslic3r/PrintConfig.cpp:864
+msgid "Perimeter extruder"
+msgstr "Umfangsextruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:866
+msgid ""
+"The extruder to use when printing perimeters and brim. First extruder is 1."
+msgstr ""
+"Extruder der bei Umfang und Krempe drucken benutzt werden soll. Der erste "
+"extruder ist 1."
+
+#: xs/src/libslic3r/PrintConfig.cpp:876
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for perimeters. "
+"You may want to use thinner extrudates to get more accurate surfaces. If "
+"expressed as percentage (for example 200%) it will be computed over layer "
+"height."
+msgstr ""
+"Wenn diese stellung nicht Null ist dan bestimmt sie the Extrusionsbreite von "
+"Umfgängen.  Mann will eventuel dunnere Extrudate benutzen um genauere "
+"Oberflächen zu drucken.  Als Prozent eigegeben (z.B.: 200%) wird sie relativ "
+"der Schichtdicke ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:889
+msgid "Speed for perimeters (contours, aka vertical shells)."
+msgstr "Geschwindigkeit für Umfänge."
+
+#: xs/src/libslic3r/PrintConfig.cpp:901
+msgid ""
+"This option sets the number of perimeters to generate for each layer. Note "
+"that Slic3r may increase this number automatically when it detects sloping "
+"surfaces which benefit from a higher number of perimeters if the Extra "
+"Perimeters option is enabled."
+msgstr ""
+"Diese Stellung bestimmt die Zahl der Umfänge die für jede Schicht generiert "
+"werden.  Slic3r kann diese Zahl automatisch vergrößern wenn es schräge "
+"Oberflächen erkent die mit mehr Umfängen besser drucken wenn die \"Extra "
+"Umfänge wenn Notwendig\" Option aktiviert ist."
+
+#: xs/src/libslic3r/PrintConfig.cpp:909
+msgid "Post-processing scripts"
+msgstr "Nacharbeitungsprogramm"
+
+#: xs/src/libslic3r/PrintConfig.cpp:910
+msgid ""
+"If you want to process the output G-code through custom scripts, just list "
+"their absolute paths here. Separate multiple scripts on individual lines. "
+"Scripts will be passed the absolute path to the G-code file as the first "
+"argument, and they can access the Slic3r config settings by reading "
+"environment variables."
+msgstr ""
+"Wenn man Programme den G-code automatisch nacharbeiten lassen will, kann man "
+"hier deren absolute Pfade eingeben.  Jedes program auf seine einge zeile "
+"eingeben.  Der Pfad zum G-code wird als erstes Kommandozeilenargument ans "
+"Programm gegeben, und die programme können Slic3r Einstellungen as "
+"Umgebungsvariable abrufen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:924
+msgid "Pressure advance"
+msgstr "Düsendruckkontrolle"
+
+#: xs/src/libslic3r/PrintConfig.cpp:926
+msgid ""
+"When set to a non-zero value, this experimental option enables pressure "
+"regulation. It's the K constant for the advance algorithm that pushes more "
+"or less filament upon speed changes. It's useful for Bowden-tube extruders. "
+"Reasonable values are in range 0-10."
+msgstr ""
+"Wenn diese Experimentalstellung nicht Null ist dann ist Düsendruckkontrolle "
+"aktiviert.  Die Stellung ist die K Konstante die der Vorrücksalogrithmus der "
+"mehr oder weniger Filament bei Geschwindigkeitsänderungen schiebt.  Nützlich "
+"bei Bowden-tube Extrudern. 0-10 sind zumutbare Stellungen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:932
+msgid "Raft layers"
+msgstr "Gründungsfloßschichten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:934
+msgid ""
+"The object will be raised by this number of layers, and support material "
+"will be generated under it."
+msgstr ""
+"Das Objekt wird diese Zhal von Schichten gehoben, und Understützungsmaterial "
+"wird darunter generiert."
+
+#: xs/src/libslic3r/PrintConfig.cpp:941
+msgid "Raft offset"
+msgstr "Gründungsfloßversatz"
+
+#: xs/src/libslic3r/PrintConfig.cpp:943
+msgid "Horizontal margin between object base layer and raft contour."
+msgstr "Horizontalspielraum zwischen Objectbasisschicht und Gründungsfloßkontur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:950
+msgid "Resolution (deprecated)"
+msgstr "Auflösung (veraltet)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:951
+msgid ""
+"Minimum detail resolution, used to simplify the input file for speeding up "
+"the slicing job and reducing memory usage. High-resolution models often "
+"carry more detail than printers can render. Set to zero to disable any "
+"simplification and use full resolution from input."
+msgstr ""
+"Diese Minimaldetailauflösung ist benutzt um Inputdateien zu vereinfachen, "
+"das Slicing zu beschleunigen, und Speicher zu schonen.  Modele mit "
+"Hochauflösung haben oft Details die der Drucker nicht Vollziehen kann.  Auf "
+"Null stellen um vereinfachen zu deaktivieren und die volle Auflösung des "
+"Inputs zu benutzen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:958
+msgid "Minimum travel after retraction"
+msgstr "Minimalbewegung nach Einziehen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:959 xs/src/libslic3r/PrintConfig.cpp:971
+#: xs/src/libslic3r/PrintConfig.cpp:982 xs/src/libslic3r/PrintConfig.cpp:1007
+#: xs/src/libslic3r/PrintConfig.cpp:1020 xs/src/libslic3r/PrintConfig.cpp:1033
+#: xs/src/libslic3r/PrintConfig.cpp:1045 xs/src/libslic3r/PrintConfig.cpp:1068
+#: xs/src/libslic3r/PrintConfig.cpp:1548
+msgid "Retraction"
+msgstr "Einziehen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:960
+msgid ""
+"Retraction is not triggered when travel moves are shorter than this length."
+msgstr "Einziehen wird bei Bewegung dieser Distanz oder kürzer nicht ausgelöst."
+
+#: xs/src/libslic3r/PrintConfig.cpp:970
+msgid "Retract on layer change"
+msgstr "Bei Schichtenwechsel Einziehen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:972
+msgid "This flag enforces a retraction whenever a Z move is done."
+msgstr "Diese Stellung zwingt Einziehen bei jeder Z bewegung."
+
+#: xs/src/libslic3r/PrintConfig.cpp:981 xs/src/libslic3r/PrintConfig.cpp:994
+msgid "Length"
+msgstr "Länge"
+
+#: xs/src/libslic3r/PrintConfig.cpp:984
+msgid ""
+"When retraction is triggered, filament is pulled back by the specified "
+"amount (the length is measured on raw filament, before it enters the "
+"extruder)."
+msgstr ""
+"Wenn Einziehen ausgelöst wird, wird das Filament diese Länge zurückgezogen.  "
+"(Die Länge ist am Rohfilament gemessen vordem es im Extruder ist.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:996
+msgid ""
+"When retraction is triggered before changing tool, filament is pulled back "
+"by the specified amount (the length is measured on raw filament, before it "
+"enters the extruder)."
+msgstr ""
+"Wenn Einziehen ausgelöst wird, wird das Filament diese Länge zurückgezogen.  "
+"(Die Länge ist am Rohfilament gemessen vordem es im Extruder ist.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1006
+msgid "Lift Z"
+msgstr "Z Heben"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1008
+msgid ""
+"If you set this to a positive value, Z is quickly raised every time a "
+"retraction is triggered. When using multiple extruders, only the setting for "
+"the first extruder will be considered."
+msgstr ""
+"Wenn diese Stellung positiv ist wird die Z Achse schnell gehoben jedesmal "
+"wenn Einziehen ausgelöst wird.  Bei mehrfachen Extrudern gilt nur die "
+"Stellung vom Ersten Extruder."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1018
+msgid "Above Z"
+msgstr "Über Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1021
+msgid ""
+"If you set this to a positive value, Z lift will only take place above the "
+"specified absolute Z. You can tune this setting for skipping lift on the "
+"first layers."
+msgstr ""
+"Wenn diese stellung Positiv ist, dann findet Z Heben nur über dieser "
+"absoluten Z-position statt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1031
+msgid "Below Z"
+msgstr "Unter Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1034
+msgid ""
+"If you set this to a positive value, Z lift will only take place below the "
+"specified absolute Z. You can tune this setting for limiting lift to the "
+"first layers."
+msgstr ""
+"Wenn diese stellung Positiv ist, dann findet Z Heben nur unter dieser "
+"absoluten Z-position statt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1044 xs/src/libslic3r/PrintConfig.cpp:1056
+msgid "Extra length on restart"
+msgstr "Extra Länge bei Neustart"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1046
+msgid ""
+"When the retraction is compensated after the travel move, the extruder will "
+"push this additional amount of filament. This setting is rarely needed."
+msgstr ""
+"Wenn nach der Bewegung das Einziehen ausgegleicht wird, wird der Extruder "
+"diese Extramenge Filament schieben.  Diese stellung ist nur selten notwendig."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1057
+msgid ""
+"When the retraction is compensated after changing tool, the extruder will "
+"push this additional amount of filament."
+msgstr ""
+"Wenn nach der Bewegung das Einziehen ausgegleicht wird, wird der Extruder "
+"diese Extramenge Filament schieben."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1069
+msgid ""
+"The speed for retractions (it only applies to the extruder motor). If you "
+"use the Firmware Retraction option, please note this value still affects the "
+"auto-speed pressure regulator."
+msgstr ""
+"Einziehungsgeschwindigkeit (betrifft nur den Extrudermotor.) Man sei "
+"angewiesen dass wenn die Firmwareeinziehungsstellung benutzt wird, diese "
+"stellung trotzdem den \"auto-speed pressure regulator\" betrifft."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1079
+msgid "Seam position"
+msgstr "Saumposition"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1081
+msgid "Position of perimeters starting points."
+msgstr "Position des Umfanganfangs"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1098
+msgid "USB/serial port for printer connection."
+msgstr "USB/serial port für Drucker Anschluß."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1107
+msgid "Speed (baud) of USB/serial port for printer connection."
+msgstr "Geschwindigkeit (baud) des USB/serial port für Drucker Anschluß."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1117
+msgid "Distance from object"
+msgstr "Distance vom Objekt"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1119
+msgid ""
+"Distance between skirt and object(s). Set this to zero to attach the skirt "
+"to the object(s) and get a brim for better adhesion."
+msgstr ""
+"Distanz zwischen Zarge und Objekt.  Auf Null stellen um die Zarge an das "
+"Objekt zu verbinden und eine Krempe für bessere Haftung zu generieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1126
+msgid "Skirt height"
+msgstr "Zargengröße"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1128
+msgid ""
+"Height of skirt expressed in layers. Set this to a tall value to use skirt "
+"as a shield against drafts."
+msgstr ""
+"Größe der Zarge in Schichten.  Eine große Zarge kann gegen Züge schützen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1134
+msgid "Loops (minimum)"
+msgstr "Schalaufen (minimal)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1137
+msgid ""
+"Number of loops for the skirt. If the Minimum Extrusion Length option is "
+"set, the number of loops might be greater than the one configured here. Set "
+"this to zero to disable skirt completely."
+msgstr ""
+"Zahl der Schlaufen in der Zarge.  Wenn Minimalextrusionslänge kann die Zahl "
+"von Schlaufen in der Zarge größer sein.   Auf Null stellen um Zargen zu "
+"deaktivieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1143
+msgid "Slow down if layer print time is below"
+msgstr "Langsamer drucken wenn die Schichtendruckzeit weniger als ___ ist"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1144
+msgid ""
+"If layer print time is estimated below this number of seconds, print moves "
+"speed will be scaled down to extend duration to this value."
+msgstr ""
+"Wenn die Schichtendruckzeitseinschätzung weniger als diese Zahl von Sekunden "
+"ist dann wird die Druckgeschwindigkeit langsamer skaliert um die "
+"Schichtdruckzeit auf die vorgeschriebene Zeit zu verlängern."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1153
+msgid "↳ small"
+msgstr "↳ klein"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1157
+msgid ""
+"This separate setting will affect the speed of perimeters having radius <= "
+"6.5mm (usually holes). If expressed as percentage (for example: 80%) it will "
+"be calculated on the perimeters speed setting above."
+msgstr ""
+"Diese getrennte stelling betrifft the Druckgeschwindigkeit von Umfängen mit "
+"Radius <= 6.5mm (normalerweise in Löchern). Als Prozent eigegeben (z. B.: "
+"80%) wird sie relativ der Umfangsgeschwindigkeit oben ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1167
+msgid "Solid infill threshold area"
+msgstr "Massivinfillflächeninhaltschwellwert "
+
+#: xs/src/libslic3r/PrintConfig.cpp:1169
+msgid ""
+"Force solid infill for regions having a smaller area than the specified "
+"threshold."
+msgstr ""
+"Zwinge Massivinfill in Regionen deren Flächeninhalt kleiner als diese "
+"Schwellwert ist."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1176
+msgid "Solid infill extruder"
+msgstr "Massivinfillextruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1178
+msgid "The extruder to use when printing solid infill."
+msgstr "Der Extruder der beim Drucken von Massivinfill benutzt werden soll."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1184
+msgid "Solid infill every"
+msgstr "Massivinfill jede"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1186
+msgid ""
+"This feature allows to force a solid layer every given number of layers. "
+"Zero to disable. You can set this to any value (for example 9999); Slic3r "
+"will automatically choose the maximum possible number of layers to combine "
+"according to nozzle diameter and layer height."
+msgstr ""
+"Diese Einstellung Generiert eine dichte Schicht je der eingegeben Zahl von "
+"Schichten.  Auf Null stellen um zu deaktivieren.  Man kann diese Stellung "
+"auf eine beliebige Zahl stellen (z. B. 9999), und Slic3r wird automatisch "
+"die maximal verienbaren Schichten duch Düsenduchmesser und Schichtdicke "
+"ausrechnen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1193 xs/src/libslic3r/PrintConfig.cpp:1206
+msgid "↳ solid"
+msgstr "↳ massiv"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1197
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"solid surfaces. If expressed as percentage (for example 90%) it will be "
+"computed over layer height."
+msgstr ""
+"Wenn diese Einstellung nicht Null ist dann bestimmt sie die Extrusionsbreite "
+"von festeb Oberflächen.  Als Prozent eingegeben (z. B. 90%) wird sie relativ "
+"der Schichtdicke ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1210
+msgid ""
+"Speed for printing solid regions (top/bottom/internal horizontal shells). "
+"This can be expressed as a percentage (for example: 80%) over the default "
+"infill speed above."
+msgstr ""
+"Druckgeschwindigkeit für dichte zonen (Boden/Decke/internen horizontalen "
+"Hüllen).  Als Prozent eingegeben (z. B.: 80%) wirds sie relativ der "
+"Standardinfillgetschwindigkeit ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1221
+msgid "Solid layers"
+msgstr "Dichte Schichten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1222
+msgid "Number of solid layers to generate on top and bottom surfaces."
+msgstr ""
+"Zahl der dichten Schichten die am Boden und an der Decke generiert werden "
+"sollen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1229
+msgid "Spiral vase"
+msgstr "Spiralvase"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1231
+msgid ""
+"This feature will raise Z gradually while printing a single-walled object in "
+"order to remove any visible seam. This option requires a single perimeter, "
+"no infill, no top solid layers and no support material. You can still set "
+"any number of bottom solid layers as well as skirt/brim loops. It won't work "
+"when printing more than an object."
+msgstr ""
+"Dieses Druckmethode erhöht die Z Position allmählich, während eine einfache "
+"Hülle gedruckt wird um jeglichen sichtbaren Saum zu vermeiden.  Diese Option "
+"erfordert stellungen auf einen einzigen Umfang, kein Infill, keine dichten "
+"Deckenschichten und kein Unterstützungsmaterial.  Man kann noch eine "
+"beliebige zahl der dichten Bodenschichten, und auch Zarg- oder "
+"Krempenschlaufen drucken.  Die Methode funktioniert auch nicht wenn man mehr "
+"als ein Objekt druckt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1236
+msgid "Temperature variation"
+msgstr "Temperaturunterschied"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1239
+msgid ""
+"Temperature difference to be applied when an extruder is not active.  "
+"Enables a full-height \"sacrificial\" skirt on which the nozzles are "
+"periodically wiped."
+msgstr ""
+"Temperaturunterschied der den nicht aktiven Extrudern bezogen wird.  "
+"Aktiviert eine große Opferzarge an der die Düsen abgewischt werden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1247 xs/src/libslic3r/PrintConfig.cpp:1256
+msgid "Start G-code"
+msgstr "Start G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1248
+msgid ""
+"This start procedure is inserted at the beginning, after bed has reached the "
+"target temperature and extruder just started heating, and before extruder "
+"has finished heating. If Slic3r detects M104, M109, M140 or M190 in your "
+"custom codes, such commands will not be prepended automatically so you're "
+"free to customize the order of heating commands and other custom actions. "
+"Note that you can use placeholder variables for all Slic3r settings, so you "
+"can put a \"M109 S[first_layer_temperature]\" command wherever you want."
+msgstr ""
+"Diese Routine wird am anfang des G-codes eingefügt, nachdem das Druckbrett "
+"aufgeheizt ist und die Extruder heizung grade angeschaltet ist, und vordem "
+"der Extruder seine Zieltemperatur erreicht hat.  Wenn Slic3r M104, M109, "
+"M140, oder M190 in dieser Routine erkennt dann werden solche Codes nicht "
+"automatisch generiert so dass man die reinfolge der Heizungsbefehle frei "
+"anpassen kann.  Man kann in diesm Code Platzhalter anwenden, zum Beispiel, "
+"könnte irgendwo in der Routine der \"M109 S[first_layer_temperature]\" "
+"Befehl stehen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1257
+msgid ""
+"This start procedure is inserted at the beginning, after any printer start "
+"gcode. This is used to override settings for a specific filament. If Slic3r "
+"detects M104, M109, M140 or M190 in your custom codes, such commands will "
+"not be prepended automatically so you're free to customize the order of "
+"heating commands and other custom actions. Note that you can use placeholder "
+"variables for all Slic3r settings, so you can put a \"M109 "
+"S[first_layer_temperature]\" command wherever you want. If you have multiple "
+"extruders, the gcode is processed in extruder order."
+msgstr ""
+"Diese Routine wird am anfang des G-codes eingefügt, nachdem das Druckbrett "
+"aufgeheizt ist und die Extruder heizung grade angeschaltet ist, und vordem "
+"der Extruder seine Zieltemperatur erreicht hat.  Wenn Slic3r M104, M109, "
+"M140, oder M190 in dieser Routine erkennt dann werden solche Codes nicht "
+"automatisch generiert so dass man die reinfolge der Heizungsbefehle frei "
+"anpassen kann.  Man kann in diesm Code Platzhalter anwenden, zum Beispiel, "
+"könnte irgendwo in der Routine der \"M109 S[first_layer_temperature]\" "
+"Befehl stehen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1269
+msgid "Generate support material"
+msgstr "Generiere Unterstützungsmaterial"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1271
+msgid "Enable support material generation."
+msgstr "Aktiviert generierung von Unterstützungsmaterial"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1276
+msgid "Pattern angle"
+msgstr "Muster Winkel"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1278
+msgid ""
+"Use this setting to rotate the support material pattern on the horizontal "
+"plane."
+msgstr ""
+"Diese stellung dreht das Unterstützungsmaterialsmuster in der Horizontalebene"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1286
+msgid "Support on build plate only"
+msgstr "Unterstützungsmaterial nur auf dem Druckbrett"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1288
+msgid ""
+"Only create support if it lies on a build plate. Don't create support on a "
+"print."
+msgstr ""
+"Unterstützungsmaterial nur generieren wenn es auf dem Druckbrett ist.  "
+"Unterstützungsmaterial nicht auf Objekten generieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1294
+msgid "Contact Z distance"
+msgstr "Kontakt Z-distanz"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1296
+msgid ""
+"The vertical distance between object and support material interface. Setting "
+"this to 0 will also prevent Slic3r from using bridge flow and speed for the "
+"first object layer."
+msgstr ""
+"Die vertikale distanz zwischen Objekt und Unterstützungsmaterial.  Wenn "
+"diese stellung 0 ist wird Slic3r die Brücken Fluss und "
+"Brückengeschwindigkeits stellungen bei der ersten Objektschicht ignoriert."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1307
+msgid "Enforce support for the first"
+msgstr "Zwinge Unterstützungsmaterial bei den ersten "
+
+#: xs/src/libslic3r/PrintConfig.cpp:1309
+msgid ""
+"Generate support material for the specified number of layers counting from "
+"bottom, regardless of whether normal support material is enabled or not and "
+"regardless of any angle threshold. This is useful for getting more adhesion "
+"of objects having a very thin or poor footprint on the build plate."
+msgstr ""
+"Generiere Unterstützungsmaterial für die eingegebe Zahl von Schichten vom "
+"Boden.  Generiert Material unabhängig von der aktivierung von normalem "
+"Unterstützungsmaterial oder jeglichem Winkelschwellwert.  Nützlich um "
+"Haftung für Objekte die dunne oder schwache Grundlagen am Druckbrett haben."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1317
+msgid "Support material/raft/skirt extruder"
+msgstr "Unterstützungsmaterial Gründungsfloß und Zargen Extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1319
+msgid "The extruder to use when printing support material, raft and skirt."
+msgstr ""
+"Der Extruder der bei Unterstützungsmaterial Gründungsfloß und Zargen zu "
+"benutzen ist."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1328
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for support "
+"material. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+msgstr ""
+"Wenn diese stellung nicht Null ist dan bestimmt sie die Extrusionsbreite des "
+"Unterstützungsmaterial.  Als Prozent eingegeben (z. B. 90%) wird sie relativ "
+"der Schichtendicke ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1337
+msgid "Support material/raft interface extruder"
+msgstr "Unterstützungsmaterial und Gründungsfloß Schnittstellen Extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1339
+msgid ""
+"The extruder to use when printing support material interface. This affects "
+"raft too."
+msgstr ""
+"Extruder der beim drucken der Schnittstelle zwischen Unterstützungsmaterial "
+"und Objekt, und zu benutzen ist.  Betrifft auch die Schnittstelle zwischen "
+"dem Gründungsfloß und dem Objekt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1345
+msgid "Interface layers"
+msgstr "Schnittstellen Schichten"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1347
+msgid ""
+"Number of interface layers to insert between the object(s) and support "
+"material."
+msgstr ""
+"Zahl der Schichten von Schnittstellenmaterial die zwischen Objekt und "
+"Unterstützungsmaterial generiert werden sollen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1354
+msgid "Interface pattern spacing"
+msgstr "Schnistellenmuster Abstand"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1356
+msgid "Spacing between interface lines. Set zero to get a solid interface."
+msgstr ""
+"Abstand zwischen Schnittstellenmateriallinien.  Auf Null stellen um dichtes "
+"Schnittstellenmaterial zu generieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1363
+msgid "↳ interface"
+msgstr "↳ Schnitstellen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1364
+msgid "Interface Speed"
+msgstr "Schnittstellendruckgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1365
+msgid "Support material interface speed"
+msgstr "Unterstützungsmaterialschnittstellendruckgeschwindigkeit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1368
+msgid ""
+"Speed for printing support material interface layers. If expressed as "
+"percentage (for example 50%) it will be calculated over support material "
+"speed."
+msgstr ""
+"Druckgeschwindigkeitsstellung für Unterstützungsmaterialschnittstellen. Als "
+"Prozent eingegeben (z.B 50%) wird sie relativ der "
+"Unterstützungsmaterialdruckgeschwindigkeit ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1378
+msgid "Pattern"
+msgstr "Muster"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1380
+msgid "Pattern used to generate support material."
+msgstr "Unterstützungsmaterialmuster."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1394
+msgid "Pattern spacing"
+msgstr "Muster Abstand"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1396
+msgid "Spacing between support material lines."
+msgstr "Abstand zwischen Unterstützungsmateriallinien."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1409
+msgid "Speed for printing support material."
+msgstr "Understützungsmaterialdruckgeschwindigkeit."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1418
+msgid "Overhang threshold"
+msgstr "Überhangschwellwert"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1420
+#, c-format
+msgid ""
+"Support material will not be generated for overhangs whose slope angle (90° "
+"= vertical) is above the given threshold. In other words, this value "
+"represent the most horizontal slope (measured from the horizontal plane) "
+"that you can print without support material. Set to a percentage to "
+"automatically detect based on some % of overhanging perimeter width instead "
+"(recommended)."
+msgstr ""
+"Understützungsmaterial wird nicht generiert wenn der Winkel eines Überhangs "
+"größer ist als diese stellung  (90° = vertikal).  Anders gesagt: Diese "
+"stellung ist der flachste Winke (von Horizontal gemessen) den man ohne "
+"Understützungsmaterial drucken kann.   Als Prozent eingeben um statdessen "
+"automatisch als % von überhängenden Umfang anzuerkennen (empfohlen)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1429
+msgid ""
+"Extruder temperature for layers after the first one. Set this to zero to "
+"disable temperature control commands in the output."
+msgstr ""
+"Extrudertemperatur für Schichten nach der ersten.  Auf Null stellen um "
+"Temparaturkontrolcode in der Outputdatei zu deaktivieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1441
+msgid "Detect thin walls"
+msgstr "Dünne Wände Identifizieren"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1443
+msgid ""
+"Detect single-width walls (parts where two extrusions don't fit and we need "
+"to collapse them into a single trace)."
+msgstr ""
+"Identifiziere einbreitige Wände.  (Wo zwei Extrudate nicht passen, und in "
+"ein eiziges zusammengefügt werden müssen.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1448
+msgid "Threads"
+msgstr "Threads"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1449
+msgid ""
+"Threads are used to parallelize long-running tasks. Optimal threads number "
+"is slightly above the number of available cores/processors."
+msgstr ""
+"Threads sind bei Parallelrechnung benutzt.  Die optimale Zahl ist ein "
+"bisschen größer als die zahl von verfügbarern Cores/Prozessoren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1458
+msgid "Tool change G-code"
+msgstr "Werkzeugwechsel G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1459
+msgid ""
+"This custom code is inserted right before every extruder change. Note that "
+"you can use placeholder variables for all Slic3r settings as well as "
+"[previous_extruder] and [next_extruder]."
+msgstr ""
+"Dieser G-Code wird vor jedem Extruderwechsel eingefügt.  Mann kann in diesem "
+"Code Platzhalter für alle Slic3r Einstellung und auch [previous_extruder] "
+"und [next_extruder] anwenden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1467 xs/src/libslic3r/PrintConfig.cpp:1488
+#, fuzzy
+msgid "↳ top solid"
+msgstr "↳ Dichte Decke"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1471
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"top surfaces. You may want to use thinner extrudates to fill all narrow "
+"regions and get a smoother finish. If expressed as percentage (for example "
+"90%) it will be computed over layer height."
+msgstr ""
+"Wenn nicht null bestimmt diese Stellung the Extrusionsbreite für "
+"Deckenoberflächen.  Mann will vielleicht dünnere Extrudate um schmale Zonen "
+"zu füllen und eine glatte Oberfläche zue ducken.  Als Prozent eingegeben (z. "
+"B. 90%) wird sie relativ der Schichtdicke ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1480 xs/src/libslic3r/PrintConfig.cpp:1502
+msgid "Top"
+msgstr "Decke"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1483
+msgid ""
+"Infill pattern for top layers. This only affects the external visible layer, "
+"and not its adjacent solid shells."
+msgstr ""
+"Infillmuster für Deckenschichten.   Diese Stellung betrifft nur die äusere "
+"sichtbare Schicht und nicht dem dichten Rand nebenan."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1492
+msgid ""
+"Speed for printing top solid layers (it only applies to the uppermost "
+"external layers and not to their internal solid layers). You may want to "
+"slow down this to get a nicer surface finish. This can be expressed as a "
+"percentage (for example: 80%) over the solid infill speed above."
+msgstr ""
+"Druckgeschwindigkeit für Oberschichten (betrifft nur die äusere sichtbare "
+"Schicht und nicht dem dichten Rand nebenan).  Mann will eventuel langsamer "
+"drucken um eine bessere Oberflächenqualität zu erhalten. Als Prozent "
+"eingegeben (z. B. 80%) wird diese Stellung relativ der "
+"Infillgeschwindingkeitsstellung ausgerechnet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1504
+msgid "Number of solid layers to generate on top surfaces."
+msgstr "Zahl der dichten Schichten die als Decke generiert werden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1511
+msgid "Travel"
+msgstr "Eilgang"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1513
+msgid "Speed for travel moves (jumps between distant extrusion points)."
+msgstr "Eilganggeschwindigkeit (zwischen entfernten Extrudionsplätzen)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1521
+msgid "Use firmware retraction"
+msgstr "Firmware Zurückziehen aktivieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1522
+msgid ""
+"This experimental setting uses G10 and G11 commands to have the firmware "
+"handle the retraction. This is only supported in recent Marlin."
+msgstr ""
+"Experimentalstellung die G10 und G11 G-Code benutzt so dass die "
+"Druckerfirmware das Zurückziehen übernimmt.  Nur mit neuen Marlin Versionen "
+"möglich."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1527
+msgid "Use relative E distances"
+msgstr "Relitive Extrusiondistanz Benutzen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1528
+msgid ""
+"If your firmware requires relative E values, check this, otherwise leave it "
+"unchecked. Most firmwares use absolute values."
+msgstr ""
+"Wenn die Druckerfirmware relative E-Koordinate benötigt, aktiviere diese "
+"stellung.  Sonst deaktiviert lassen.  Typische Drucker benutzen absolute "
+"Koordinaten."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1533
+msgid "Use volumetric E"
+msgstr "Volumetrische E Benutzen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1534
+msgid ""
+"This experimental setting uses outputs the E values in cubic millimeters "
+"instead of linear millimeters. If your firmware doesn't already know "
+"filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] "
+"T0' in your start G-code in order to turn volumetric mode on and use the "
+"filament diameter associated to the filament selected in Slic3r. This is "
+"only supported in recent Marlin."
+msgstr ""
+"Diese Experimentalstellung generiert E-Koordinaten in Kubikmillimeter stat "
+"in linearen Millimetern.  Wenn die Firmware den Filamentdurchmesser noch "
+"nicht weiss, kann Man befehle wie 'M200 D[filament_diameter_0] T0' in den "
+"start G-Code eingeben um Volumenmodus zu aktivieren und den "
+"Fialmentdurchmesser in der Slic3reinstellun zu benutzen.   Nur mit neuen "
+"Marlin Versionen möglich."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1539
+msgid "Vibration limit (deprecated)"
+msgstr "Vibrirgrenze (veraltet)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1540
+msgid ""
+"This experimental option will slow down those moves hitting the configured "
+"frequency limit. The purpose of limiting vibrations is to avoid mechanical "
+"resonance. Set zero to disable."
+msgstr ""
+"Diese Experimentalstellung werden Bewegungen die die Eingestellte Frequenz "
+"treffen verlangsamt.  Das Ziel des Einschränken der Vibrationen ist "
+"mechanische Resonanz zu vermeiden.  Zu deaktivieren auf Null stellen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1547
+msgid "Wipe while retracting"
+msgstr "Während Zurückziehen wischen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1549
+msgid ""
+"This flag will move the nozzle while retracting to minimize the possible "
+"blob on leaky extruders."
+msgstr ""
+"Diese Stellung wird die Düse während dem Zurückziehen um Tropfen am Extruder "
+"zu minimieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1558
+msgid "XY Size Compensation"
+msgstr "XY Gößenausgleich"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1560
+msgid ""
+"The object will be grown/shrunk in the XY plane by the configured value "
+"(negative = inwards, positive = outwards). This might be useful for fine-"
+"tuning hole sizes."
+msgstr ""
+"Das Objekt wird in der XY-Ebene vergrößert oder gerschrumpft (negativ="
+"einwärts, positiv = auswärts).  Dass könnte für fein-kontrolle von "
+"Lochgrößen nützlich sein."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1566
+msgid "Z offset"
+msgstr "Z Abstand"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1567
+msgid ""
+"This value will be added (or subtracted) from all the Z coordinates in the "
+"output G-code. It is used to compensate for bad Z endstop position: for "
+"example, if your endstop zero actually leaves the nozzle 0.3mm far from the "
+"print bed, set this to -0.3 (or fix your endstop)."
+msgstr ""
+"Diese stellung wird allen Z-Koordinaten in dem G-Code zugesätzt (oder "
+"abgezogen).  Sie ist zum ausgleich einer schlechten Z-Endanschlagsposition "
+"geeignet:  Zum Beispiel, wenn der Endanschlagnull die Düse 0.3mm vom "
+"Druckbrett lässt, kann man hier -0.3 eingeben."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1573
+msgid "Z full steps/mm"
+msgstr "Z Vollschritte/mm"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1574
+msgid ""
+"Set this to the number of *full* steps (not microsteps) needed for moving "
+"the Z axis by 1mm; you can calculate this by dividing the number of "
+"microsteps configured in your firmware by the microstepping amount (8, 16, "
+"32). Slic3r will round your configured layer height to the nearest multiple "
+"of that value in order to ensure the best accuracy. This is most useful for "
+"machines with imperial leadscrews or belt-driven Z or for unusual layer "
+"heights with metric leadscrews. Set to zero to disable this experimental "
+"feature."
+msgstr ""
+"Die Zahl der *Voll*schritte (nicht Microschritte) die die Z-achse 1mm "
+"bewegen.  Mann kann diese Zahl ausrechnen wenn man die Zahl von "
+"Micrschritten in der Firmware durch die Microschrittmenge (8, 16, 32) "
+"teilt.  Slicer wird die Schichtdicke auf das nähste Vielfache davon abrunden "
+"um für die beste Genauigkeit zu sorgen.  Nützlich wenn der Drucker "
+"Imperialeinheitenleitspindel oder ungewöhnliche Z-Schritte macht.  Zum "
+"deaktivieren auf Null stellen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1716 xs/src/libslic3r/PrintConfig.cpp:1722
+#: xs/src/libslic3r/PrintConfig.cpp:1728 xs/src/libslic3r/PrintConfig.cpp:1734
+msgid "Cut"
+msgstr "Schnitt"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1717
+msgid "Cut model at the given Z."
+msgstr "Model an dem eingegeben Z-Wert Abschneiden"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1723
+msgid "Cut model in the XY plane into tiles of the specified max size."
+msgstr "Model in der XY-Ebene in Kacheln der eingegeben Maximalgöße aufteilen."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1729
+msgid "Cut model at the given X."
+msgstr "Model an dem eingegeben X-Wert Abschneiden"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1735
+msgid "Cut model at the given Y."
+msgstr "Model an dem eingegeben X-Wert Abschneiden"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1740 xs/src/libslic3r/PrintConfig.cpp:1752
+msgid "Export SVG"
+msgstr "SVG Datei Export"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1741
+msgid "Export the model as OBJ."
+msgstr "Datei als OBJ Exportieren"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1746
+msgid "Export POV"
+msgstr "POV Datei Export"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1747
+msgid "Export the model as POV-Ray definition."
+msgstr "Model als POV-Ray definition exportieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1753
+msgid "Slice the model and export slices as SVG."
+msgstr "Model aufschneiden und the Scheiben als SVG exportieren."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1758
+msgid "Output Model Info"
+msgstr "Modelinfo Ausgeben"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1759
+msgid "Write information about the model to the console."
+msgstr "Information über das Model an die Konsole schreiben."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1764
+msgid "Load config file"
+msgstr "Config Datei Laden"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1765
+msgid ""
+"Load configuration from the specified file. It can be used more than once to "
+"load options from multiple files."
+msgstr ""
+"Konfiguration von der eingegebenen Datei laden. Kann mehrmals benutzt um "
+"Optionen von mehreren Dateien zu laden."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1770
+msgid "Output File"
+msgstr "Outputdatei"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1771
+msgid ""
+"The file where the output will be written (if not specified, it will be "
+"based on the input file)."
+msgstr ""
+"Die Datei wo der Output gespeichert wird.  (Wenn kein name eingegeben ist "
+"bestimmt die Inputdatei die Outputdatei.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1776
+msgid "Rotate"
+msgstr "Drehen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1777
+msgid "Rotation angle around the Z axis in degrees (0-360, default: 0)."
+msgstr "Drehwinkel um die Z-Achse in Grad (0-360, Standard: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1782
+msgid "Rotate around X"
+msgstr "Um X Drehen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1783
+msgid "Rotation angle around the X axis in degrees (0-360, default: 0)."
+msgstr "Drehwinkel um die X-Achse in Grad (0-360, Standard: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1788
+msgid "Rotate around Y"
+msgstr "Um X Drehen"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1789
+msgid "Rotation angle around the Y axis in degrees (0-360, default: 0)."
+msgstr "Drehwinkel um die Y-Achse in Grad (0-360, Standard: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1794
+msgid "Save config file"
+msgstr "Konfiguration speichern"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1795
+msgid "Save configuration to the specified file."
+msgstr "Konfiguration in der eingegeben Datei speichern"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1800
+msgid "Scale"
+msgstr "Skalieren"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1801
+msgid "Scaling factor (default: 1)."
+msgstr "Skalierfaktor (Standard: 1)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1806
+msgid "Scale to Fit"
+msgstr "Anpassend skalieren"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1807
+msgid "Scale to fit the given volume."
+msgstr "Dem eingegebenen Volum anpassend skalieren."

--- a/translation/en_US.po
+++ b/translation/en_US.po
@@ -285,11 +285,11 @@ msgstr "Disable fan for the first"
 
 #: xs/src/libslic3r/PrintConfig.cpp:169
 msgid ""
-"You can set this to a positive value to disable fan at all during the first "
-"layers, so that it does not make adhesion worse."
+"This disables the fan completely for the first N layers "
+"to aid in the adhesion of media to the bed. (default 3)"
 msgstr ""
-"You can set this to a positive value to disable fan at all during the first "
-"layers, so that it does not make adhesion worse."
+"This disables the fan completely for the first N layers "
+"to aid in the adhesion of media to the bed. (default 3)"
 
 #: xs/src/libslic3r/PrintConfig.cpp:170
 msgid "layers"

--- a/translation/en_US.po
+++ b/translation/en_US.po
@@ -1,0 +1,2093 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Slic3r\n"
+"POT-Creation-Date: 2017-03-29 00:02-0600\n"
+"PO-Revision-Date: 2017-03-29 00:08-0600\n"
+"Last-Translator: \n"
+"Language-Team: Joseph Lenox <lenox.joseph@gmail.com>\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.6.10\n"
+"X-Poedit-Basepath: ../\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __TRANS;__\n"
+"X-Poedit-SearchPath-0: xs/src/libslic3r\n"
+"X-Poedit-SearchPath-1: xs/xrc/slic3r/GUI\n"
+"X-Poedit-SearchPath-2: xs/xrc/slic3r\n"
+
+#: xs/src/libslic3r/PrintConfig.cpp:18
+msgid "Rectilinear"
+msgstr "Rectilinear"
+
+#: xs/src/libslic3r/PrintConfig.cpp:19
+msgid "Concentric"
+msgstr "Concentric"
+
+#: xs/src/libslic3r/PrintConfig.cpp:20
+msgid "Hilbert Curve"
+msgstr "Hilbert Curve"
+
+#: xs/src/libslic3r/PrintConfig.cpp:21
+msgid "Archimedean Chords"
+msgstr "Archimedean Chords"
+
+#: xs/src/libslic3r/PrintConfig.cpp:22
+msgid "Octagram Spiral"
+msgstr "Octagram Spiral"
+
+#: xs/src/libslic3r/PrintConfig.cpp:27
+msgid "Avoid crossing perimeters"
+msgstr "Avoid crossing perimeters"
+
+#: xs/src/libslic3r/PrintConfig.cpp:28 xs/src/libslic3r/PrintConfig.cpp:77
+#: xs/src/libslic3r/PrintConfig.cpp:252 xs/src/libslic3r/PrintConfig.cpp:259
+#: xs/src/libslic3r/PrintConfig.cpp:544 xs/src/libslic3r/PrintConfig.cpp:712
+#: xs/src/libslic3r/PrintConfig.cpp:726 xs/src/libslic3r/PrintConfig.cpp:820
+#: xs/src/libslic3r/PrintConfig.cpp:842 xs/src/libslic3r/PrintConfig.cpp:900
+#: xs/src/libslic3r/PrintConfig.cpp:1080 xs/src/libslic3r/PrintConfig.cpp:1230
+#: xs/src/libslic3r/PrintConfig.cpp:1442 xs/src/libslic3r/PrintConfig.cpp:1503
+msgid "Layers and Perimeters"
+msgstr "Layers and Perimeters"
+
+#: xs/src/libslic3r/PrintConfig.cpp:29
+msgid ""
+"Optimize travel moves in order to minimize the crossing of perimeters. This "
+"is mostly useful with Bowden extruders which suffer from oozing. This "
+"feature slows down both the print and the G-code generation."
+msgstr ""
+"Optimize travel moves in order to minimize the crossing of perimeters. This "
+"is mostly useful with Bowden extruders which suffer from oozing. This "
+"feature slows down both the print and the G-code generation."
+
+#: xs/src/libslic3r/PrintConfig.cpp:34
+msgid "Bed shape"
+msgstr "Bed shape"
+
+#: xs/src/libslic3r/PrintConfig.cpp:44
+msgid "Has heated bed"
+msgstr "Has heated bed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:45
+msgid ""
+"Unselecting this will suppress automatic generation of bed heating gcode."
+msgstr ""
+"Unselecting this will suppress automatic generation of bed heating gcode."
+
+#: xs/src/libslic3r/PrintConfig.cpp:50 xs/src/libslic3r/PrintConfig.cpp:1428
+msgid "Other layers"
+msgstr "Other layers"
+
+#: xs/src/libslic3r/PrintConfig.cpp:51
+msgid "Bed temperature for layers after the first one."
+msgstr "Bed temperature for layers after the first one."
+
+#: xs/src/libslic3r/PrintConfig.cpp:53
+msgid "Bed temperature"
+msgstr "Bed temperature"
+
+#: xs/src/libslic3r/PrintConfig.cpp:59
+msgid "Before layer change G-code"
+msgstr "Before layer change G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:60
+msgid ""
+"This custom code is inserted at every layer change, right before the Z move. "
+"Note that you can use placeholder variables for all Slic3r settings as well "
+"as [layer_num] and [layer_z]."
+msgstr ""
+"This custom code is inserted at every layer change, right before the Z move. "
+"Note that you can use placeholder variables for all Slic3r settings as well "
+"as [layer_num] and [layer_z]."
+
+#: xs/src/libslic3r/PrintConfig.cpp:68 xs/src/libslic3r/PrintConfig.cpp:76
+msgid "Bottom"
+msgstr "Bottom"
+
+#: xs/src/libslic3r/PrintConfig.cpp:69
+msgid "Bottom infill pattern"
+msgstr "Bottom infill pattern"
+
+#: xs/src/libslic3r/PrintConfig.cpp:70 xs/src/libslic3r/PrintConfig.cpp:216
+#: xs/src/libslic3r/PrintConfig.cpp:425 xs/src/libslic3r/PrintConfig.cpp:437
+#: xs/src/libslic3r/PrintConfig.cpp:475 xs/src/libslic3r/PrintConfig.cpp:482
+#: xs/src/libslic3r/PrintConfig.cpp:624 xs/src/libslic3r/PrintConfig.cpp:634
+#: xs/src/libslic3r/PrintConfig.cpp:651 xs/src/libslic3r/PrintConfig.cpp:664
+#: xs/src/libslic3r/PrintConfig.cpp:671 xs/src/libslic3r/PrintConfig.cpp:686
+#: xs/src/libslic3r/PrintConfig.cpp:1168 xs/src/libslic3r/PrintConfig.cpp:1185
+#: xs/src/libslic3r/PrintConfig.cpp:1482
+msgid "Infill"
+msgstr "Infill"
+
+#: xs/src/libslic3r/PrintConfig.cpp:71
+msgid ""
+"Infill pattern for bottom layers. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+msgstr ""
+"Infill pattern for bottom layers. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+
+#: xs/src/libslic3r/PrintConfig.cpp:78
+msgid "Number of solid layers to generate on bottom surfaces."
+msgstr "Number of solid layers to generate on bottom surfaces."
+
+#: xs/src/libslic3r/PrintConfig.cpp:80
+msgid "Bottom solid layers"
+msgstr "Bottom solid layers"
+
+#: xs/src/libslic3r/PrintConfig.cpp:85
+msgid "Bridge"
+msgstr "Bridge"
+
+#: xs/src/libslic3r/PrintConfig.cpp:86 xs/src/libslic3r/PrintConfig.cpp:160
+#: xs/src/libslic3r/PrintConfig.cpp:514 xs/src/libslic3r/PrintConfig.cpp:625
+#: xs/src/libslic3r/PrintConfig.cpp:857
+msgid "Speed > Acceleration"
+msgstr "Speed > Acceleration"
+
+#: xs/src/libslic3r/PrintConfig.cpp:87
+msgid ""
+"This is the acceleration your printer will use for bridges. Set zero to "
+"disable acceleration control for bridges."
+msgstr ""
+"This is the acceleration your printer will use for bridges. Set zero to "
+"disable acceleration control for bridges."
+
+#: xs/src/libslic3r/PrintConfig.cpp:94
+msgid "Bridges fan speed"
+msgstr "Bridges fan speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:95
+msgid "This fan speed is enforced during all bridges and overhangs."
+msgstr "This fan speed is enforced during all bridges and overhangs."
+
+#: xs/src/libslic3r/PrintConfig.cpp:103
+msgid "Bridge flow ratio"
+msgstr "Bridge flow ratio"
+
+#: xs/src/libslic3r/PrintConfig.cpp:104 xs/src/libslic3r/PrintConfig.cpp:147
+#: xs/src/libslic3r/PrintConfig.cpp:678 xs/src/libslic3r/PrintConfig.cpp:1559
+msgid "Advanced"
+msgstr "Advanced"
+
+#: xs/src/libslic3r/PrintConfig.cpp:105
+msgid ""
+"This factor affects the amount of plastic for bridging. You can decrease it "
+"slightly to pull the extrudates and prevent sagging, although default "
+"settings are usually good and you should experiment with cooling (use a fan) "
+"before tweaking this."
+msgstr ""
+"This factor affects the amount of plastic for bridging. You can decrease it "
+"slightly to pull the extrudates and prevent sagging, although default "
+"settings are usually good and you should experiment with cooling (use a fan) "
+"before tweaking this."
+
+#: xs/src/libslic3r/PrintConfig.cpp:111
+msgid "Bridges"
+msgstr "Bridges"
+
+#: xs/src/libslic3r/PrintConfig.cpp:113 xs/src/libslic3r/PrintConfig.cpp:240
+#: xs/src/libslic3r/PrintConfig.cpp:553 xs/src/libslic3r/PrintConfig.cpp:576
+#: xs/src/libslic3r/PrintConfig.cpp:688 xs/src/libslic3r/PrintConfig.cpp:744
+#: xs/src/libslic3r/PrintConfig.cpp:753 xs/src/libslic3r/PrintConfig.cpp:888
+#: xs/src/libslic3r/PrintConfig.cpp:1067 xs/src/libslic3r/PrintConfig.cpp:1105
+#: xs/src/libslic3r/PrintConfig.cpp:1156 xs/src/libslic3r/PrintConfig.cpp:1209
+#: xs/src/libslic3r/PrintConfig.cpp:1491 xs/src/libslic3r/PrintConfig.cpp:1512
+msgid "Speed"
+msgstr "Speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:114
+msgid "Speed for printing bridges."
+msgstr "Speed for printing bridges."
+
+#: xs/src/libslic3r/PrintConfig.cpp:124
+msgid "Brim connections width"
+msgstr "Brim connections width"
+
+#: xs/src/libslic3r/PrintConfig.cpp:125 xs/src/libslic3r/PrintConfig.cpp:134
+#: xs/src/libslic3r/PrintConfig.cpp:701 xs/src/libslic3r/PrintConfig.cpp:779
+#: xs/src/libslic3r/PrintConfig.cpp:1118 xs/src/libslic3r/PrintConfig.cpp:1127
+#: xs/src/libslic3r/PrintConfig.cpp:1135
+msgid "Skirt and brim"
+msgstr "Skirt and brim"
+
+#: xs/src/libslic3r/PrintConfig.cpp:126
+msgid ""
+"If set to a positive value, straight connections will be built on the first "
+"layer between adjacent objects."
+msgstr ""
+"If set to a positive value, straight connections will be built on the first "
+"layer between adjacent objects."
+
+#: xs/src/libslic3r/PrintConfig.cpp:133
+msgid "Exterior brim width"
+msgstr "Exterior brim width"
+
+#: xs/src/libslic3r/PrintConfig.cpp:135
+msgid ""
+"Horizontal width of the brim that will be printed around each object on the "
+"first layer."
+msgstr ""
+"Horizontal width of the brim that will be printed around each object on the "
+"first layer."
+
+#: xs/src/libslic3r/PrintConfig.cpp:142
+msgid "Compatible printers"
+msgstr "Compatible printers"
+
+#: xs/src/libslic3r/PrintConfig.cpp:146
+msgid "Complete individual objects"
+msgstr "Complete individual objects"
+
+#: xs/src/libslic3r/PrintConfig.cpp:148
+msgid ""
+"When printing multiple objects or copies, this feature will complete each "
+"object before moving onto next one (and starting it from its bottom layer). "
+"This feature is useful to avoid the risk of ruined prints. Slic3r should "
+"warn and prevent you from extruder collisions, but beware."
+msgstr ""
+"When printing multiple objects or copies, this feature will complete each "
+"object before moving onto next one (and starting it from its bottom layer). "
+"This feature is useful to avoid the risk of ruined prints. Slic3r should "
+"warn and prevent you from extruder collisions, but beware."
+
+#: xs/src/libslic3r/PrintConfig.cpp:153
+msgid "Enable auto cooling"
+msgstr "Enable auto cooling"
+
+#: xs/src/libslic3r/PrintConfig.cpp:154
+msgid ""
+"This flag enables the automatic cooling logic that adjusts print speed and "
+"fan speed according to layer printing time."
+msgstr ""
+"This flag enables the automatic cooling logic that adjusts print speed and "
+"fan speed according to layer printing time."
+
+#: xs/src/libslic3r/PrintConfig.cpp:159
+msgid "Default"
+msgstr "Default"
+
+#: xs/src/libslic3r/PrintConfig.cpp:161
+msgid ""
+"This is the acceleration your printer will be reset to after the role-"
+"specific acceleration values are used (perimeter/infill). Set zero to "
+"prevent resetting acceleration at all."
+msgstr ""
+"This is the acceleration your printer will be reset to after the role-"
+"specific acceleration values are used (perimeter/infill). Set zero to "
+"prevent resetting acceleration at all."
+
+#: xs/src/libslic3r/PrintConfig.cpp:168
+msgid "Disable fan for the first"
+msgstr "Disable fan for the first"
+
+#: xs/src/libslic3r/PrintConfig.cpp:169
+msgid ""
+"You can set this to a positive value to disable fan at all during the first "
+"layers, so that it does not make adhesion worse."
+msgstr ""
+"You can set this to a positive value to disable fan at all during the first "
+"layers, so that it does not make adhesion worse."
+
+#: xs/src/libslic3r/PrintConfig.cpp:170
+msgid "layers"
+msgstr "layers"
+
+#: xs/src/libslic3r/PrintConfig.cpp:177
+msgid "Don't support bridges"
+msgstr "Don't support bridges"
+
+#: xs/src/libslic3r/PrintConfig.cpp:178 xs/src/libslic3r/PrintConfig.cpp:933
+#: xs/src/libslic3r/PrintConfig.cpp:942 xs/src/libslic3r/PrintConfig.cpp:1270
+#: xs/src/libslic3r/PrintConfig.cpp:1277 xs/src/libslic3r/PrintConfig.cpp:1287
+#: xs/src/libslic3r/PrintConfig.cpp:1295 xs/src/libslic3r/PrintConfig.cpp:1308
+#: xs/src/libslic3r/PrintConfig.cpp:1325 xs/src/libslic3r/PrintConfig.cpp:1346
+#: xs/src/libslic3r/PrintConfig.cpp:1355 xs/src/libslic3r/PrintConfig.cpp:1367
+#: xs/src/libslic3r/PrintConfig.cpp:1379 xs/src/libslic3r/PrintConfig.cpp:1395
+#: xs/src/libslic3r/PrintConfig.cpp:1406 xs/src/libslic3r/PrintConfig.cpp:1408
+#: xs/src/libslic3r/PrintConfig.cpp:1419
+msgid "Support material"
+msgstr "Support material"
+
+#: xs/src/libslic3r/PrintConfig.cpp:179
+msgid ""
+"Experimental option for preventing support material from being generated "
+"under bridged areas."
+msgstr ""
+"Experimental option for preventing support material from being generated "
+"under bridged areas."
+
+#: xs/src/libslic3r/PrintConfig.cpp:184
+msgid "Distance between copies"
+msgstr "Distance between copies"
+
+#: xs/src/libslic3r/PrintConfig.cpp:185
+msgid "Distance used for the auto-arrange feature of the plater."
+msgstr "Distance used for the auto-arrange feature of the plater."
+
+#: xs/src/libslic3r/PrintConfig.cpp:193 xs/src/libslic3r/PrintConfig.cpp:202
+msgid "End G-code"
+msgstr "End G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:194
+msgid ""
+"This end procedure is inserted at the end of the output file. Note that you "
+"can use placeholder variables for all Slic3r settings."
+msgstr ""
+"This end procedure is inserted at the end of the output file. Note that you "
+"can use placeholder variables for all Slic3r settings."
+
+#: xs/src/libslic3r/PrintConfig.cpp:203
+msgid ""
+"This end procedure is inserted at the end of the output file, before the "
+"printer end gcode. Note that you can use placeholder variables for all "
+"Slic3r settings. If you have multiple extruders, the gcode is processed in "
+"extruder order."
+msgstr ""
+"This end procedure is inserted at the end of the output file, before the "
+"printer end gcode. Note that you can use placeholder variables for all "
+"Slic3r settings. If you have multiple extruders, the gcode is processed in "
+"extruder order."
+
+#: xs/src/libslic3r/PrintConfig.cpp:215
+msgid "Top/bottom fill pattern"
+msgstr "Top/bottom fill pattern"
+
+#: xs/src/libslic3r/PrintConfig.cpp:217
+msgid ""
+"Fill pattern for top/bottom infill. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+msgstr ""
+"Fill pattern for top/bottom infill. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+
+#: xs/src/libslic3r/PrintConfig.cpp:224 xs/src/libslic3r/PrintConfig.cpp:237
+msgid "↳ external"
+msgstr "↳ external"
+
+#: xs/src/libslic3r/PrintConfig.cpp:225
+msgid "External perimeters extrusion width"
+msgstr "External perimeters extrusion width"
+
+#: xs/src/libslic3r/PrintConfig.cpp:227 xs/src/libslic3r/PrintConfig.cpp:323
+#: xs/src/libslic3r/PrintConfig.cpp:532 xs/src/libslic3r/PrintConfig.cpp:653
+#: xs/src/libslic3r/PrintConfig.cpp:875 xs/src/libslic3r/PrintConfig.cpp:1196
+#: xs/src/libslic3r/PrintConfig.cpp:1327 xs/src/libslic3r/PrintConfig.cpp:1470
+msgid "Extrusion Width"
+msgstr "Extrusion Width"
+
+#: xs/src/libslic3r/PrintConfig.cpp:228
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for external "
+"perimeters. If auto is chosen, a value will be used that maximizes accuracy "
+"of the external visible surfaces. If expressed as percentage (for example "
+"200%) it will be computed over layer height."
+msgstr ""
+"Set this to a non-zero value to set a manual extrusion width for external "
+"perimeters. If auto is chosen, a value will be used that maximizes accuracy "
+"of the external visible surfaces. If expressed as percentage (for example "
+"200%) it will be computed over layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:238
+msgid "External perimeters speed"
+msgstr "External perimeters speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:241
+msgid ""
+"This separate setting will affect the speed of external perimeters (the "
+"visible ones). If expressed as percentage (for example: 80%) it will be "
+"calculated on the perimeters speed setting above."
+msgstr ""
+"This separate setting will affect the speed of external perimeters (the "
+"visible ones). If expressed as percentage (for example: 80%) it will be "
+"calculated on the perimeters speed setting above."
+
+#: xs/src/libslic3r/PrintConfig.cpp:251
+msgid "External perimeters first"
+msgstr "External perimeters first"
+
+#: xs/src/libslic3r/PrintConfig.cpp:253
+msgid ""
+"Print contour perimeters from the outermost one to the innermost one instead "
+"of the default inverse order."
+msgstr ""
+"Print contour perimeters from the outermost one to the innermost one instead "
+"of the default inverse order."
+
+#: xs/src/libslic3r/PrintConfig.cpp:258
+msgid "Extra perimeters if needed"
+msgstr "Extra perimeters if needed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:260
+msgid "Add more perimeters when needed for avoiding gaps in sloping walls."
+msgstr "Add more perimeters when needed for avoiding gaps in sloping walls."
+
+#: xs/src/libslic3r/PrintConfig.cpp:266 xs/src/libslic3r/PrintConfig.cpp:925
+msgid "Extruder"
+msgstr "Extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:267 xs/src/libslic3r/PrintConfig.cpp:644
+#: xs/src/libslic3r/PrintConfig.cpp:828 xs/src/libslic3r/PrintConfig.cpp:865
+#: xs/src/libslic3r/PrintConfig.cpp:1177 xs/src/libslic3r/PrintConfig.cpp:1238
+#: xs/src/libslic3r/PrintConfig.cpp:1318 xs/src/libslic3r/PrintConfig.cpp:1338
+msgid "Extruders"
+msgstr "Extruders"
+
+#: xs/src/libslic3r/PrintConfig.cpp:268
+msgid ""
+"The extruder to use (unless more specific extruder settings are specified)."
+msgstr ""
+"The extruder to use (unless more specific extruder settings are specified)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:278
+msgid "Height"
+msgstr "Height"
+
+#: xs/src/libslic3r/PrintConfig.cpp:279
+msgid ""
+"Set this to the vertical distance between your nozzle tip and (usually) the "
+"X carriage rods. In other words, this is the height of the clearance "
+"cylinder around your extruder, and it represents the maximum depth the "
+"extruder can peek before colliding with other printed objects."
+msgstr ""
+"Set this to the vertical distance between your nozzle tip and (usually) the "
+"X carriage rods. In other words, this is the height of the clearance "
+"cylinder around your extruder, and it represents the maximum depth the "
+"extruder can peek before colliding with other printed objects."
+
+#: xs/src/libslic3r/PrintConfig.cpp:286
+msgid "Radius"
+msgstr "Radius"
+
+#: xs/src/libslic3r/PrintConfig.cpp:287
+msgid ""
+"Set this to the clearance radius around your extruder. If the extruder is "
+"not centered, choose the largest value for safety. This setting is used to "
+"check for collisions and to display the graphical preview in the plater."
+msgstr ""
+"Set this to the clearance radius around your extruder. If the extruder is "
+"not centered, choose the largest value for safety. This setting is used to "
+"check for collisions and to display the graphical preview in the plater."
+
+#: xs/src/libslic3r/PrintConfig.cpp:294
+msgid "Extruder offset"
+msgstr "Extruder offset"
+
+#: xs/src/libslic3r/PrintConfig.cpp:295
+msgid ""
+"If your firmware doesn't handle the extruder displacement you need the G-"
+"code to take it into account. This option lets you specify the displacement "
+"of each extruder with respect to the first one. It expects positive "
+"coordinates (they will be subtracted from the XY coordinate)."
+msgstr ""
+"If your firmware doesn't handle the extruder displacement you need the G-"
+"code to take it into account. This option lets you specify the displacement "
+"of each extruder with respect to the first one. It expects positive "
+"coordinates (they will be subtracted from the XY coordinate)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:305
+msgid "Extrusion axis"
+msgstr "Extrusion axis"
+
+#: xs/src/libslic3r/PrintConfig.cpp:306
+msgid ""
+"Use this option to set the axis letter associated to your printer's extruder "
+"(usually E but some printers use A)."
+msgstr ""
+"Use this option to set the axis letter associated to your printer's extruder "
+"(usually E but some printers use A)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:311
+msgid "Extrusion multiplier"
+msgstr "Extrusion multiplier"
+
+#: xs/src/libslic3r/PrintConfig.cpp:312
+msgid ""
+"This factor changes the amount of flow proportionally. You may need to tweak "
+"this setting to get nice surface finish and correct single wall widths. "
+"Usual values are between 0.9 and 1.1. If you think you need to change this "
+"more, check filament diameter and your firmware E steps."
+msgstr ""
+"This factor changes the amount of flow proportionally. You may need to tweak "
+"this setting to get nice surface finish and correct single wall widths. "
+"Usual values are between 0.9 and 1.1. If you think you need to change this "
+"more, check filament diameter and your firmware E steps."
+
+#: xs/src/libslic3r/PrintConfig.cpp:321
+msgid "Default extrusion width"
+msgstr "Default extrusion width"
+
+#: xs/src/libslic3r/PrintConfig.cpp:324
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width. If expressed "
+"as percentage (for example: 230%) it will be computed over layer height."
+msgstr ""
+"Set this to a non-zero value to set a manual extrusion width. If expressed "
+"as percentage (for example: 230%) it will be computed over layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:333
+msgid "Keep fan always on"
+msgstr "Keep fan always on"
+
+#: xs/src/libslic3r/PrintConfig.cpp:334
+msgid ""
+"If this is enabled, fan will never be disabled and will be kept running at "
+"least at its minimum speed. Useful for PLA, harmful for ABS."
+msgstr ""
+"If this is enabled, fan will never be disabled and will be kept running at "
+"least at its minimum speed. Useful for PLA, harmful for ABS."
+
+#: xs/src/libslic3r/PrintConfig.cpp:339
+msgid "Enable fan if layer print time is below"
+msgstr "Enable fan if layer print time is below"
+
+#: xs/src/libslic3r/PrintConfig.cpp:340
+msgid ""
+"If layer print time is estimated below this number of seconds, fan will be "
+"enabled and its speed will be calculated by interpolating the minimum and "
+"maximum speeds."
+msgstr ""
+"If layer print time is estimated below this number of seconds, fan will be "
+"enabled and its speed will be calculated by interpolating the minimum and "
+"maximum speeds."
+
+#: xs/src/libslic3r/PrintConfig.cpp:349
+msgid "Color"
+msgstr "Color"
+
+#: xs/src/libslic3r/PrintConfig.cpp:350
+msgid "This is only used in the Slic3r interface as a visual help."
+msgstr "This is only used in the Slic3r interface as a visual help."
+
+#: xs/src/libslic3r/PrintConfig.cpp:360
+msgid "Filament notes"
+msgstr "Filament notes"
+
+#: xs/src/libslic3r/PrintConfig.cpp:361
+msgid "You can put your notes regarding the filament here."
+msgstr "You can put your notes regarding the filament here."
+
+#: xs/src/libslic3r/PrintConfig.cpp:373 xs/src/libslic3r/PrintConfig.cpp:752
+msgid "Max volumetric speed"
+msgstr "Max volumetric speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:374
+msgid ""
+"Maximum volumetric speed allowed for this filament. Limits the maximum "
+"volumetric speed of a print to the minimum of print and filament volumetric "
+"speed. Set to zero for no limit."
+msgstr ""
+"Maximum volumetric speed allowed for this filament. Limits the maximum "
+"volumetric speed of a print to the minimum of print and filament volumetric "
+"speed. Set to zero for no limit."
+
+#: xs/src/libslic3r/PrintConfig.cpp:385
+msgid "Diameter"
+msgstr "Diameter"
+
+#: xs/src/libslic3r/PrintConfig.cpp:386
+msgid ""
+"Enter your filament diameter here. Good precision is required, so use a "
+"caliper and do multiple measurements along the filament, then compute the "
+"average."
+msgstr ""
+"Enter your filament diameter here. Good precision is required, so use a "
+"caliper and do multiple measurements along the filament, then compute the "
+"average."
+
+#: xs/src/libslic3r/PrintConfig.cpp:397
+msgid "Density"
+msgstr "Density"
+
+#: xs/src/libslic3r/PrintConfig.cpp:398
+msgid ""
+"Enter your filament density here. This is only for statistical information. "
+"A decent way is to weigh a known length of filament and compute the ratio of "
+"the length to volume. Better is to calculate the volume directly through "
+"displacement."
+msgstr ""
+"Enter your filament density here. This is only for statistical information. "
+"A decent way is to weigh a known length of filament and compute the ratio of "
+"the length to volume. Better is to calculate the volume directly through "
+"displacement."
+
+#: xs/src/libslic3r/PrintConfig.cpp:409
+msgid "Cost"
+msgstr "Cost"
+
+#: xs/src/libslic3r/PrintConfig.cpp:410
+msgid ""
+"Enter your filament cost per kg here. This is only for statistical "
+"information."
+msgstr ""
+"Enter your filament cost per kg here. This is only for statistical "
+"information."
+
+# Set this to be the local currency symbol.
+#: xs/src/libslic3r/PrintConfig.cpp:411
+msgid "money/kg"
+msgstr "$/kg"
+
+#: xs/src/libslic3r/PrintConfig.cpp:424
+msgid "Fill angle"
+msgstr "Fill angle"
+
+#: xs/src/libslic3r/PrintConfig.cpp:426
+msgid ""
+"Default base angle for infill orientation. Cross-hatching will be applied to "
+"this. Bridges will be infilled using the best direction Slic3r can detect, "
+"so this setting does not affect them."
+msgstr ""
+"Default base angle for infill orientation. Cross-hatching will be applied to "
+"this. Bridges will be infilled using the best direction Slic3r can detect, "
+"so this setting does not affect them."
+
+#: xs/src/libslic3r/PrintConfig.cpp:436
+msgid "Fill density"
+msgstr "Fill density"
+
+#: xs/src/libslic3r/PrintConfig.cpp:438
+msgid "Density of internal infill, expressed in the range 0% - 100%."
+msgstr "Density of internal infill, expressed in the range 0% - 100%."
+
+#: xs/src/libslic3r/PrintConfig.cpp:474
+msgid "Fill gaps"
+msgstr "Fill gaps"
+
+#: xs/src/libslic3r/PrintConfig.cpp:476
+msgid ""
+"If this is enabled, gaps will be filled with single passes. Enable this for "
+"better quality, disable it for shorter printing times."
+msgstr ""
+"If this is enabled, gaps will be filled with single passes. Enable this for "
+"better quality, disable it for shorter printing times."
+
+#: xs/src/libslic3r/PrintConfig.cpp:481
+msgid "Fill pattern"
+msgstr "Fill pattern"
+
+#: xs/src/libslic3r/PrintConfig.cpp:483
+msgid "Fill pattern for general low-density infill."
+msgstr "Fill pattern for general low-density infill."
+
+#: xs/src/libslic3r/PrintConfig.cpp:513 xs/src/libslic3r/PrintConfig.cpp:522
+#: xs/src/libslic3r/PrintConfig.cpp:530 xs/src/libslic3r/PrintConfig.cpp:561
+msgid "First layer"
+msgstr "First layer"
+
+#: xs/src/libslic3r/PrintConfig.cpp:515
+msgid ""
+"This is the acceleration your printer will use for first layer. Set zero to "
+"disable acceleration control for first layer."
+msgstr ""
+"This is the acceleration your printer will use for first layer. Set zero to "
+"disable acceleration control for first layer."
+
+#: xs/src/libslic3r/PrintConfig.cpp:523
+msgid ""
+"Heated build plate temperature for the first layer. Set this to zero to "
+"disable bed temperature control commands in the output."
+msgstr ""
+"Heated build plate temperature for the first layer. Set this to zero to "
+"disable bed temperature control commands in the output."
+
+#: xs/src/libslic3r/PrintConfig.cpp:533
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for first "
+"layer. You can use this to force fatter extrudates for better adhesion. If "
+"expressed as percentage (for example 120%) it will be computed over first "
+"layer height."
+msgstr ""
+"Set this to a non-zero value to set a manual extrusion width for first "
+"layer. You can use this to force fatter extrudates for better adhesion. If "
+"expressed as percentage (for example 120%) it will be computed over first "
+"layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:543
+msgid "First layer height"
+msgstr "First layer height"
+
+#: xs/src/libslic3r/PrintConfig.cpp:545
+msgid ""
+"When printing with very low layer heights, you might still want to print a "
+"thicker bottom layer to improve adhesion and tolerance for non perfect build "
+"plates. This can be expressed as an absolute value or as a percentage (for "
+"example: 150%) over the default layer height."
+msgstr ""
+"When printing with very low layer heights, you might still want to print a "
+"thicker bottom layer to improve adhesion and tolerance for non perfect build "
+"plates. This can be expressed as an absolute value or as a percentage (for "
+"example: 150%) over the default layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:552
+msgid "First layer speed"
+msgstr "First layer speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:554
+msgid ""
+"If expressed as absolute value in mm/s, this speed will be applied to all "
+"the print moves of the first layer, regardless of their type. If expressed "
+"as a percentage (for example: 40%) it will scale the default speeds."
+msgstr ""
+"If expressed as absolute value in mm/s, this speed will be applied to all "
+"the print moves of the first layer, regardless of their type. If expressed "
+"as a percentage (for example: 40%) it will scale the default speeds."
+
+#: xs/src/libslic3r/PrintConfig.cpp:562
+msgid ""
+"Extruder temperature for first layer. If you want to control temperature "
+"manually during print, set this to zero to disable temperature control "
+"commands in the output file."
+msgstr ""
+"Extruder temperature for first layer. If you want to control temperature "
+"manually during print, set this to zero to disable temperature control "
+"commands in the output file."
+
+#: xs/src/libslic3r/PrintConfig.cpp:573
+msgid "↳ gaps"
+msgstr "↳ gaps"
+
+#: xs/src/libslic3r/PrintConfig.cpp:577
+msgid ""
+"Speed for filling gaps. Since these are usually single lines you might want "
+"to use a low speed for better sticking. If expressed as percentage (for "
+"example: 80%) it will be calculated on the infill speed setting above."
+msgstr ""
+"Speed for filling gaps. Since these are usually single lines you might want "
+"to use a low speed for better sticking. If expressed as percentage (for "
+"example: 80%) it will be calculated on the infill speed setting above."
+
+#: xs/src/libslic3r/PrintConfig.cpp:587
+msgid "Use native G-code arcs"
+msgstr "Use native G-code arcs"
+
+#: xs/src/libslic3r/PrintConfig.cpp:588
+msgid ""
+"This experimental feature tries to detect arcs from segments and generates "
+"G2/G3 arc commands instead of multiple straight G1 commands."
+msgstr ""
+"This experimental feature tries to detect arcs from segments and generates "
+"G2/G3 arc commands instead of multiple straight G1 commands."
+
+#: xs/src/libslic3r/PrintConfig.cpp:593
+msgid "Verbose G-code"
+msgstr "Verbose G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:594
+msgid ""
+"Enable this to get a commented G-code file, with each line explained by a "
+"descriptive text. If you print from SD card, the additional weight of the "
+"file could make your firmware slow down."
+msgstr ""
+"Enable this to get a commented G-code file, with each line explained by a "
+"descriptive text. If you print from SD card, the additional weight of the "
+"file could make your firmware slow down."
+
+#: xs/src/libslic3r/PrintConfig.cpp:599
+msgid "G-code flavor"
+msgstr "G-code flavor"
+
+#: xs/src/libslic3r/PrintConfig.cpp:600
+msgid ""
+"Some G/M-code commands, including temperature control and others, are not "
+"universal. Set this option to your printer's firmware to get a compatible "
+"output. The \"No extrusion\" flavor prevents Slic3r from exporting any "
+"extrusion value at all."
+msgstr ""
+"Some G/M-code commands, including temperature control and others, are not "
+"universal. Set this option to your printer's firmware to get a compatible "
+"output. The \"No extrusion\" flavor prevents Slic3r from exporting any "
+"extrusion value at all."
+
+#: xs/src/libslic3r/PrintConfig.cpp:626
+msgid ""
+"This is the acceleration your printer will use for infill. Set zero to "
+"disable acceleration control for infill."
+msgstr ""
+"This is the acceleration your printer will use for infill. Set zero to "
+"disable acceleration control for infill."
+
+#: xs/src/libslic3r/PrintConfig.cpp:633
+msgid "Combine infill every"
+msgstr "Combine infill every"
+
+#: xs/src/libslic3r/PrintConfig.cpp:635
+msgid ""
+"This feature allows to combine infill and speed up your print by extruding "
+"thicker infill layers while preserving thin perimeters, thus accuracy."
+msgstr ""
+"This feature allows to combine infill and speed up your print by extruding "
+"thicker infill layers while preserving thin perimeters, thus accuracy."
+
+#: xs/src/libslic3r/PrintConfig.cpp:643
+msgid "Infill extruder"
+msgstr "Infill extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:645
+msgid "The extruder to use when printing infill."
+msgstr "The extruder to use when printing infill."
+
+#: xs/src/libslic3r/PrintConfig.cpp:654
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill. You "
+"may want to use fatter extrudates to speed up the infill and make your parts "
+"stronger. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+msgstr ""
+"Set this to a non-zero value to set a manual extrusion width for infill. You "
+"may want to use fatter extrudates to speed up the infill and make your parts "
+"stronger. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:663
+msgid "Infill before perimeters"
+msgstr "Infill before perimeters"
+
+#: xs/src/libslic3r/PrintConfig.cpp:665
+msgid ""
+"This option will switch the print order of perimeters and infill, making the "
+"latter first."
+msgstr ""
+"This option will switch the print order of perimeters and infill, making the "
+"latter first."
+
+#: xs/src/libslic3r/PrintConfig.cpp:670
+msgid "Only infill where needed"
+msgstr "Only infill where needed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:672
+msgid ""
+"This option will limit infill to the areas actually needed for supporting "
+"ceilings (it will act as internal support material). If enabled, slows down "
+"the G-code generation due to the multiple checks involved."
+msgstr ""
+"This option will limit infill to the areas actually needed for supporting "
+"ceilings (it will act as internal support material). If enabled, slows down "
+"the G-code generation due to the multiple checks involved."
+
+#: xs/src/libslic3r/PrintConfig.cpp:677
+msgid "Infill/perimeters overlap"
+msgstr "Infill/perimeters overlap"
+
+#: xs/src/libslic3r/PrintConfig.cpp:679
+msgid ""
+"This setting applies an additional overlap between infill and perimeters for "
+"better bonding. Theoretically this shouldn't be needed, but backlash might "
+"cause gaps. If expressed as percentage (example: 15%) it is calculated over "
+"perimeter extrusion width."
+msgstr ""
+"This setting applies an additional overlap between infill and perimeters for "
+"better bonding. Theoretically this shouldn't be needed, but backlash might "
+"cause gaps. If expressed as percentage (example: 15%) it is calculated over "
+"perimeter extrusion width."
+
+#: xs/src/libslic3r/PrintConfig.cpp:689
+msgid "Speed for printing the internal fill."
+msgstr "Speed for printing the internal fill."
+
+#: xs/src/libslic3r/PrintConfig.cpp:700
+msgid "Interior brim width"
+msgstr "Interior brim width"
+
+#: xs/src/libslic3r/PrintConfig.cpp:702
+msgid ""
+"Horizontal width of the brim that will be printed inside object holes on the "
+"first layer."
+msgstr ""
+"Horizontal width of the brim that will be printed inside object holes on the "
+"first layer."
+
+#: xs/src/libslic3r/PrintConfig.cpp:709
+msgid "Interface shells"
+msgstr "Interface shells"
+
+#: xs/src/libslic3r/PrintConfig.cpp:710
+msgid ""
+"Force the generation of solid shells between adjacent materials/volumes. "
+"Useful for multi-extruder prints with translucent materials or manual "
+"soluble support material."
+msgstr ""
+"Force the generation of solid shells between adjacent materials/volumes. "
+"Useful for multi-extruder prints with translucent materials or manual "
+"soluble support material."
+
+#: xs/src/libslic3r/PrintConfig.cpp:716
+msgid "After layer change G-code"
+msgstr "After layer change G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:717
+msgid ""
+"This custom code is inserted at every layer change, right after the Z move "
+"and before the extruder moves to the first layer point. Note that you can "
+"use placeholder variables for all Slic3r settings as well as [layer_num] and "
+"[layer_z]."
+msgstr ""
+"This custom code is inserted at every layer change, right after the Z move "
+"and before the extruder moves to the first layer point. Note that you can "
+"use placeholder variables for all Slic3r settings as well as [layer_num] and "
+"[layer_z]."
+
+#: xs/src/libslic3r/PrintConfig.cpp:725
+msgid "Layer height"
+msgstr "Layer height"
+
+#: xs/src/libslic3r/PrintConfig.cpp:727
+msgid ""
+"This setting controls the height (and thus the total number) of the slices/"
+"layers. Thinner layers give better accuracy but take more time to print."
+msgstr ""
+"This setting controls the height (and thus the total number) of the slices/"
+"layers. Thinner layers give better accuracy but take more time to print."
+
+#: xs/src/libslic3r/PrintConfig.cpp:734
+msgid "Max"
+msgstr "Max"
+
+#: xs/src/libslic3r/PrintConfig.cpp:735
+msgid "This setting represents the maximum speed of your fan."
+msgstr "This setting represents the maximum speed of your fan."
+
+#: xs/src/libslic3r/PrintConfig.cpp:743
+msgid "Max print speed"
+msgstr "Max print speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:745
+msgid ""
+"When setting other speed settings to 0 Slic3r will autocalculate the optimal "
+"speed in order to keep constant extruder pressure. This experimental setting "
+"is used to set the highest print speed you want to allow."
+msgstr ""
+"When setting other speed settings to 0 Slic3r will autocalculate the optimal "
+"speed in order to keep constant extruder pressure. This experimental setting "
+"is used to set the highest print speed you want to allow."
+
+#: xs/src/libslic3r/PrintConfig.cpp:754
+msgid ""
+"This experimental setting is used to set the maximum volumetric speed your "
+"extruder supports."
+msgstr ""
+"This experimental setting is used to set the maximum volumetric speed your "
+"extruder supports."
+
+#: xs/src/libslic3r/PrintConfig.cpp:761
+msgid "Min"
+msgstr "Min"
+
+#: xs/src/libslic3r/PrintConfig.cpp:762
+msgid "This setting represents the minimum PWM your fan needs to work."
+msgstr "This setting represents the minimum PWM your fan needs to work."
+
+#: xs/src/libslic3r/PrintConfig.cpp:770
+msgid "Min print speed"
+msgstr "Min print speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:771
+msgid "Slic3r will not scale speed down below this speed."
+msgstr "Slic3r will not scale speed down below this speed."
+
+#: xs/src/libslic3r/PrintConfig.cpp:778
+msgid "Minimum extrusion length"
+msgstr "Minimum extrusion length"
+
+#: xs/src/libslic3r/PrintConfig.cpp:780
+msgid ""
+"Generate no less than the number of skirt loops required to consume the "
+"specified amount of filament on the bottom layer. For multi-extruder "
+"machines, this minimum applies to each extruder."
+msgstr ""
+"Generate no less than the number of skirt loops required to consume the "
+"specified amount of filament on the bottom layer. For multi-extruder "
+"machines, this minimum applies to each extruder."
+
+#: xs/src/libslic3r/PrintConfig.cpp:787
+msgid "Configuration notes"
+msgstr "Configuration notes"
+
+#: xs/src/libslic3r/PrintConfig.cpp:788
+msgid ""
+"You can put here your personal notes. This text will be added to the G-code "
+"header comments."
+msgstr ""
+"You can put here your personal notes. This text will be added to the G-code "
+"header comments."
+
+#: xs/src/libslic3r/PrintConfig.cpp:796
+msgid "Nozzle diameter"
+msgstr "Nozzle diameter"
+
+#: xs/src/libslic3r/PrintConfig.cpp:797
+msgid ""
+"This is the diameter of your extruder nozzle (for example: 0.5, 0.35 etc.)"
+msgstr ""
+"This is the diameter of your extruder nozzle (for example: 0.5, 0.35 etc.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:807
+msgid "API Key"
+msgstr "API Key"
+
+#: xs/src/libslic3r/PrintConfig.cpp:808
+msgid ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"API Key required for authentication."
+msgstr ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"API Key required for authentication."
+
+#: xs/src/libslic3r/PrintConfig.cpp:813
+msgid "Host or IP"
+msgstr "Host or IP"
+
+#: xs/src/libslic3r/PrintConfig.cpp:814
+msgid ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"hostname or IP address of the OctoPrint instance."
+msgstr ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"hostname or IP address of the OctoPrint instance."
+
+#: xs/src/libslic3r/PrintConfig.cpp:819
+msgid "Only retract when crossing perimeters"
+msgstr "Only retract when crossing perimeters"
+
+#: xs/src/libslic3r/PrintConfig.cpp:821
+msgid ""
+"Disables retraction when the travel path does not exceed the upper layer's "
+"perimeters (and thus any ooze will be probably invisible)."
+msgstr ""
+"Disables retraction when the travel path does not exceed the upper layer's "
+"perimeters (and thus any ooze will be probably invisible)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:826
+msgid "Enable"
+msgstr "Enable"
+
+#: xs/src/libslic3r/PrintConfig.cpp:829
+msgid ""
+"During multi-extruder prints, this option will drop the temperature of the "
+"inactive extruders to prevent oozing. It will enable a tall skirt "
+"automatically and move extruders outside such skirt when changing "
+"temperatures."
+msgstr ""
+"During multi-extruder prints, this option will drop the temperature of the "
+"inactive extruders to prevent oozing. It will enable a tall skirt "
+"automatically and move extruders outside such skirt when changing "
+"temperatures."
+
+#: xs/src/libslic3r/PrintConfig.cpp:834
+msgid "Output filename format"
+msgstr "Output filename format"
+
+#: xs/src/libslic3r/PrintConfig.cpp:835
+msgid ""
+"You can use all configuration options as variables inside this template. For "
+"example: [layer_height], [fill_density] etc. You can also use [timestamp], "
+"[year], [month], [day], [hour], [minute], [second], [version], "
+"[input_filename], [input_filename_base]."
+msgstr ""
+"You can use all configuration options as variables inside this template. For "
+"example: [layer_height], [fill_density] etc. You can also use [timestamp], "
+"[year], [month], [day], [hour], [minute], [second], [version], "
+"[input_filename], [input_filename_base]."
+
+#: xs/src/libslic3r/PrintConfig.cpp:841
+msgid "Detect bridging perimeters"
+msgstr "Detect bridging perimeters"
+
+#: xs/src/libslic3r/PrintConfig.cpp:843
+msgid ""
+"Experimental option to adjust flow for overhangs (bridge flow will be used), "
+"to apply bridge speed to them and enable fan."
+msgstr ""
+"Experimental option to adjust flow for overhangs (bridge flow will be used), "
+"to apply bridge speed to them and enable fan."
+
+#: xs/src/libslic3r/PrintConfig.cpp:848
+msgid "Overridable options"
+msgstr "Overridable options"
+
+#: xs/src/libslic3r/PrintConfig.cpp:856 xs/src/libslic3r/PrintConfig.cpp:873
+#: xs/src/libslic3r/PrintConfig.cpp:886 xs/src/libslic3r/PrintConfig.cpp:899
+msgid "Perimeters"
+msgstr "Perimeters"
+
+#: xs/src/libslic3r/PrintConfig.cpp:858
+msgid ""
+"This is the acceleration your printer will use for perimeters. A high value "
+"like 9000 usually gives good results if your hardware is up to the job. Set "
+"zero to disable acceleration control for perimeters."
+msgstr ""
+"This is the acceleration your printer will use for perimeters. A high value "
+"like 9000 usually gives good results if your hardware is up to the job. Set "
+"zero to disable acceleration control for perimeters."
+
+#: xs/src/libslic3r/PrintConfig.cpp:864
+msgid "Perimeter extruder"
+msgstr "Perimeter extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:866
+msgid ""
+"The extruder to use when printing perimeters and brim. First extruder is 1."
+msgstr ""
+"The extruder to use when printing perimeters and brim. First extruder is 1."
+
+#: xs/src/libslic3r/PrintConfig.cpp:876
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for perimeters. "
+"You may want to use thinner extrudates to get more accurate surfaces. If "
+"expressed as percentage (for example 200%) it will be computed over layer "
+"height."
+msgstr ""
+"Set this to a non-zero value to set a manual extrusion width for perimeters. "
+"You may want to use thinner extrudates to get more accurate surfaces. If "
+"expressed as percentage (for example 200%) it will be computed over layer "
+"height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:889
+msgid "Speed for perimeters (contours, aka vertical shells)."
+msgstr "Speed for perimeters (contours, aka vertical shells)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:901
+msgid ""
+"This option sets the number of perimeters to generate for each layer. Note "
+"that Slic3r may increase this number automatically when it detects sloping "
+"surfaces which benefit from a higher number of perimeters if the Extra "
+"Perimeters option is enabled."
+msgstr ""
+"This option sets the number of perimeters to generate for each layer. Note "
+"that Slic3r may increase this number automatically when it detects sloping "
+"surfaces which benefit from a higher number of perimeters if the Extra "
+"Perimeters option is enabled."
+
+#: xs/src/libslic3r/PrintConfig.cpp:909
+msgid "Post-processing scripts"
+msgstr "Post-processing scripts"
+
+#: xs/src/libslic3r/PrintConfig.cpp:910
+msgid ""
+"If you want to process the output G-code through custom scripts, just list "
+"their absolute paths here. Separate multiple scripts on individual lines. "
+"Scripts will be passed the absolute path to the G-code file as the first "
+"argument, and they can access the Slic3r config settings by reading "
+"environment variables."
+msgstr ""
+"If you want to process the output G-code through custom scripts, just list "
+"their absolute paths here. Separate multiple scripts on individual lines. "
+"Scripts will be passed the absolute path to the G-code file as the first "
+"argument, and they can access the Slic3r config settings by reading "
+"environment variables."
+
+#: xs/src/libslic3r/PrintConfig.cpp:924
+msgid "Pressure advance"
+msgstr "Pressure advance"
+
+#: xs/src/libslic3r/PrintConfig.cpp:926
+msgid ""
+"When set to a non-zero value, this experimental option enables pressure "
+"regulation. It's the K constant for the advance algorithm that pushes more "
+"or less filament upon speed changes. It's useful for Bowden-tube extruders. "
+"Reasonable values are in range 0-10."
+msgstr ""
+"When set to a non-zero value, this experimental option enables pressure "
+"regulation. It's the K constant for the advance algorithm that pushes more "
+"or less filament upon speed changes. It's useful for Bowden-tube extruders. "
+"Reasonable values are in range 0-10."
+
+#: xs/src/libslic3r/PrintConfig.cpp:932
+msgid "Raft layers"
+msgstr "Raft layers"
+
+#: xs/src/libslic3r/PrintConfig.cpp:934
+msgid ""
+"The object will be raised by this number of layers, and support material "
+"will be generated under it."
+msgstr ""
+"The object will be raised by this number of layers, and support material "
+"will be generated under it."
+
+#: xs/src/libslic3r/PrintConfig.cpp:941
+msgid "Raft offset"
+msgstr "Raft offset"
+
+#: xs/src/libslic3r/PrintConfig.cpp:943
+msgid "Horizontal margin between object base layer and raft contour."
+msgstr "Horizontal margin between object base layer and raft contour."
+
+#: xs/src/libslic3r/PrintConfig.cpp:950
+msgid "Resolution (deprecated)"
+msgstr "Resolution (deprecated)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:951
+msgid ""
+"Minimum detail resolution, used to simplify the input file for speeding up "
+"the slicing job and reducing memory usage. High-resolution models often "
+"carry more detail than printers can render. Set to zero to disable any "
+"simplification and use full resolution from input."
+msgstr ""
+"Minimum detail resolution, used to simplify the input file for speeding up "
+"the slicing job and reducing memory usage. High-resolution models often "
+"carry more detail than printers can render. Set to zero to disable any "
+"simplification and use full resolution from input."
+
+#: xs/src/libslic3r/PrintConfig.cpp:958
+msgid "Minimum travel after retraction"
+msgstr "Minimum travel after retraction"
+
+#: xs/src/libslic3r/PrintConfig.cpp:959 xs/src/libslic3r/PrintConfig.cpp:971
+#: xs/src/libslic3r/PrintConfig.cpp:982 xs/src/libslic3r/PrintConfig.cpp:1007
+#: xs/src/libslic3r/PrintConfig.cpp:1020 xs/src/libslic3r/PrintConfig.cpp:1033
+#: xs/src/libslic3r/PrintConfig.cpp:1045 xs/src/libslic3r/PrintConfig.cpp:1068
+#: xs/src/libslic3r/PrintConfig.cpp:1548
+msgid "Retraction"
+msgstr "Retraction"
+
+#: xs/src/libslic3r/PrintConfig.cpp:960
+msgid ""
+"Retraction is not triggered when travel moves are shorter than this length."
+msgstr ""
+"Retraction is not triggered when travel moves are shorter than this length."
+
+#: xs/src/libslic3r/PrintConfig.cpp:970
+msgid "Retract on layer change"
+msgstr "Retract on layer change"
+
+#: xs/src/libslic3r/PrintConfig.cpp:972
+msgid "This flag enforces a retraction whenever a Z move is done."
+msgstr "This flag enforces a retraction whenever a Z move is done."
+
+#: xs/src/libslic3r/PrintConfig.cpp:981 xs/src/libslic3r/PrintConfig.cpp:994
+msgid "Length"
+msgstr "Length"
+
+#: xs/src/libslic3r/PrintConfig.cpp:984
+msgid ""
+"When retraction is triggered, filament is pulled back by the specified "
+"amount (the length is measured on raw filament, before it enters the "
+"extruder)."
+msgstr ""
+"When retraction is triggered, filament is pulled back by the specified "
+"amount (the length is measured on raw filament, before it enters the "
+"extruder)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:996
+msgid ""
+"When retraction is triggered before changing tool, filament is pulled back "
+"by the specified amount (the length is measured on raw filament, before it "
+"enters the extruder)."
+msgstr ""
+"When retraction is triggered before changing tool, filament is pulled back "
+"by the specified amount (the length is measured on raw filament, before it "
+"enters the extruder)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1006
+msgid "Lift Z"
+msgstr "Lift Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1008
+msgid ""
+"If you set this to a positive value, Z is quickly raised every time a "
+"retraction is triggered. When using multiple extruders, only the setting for "
+"the first extruder will be considered."
+msgstr ""
+"If you set this to a positive value, Z is quickly raised every time a "
+"retraction is triggered. When using multiple extruders, only the setting for "
+"the first extruder will be considered."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1018
+msgid "Above Z"
+msgstr "Above Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1021
+msgid ""
+"If you set this to a positive value, Z lift will only take place above the "
+"specified absolute Z. You can tune this setting for skipping lift on the "
+"first layers."
+msgstr ""
+"If you set this to a positive value, Z lift will only take place above the "
+"specified absolute Z. You can tune this setting for skipping lift on the "
+"first layers."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1031
+msgid "Below Z"
+msgstr "Below Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1034
+msgid ""
+"If you set this to a positive value, Z lift will only take place below the "
+"specified absolute Z. You can tune this setting for limiting lift to the "
+"first layers."
+msgstr ""
+"If you set this to a positive value, Z lift will only take place below the "
+"specified absolute Z. You can tune this setting for limiting lift to the "
+"first layers."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1044 xs/src/libslic3r/PrintConfig.cpp:1056
+msgid "Extra length on restart"
+msgstr "Extra length on restart"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1046
+msgid ""
+"When the retraction is compensated after the travel move, the extruder will "
+"push this additional amount of filament. This setting is rarely needed."
+msgstr ""
+"When the retraction is compensated after the travel move, the extruder will "
+"push this additional amount of filament. This setting is rarely needed."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1057
+msgid ""
+"When the retraction is compensated after changing tool, the extruder will "
+"push this additional amount of filament."
+msgstr ""
+"When the retraction is compensated after changing tool, the extruder will "
+"push this additional amount of filament."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1069
+msgid ""
+"The speed for retractions (it only applies to the extruder motor). If you "
+"use the Firmware Retraction option, please note this value still affects the "
+"auto-speed pressure regulator."
+msgstr ""
+"The speed for retractions (it only applies to the extruder motor). If you "
+"use the Firmware Retraction option, please note this value still affects the "
+"auto-speed pressure regulator."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1079
+msgid "Seam position"
+msgstr "Seam position"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1081
+msgid "Position of perimeters starting points."
+msgstr "Position of perimeters starting points."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1098
+msgid "USB/serial port for printer connection."
+msgstr "USB/serial port for printer connection."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1107
+msgid "Speed (baud) of USB/serial port for printer connection."
+msgstr "Speed (baud) of USB/serial port for printer connection."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1117
+msgid "Distance from object"
+msgstr "Distance from object"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1119
+msgid ""
+"Distance between skirt and object(s). Set this to zero to attach the skirt "
+"to the object(s) and get a brim for better adhesion."
+msgstr ""
+"Distance between skirt and object(s). Set this to zero to attach the skirt "
+"to the object(s) and get a brim for better adhesion."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1126
+msgid "Skirt height"
+msgstr "Skirt height"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1128
+msgid ""
+"Height of skirt expressed in layers. Set this to a tall value to use skirt "
+"as a shield against drafts."
+msgstr ""
+"Height of skirt expressed in layers. Set this to a tall value to use skirt "
+"as a shield against drafts."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1134
+msgid "Loops (minimum)"
+msgstr "Loops (minimum)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1137
+msgid ""
+"Number of loops for the skirt. If the Minimum Extrusion Length option is "
+"set, the number of loops might be greater than the one configured here. Set "
+"this to zero to disable skirt completely."
+msgstr ""
+"Number of loops for the skirt. If the Minimum Extrusion Length option is "
+"set, the number of loops might be greater than the one configured here. Set "
+"this to zero to disable skirt completely."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1143
+msgid "Slow down if layer print time is below"
+msgstr "Slow down if layer print time is below"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1144
+msgid ""
+"If layer print time is estimated below this number of seconds, print moves "
+"speed will be scaled down to extend duration to this value."
+msgstr ""
+"If layer print time is estimated below this number of seconds, print moves "
+"speed will be scaled down to extend duration to this value."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1153
+msgid "↳ small"
+msgstr "↳ small"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1157
+msgid ""
+"This separate setting will affect the speed of perimeters having radius <= "
+"6.5mm (usually holes). If expressed as percentage (for example: 80%) it will "
+"be calculated on the perimeters speed setting above."
+msgstr ""
+"This separate setting will affect the speed of perimeters having radius <= "
+"6.5mm (usually holes). If expressed as percentage (for example: 80%) it will "
+"be calculated on the perimeters speed setting above."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1167
+msgid "Solid infill threshold area"
+msgstr "Solid infill threshold area"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1169
+msgid ""
+"Force solid infill for regions having a smaller area than the specified "
+"threshold."
+msgstr ""
+"Force solid infill for regions having a smaller area than the specified "
+"threshold."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1176
+msgid "Solid infill extruder"
+msgstr "Solid infill extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1178
+msgid "The extruder to use when printing solid infill."
+msgstr "The extruder to use when printing solid infill."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1184
+msgid "Solid infill every"
+msgstr "Solid infill every"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1186
+msgid ""
+"This feature allows to force a solid layer every given number of layers. "
+"Zero to disable. You can set this to any value (for example 9999); Slic3r "
+"will automatically choose the maximum possible number of layers to combine "
+"according to nozzle diameter and layer height."
+msgstr ""
+"This feature allows to force a solid layer every given number of layers. "
+"Zero to disable. You can set this to any value (for example 9999); Slic3r "
+"will automatically choose the maximum possible number of layers to combine "
+"according to nozzle diameter and layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1193 xs/src/libslic3r/PrintConfig.cpp:1206
+msgid "↳ solid"
+msgstr "↳ solid"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1197
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"solid surfaces. If expressed as percentage (for example 90%) it will be "
+"computed over layer height."
+msgstr ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"solid surfaces. If expressed as percentage (for example 90%) it will be "
+"computed over layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1210
+msgid ""
+"Speed for printing solid regions (top/bottom/internal horizontal shells). "
+"This can be expressed as a percentage (for example: 80%) over the default "
+"infill speed above."
+msgstr ""
+"Speed for printing solid regions (top/bottom/internal horizontal shells). "
+"This can be expressed as a percentage (for example: 80%) over the default "
+"infill speed above."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1221
+msgid "Solid layers"
+msgstr "Solid layers"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1222
+msgid "Number of solid layers to generate on top and bottom surfaces."
+msgstr "Number of solid layers to generate on top and bottom surfaces."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1229
+msgid "Spiral vase"
+msgstr "Spiral vase"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1231
+msgid ""
+"This feature will raise Z gradually while printing a single-walled object in "
+"order to remove any visible seam. This option requires a single perimeter, "
+"no infill, no top solid layers and no support material. You can still set "
+"any number of bottom solid layers as well as skirt/brim loops. It won't work "
+"when printing more than an object."
+msgstr ""
+"This feature will raise Z gradually while printing a single-walled object in "
+"order to remove any visible seam. This option requires a single perimeter, "
+"no infill, no top solid layers and no support material. You can still set "
+"any number of bottom solid layers as well as skirt/brim loops. It won't work "
+"when printing more than an object."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1236
+msgid "Temperature variation"
+msgstr "Temperature variation"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1239
+msgid ""
+"Temperature difference to be applied when an extruder is not active.  "
+"Enables a full-height \"sacrificial\" skirt on which the nozzles are "
+"periodically wiped."
+msgstr ""
+"Temperature difference to be applied when an extruder is not active.  "
+"Enables a full-height \"sacrificial\" skirt on which the nozzles are "
+"periodically wiped."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1247 xs/src/libslic3r/PrintConfig.cpp:1256
+msgid "Start G-code"
+msgstr "Start G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1248
+msgid ""
+"This start procedure is inserted at the beginning, after bed has reached the "
+"target temperature and extruder just started heating, and before extruder "
+"has finished heating. If Slic3r detects M104, M109, M140 or M190 in your "
+"custom codes, such commands will not be prepended automatically so you're "
+"free to customize the order of heating commands and other custom actions. "
+"Note that you can use placeholder variables for all Slic3r settings, so you "
+"can put a \"M109 S[first_layer_temperature]\" command wherever you want."
+msgstr ""
+"This start procedure is inserted at the beginning, after bed has reached the "
+"target temperature and extruder just started heating, and before extruder "
+"has finished heating. If Slic3r detects M104, M109, M140 or M190 in your "
+"custom codes, such commands will not be prepended automatically so you're "
+"free to customize the order of heating commands and other custom actions. "
+"Note that you can use placeholder variables for all Slic3r settings, so you "
+"can put a \"M109 S[first_layer_temperature]\" command wherever you want."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1257
+msgid ""
+"This start procedure is inserted at the beginning, after any printer start "
+"gcode. This is used to override settings for a specific filament. If Slic3r "
+"detects M104, M109, M140 or M190 in your custom codes, such commands will "
+"not be prepended automatically so you're free to customize the order of "
+"heating commands and other custom actions. Note that you can use placeholder "
+"variables for all Slic3r settings, so you can put a \"M109 "
+"S[first_layer_temperature]\" command wherever you want. If you have multiple "
+"extruders, the gcode is processed in extruder order."
+msgstr ""
+"This start procedure is inserted at the beginning, after any printer start "
+"gcode. This is used to override settings for a specific filament. If Slic3r "
+"detects M104, M109, M140 or M190 in your custom codes, such commands will "
+"not be prepended automatically so you're free to customize the order of "
+"heating commands and other custom actions. Note that you can use placeholder "
+"variables for all Slic3r settings, so you can put a \"M109 "
+"S[first_layer_temperature]\" command wherever you want. If you have multiple "
+"extruders, the gcode is processed in extruder order."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1269
+msgid "Generate support material"
+msgstr "Generate support material"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1271
+msgid "Enable support material generation."
+msgstr "Enable support material generation."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1276
+msgid "Pattern angle"
+msgstr "Pattern angle"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1278
+msgid ""
+"Use this setting to rotate the support material pattern on the horizontal "
+"plane."
+msgstr ""
+"Use this setting to rotate the support material pattern on the horizontal "
+"plane."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1286
+msgid "Support on build plate only"
+msgstr "Support on build plate only"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1288
+msgid ""
+"Only create support if it lies on a build plate. Don't create support on a "
+"print."
+msgstr ""
+"Only create support if it lies on a build plate. Don't create support on a "
+"print."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1294
+msgid "Contact Z distance"
+msgstr "Contact Z distance"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1296
+msgid ""
+"The vertical distance between object and support material interface. Setting "
+"this to 0 will also prevent Slic3r from using bridge flow and speed for the "
+"first object layer."
+msgstr ""
+"The vertical distance between object and support material interface. Setting "
+"this to 0 will also prevent Slic3r from using bridge flow and speed for the "
+"first object layer."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1307
+msgid "Enforce support for the first"
+msgstr "Enforce support for the first"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1309
+msgid ""
+"Generate support material for the specified number of layers counting from "
+"bottom, regardless of whether normal support material is enabled or not and "
+"regardless of any angle threshold. This is useful for getting more adhesion "
+"of objects having a very thin or poor footprint on the build plate."
+msgstr ""
+"Generate support material for the specified number of layers counting from "
+"bottom, regardless of whether normal support material is enabled or not and "
+"regardless of any angle threshold. This is useful for getting more adhesion "
+"of objects having a very thin or poor footprint on the build plate."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1317
+msgid "Support material/raft/skirt extruder"
+msgstr "Support material/raft/skirt extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1319
+msgid "The extruder to use when printing support material, raft and skirt."
+msgstr "The extruder to use when printing support material, raft and skirt."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1328
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for support "
+"material. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+msgstr ""
+"Set this to a non-zero value to set a manual extrusion width for support "
+"material. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1337
+msgid "Support material/raft interface extruder"
+msgstr "Support material/raft interface extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1339
+msgid ""
+"The extruder to use when printing support material interface. This affects "
+"raft too."
+msgstr ""
+"The extruder to use when printing support material interface. This affects "
+"raft too."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1345
+msgid "Interface layers"
+msgstr "Interface layers"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1347
+msgid ""
+"Number of interface layers to insert between the object(s) and support "
+"material."
+msgstr ""
+"Number of interface layers to insert between the object(s) and support "
+"material."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1354
+msgid "Interface pattern spacing"
+msgstr "Interface pattern spacing"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1356
+msgid "Spacing between interface lines. Set zero to get a solid interface."
+msgstr "Spacing between interface lines. Set zero to get a solid interface."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1363
+msgid "↳ interface"
+msgstr "↳ interface"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1364
+msgid "Interface Speed"
+msgstr "Interface Speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1365
+msgid "Support material interface speed"
+msgstr "Support material interface speed"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1368
+msgid ""
+"Speed for printing support material interface layers. If expressed as "
+"percentage (for example 50%) it will be calculated over support material "
+"speed."
+msgstr ""
+"Speed for printing support material interface layers. If expressed as "
+"percentage (for example 50%) it will be calculated over support material "
+"speed."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1378
+msgid "Pattern"
+msgstr "Pattern"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1380
+msgid "Pattern used to generate support material."
+msgstr "Pattern used to generate support material."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1394
+msgid "Pattern spacing"
+msgstr "Pattern spacing"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1396
+msgid "Spacing between support material lines."
+msgstr "Spacing between support material lines."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1409
+msgid "Speed for printing support material."
+msgstr "Speed for printing support material."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1418
+msgid "Overhang threshold"
+msgstr "Overhang threshold"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1420
+#, c-format
+msgid ""
+"Support material will not be generated for overhangs whose slope angle (90° "
+"= vertical) is above the given threshold. In other words, this value "
+"represent the most horizontal slope (measured from the horizontal plane) "
+"that you can print without support material. Set to a percentage to "
+"automatically detect based on some % of overhanging perimeter width instead "
+"(recommended)."
+msgstr ""
+"Support material will not be generated for overhangs whose slope angle (90° "
+"= vertical) is above the given threshold. In other words, this value "
+"represent the most horizontal slope (measured from the horizontal plane) "
+"that you can print without support material. Set to a percentage to "
+"automatically detect based on some % of overhanging perimeter width instead "
+"(recommended)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1429
+msgid ""
+"Extruder temperature for layers after the first one. Set this to zero to "
+"disable temperature control commands in the output."
+msgstr ""
+"Extruder temperature for layers after the first one. Set this to zero to "
+"disable temperature control commands in the output."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1441
+msgid "Detect thin walls"
+msgstr "Detect thin walls"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1443
+msgid ""
+"Detect single-width walls (parts where two extrusions don't fit and we need "
+"to collapse them into a single trace)."
+msgstr ""
+"Detect single-width walls (parts where two extrusions don't fit and we need "
+"to collapse them into a single trace)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1448
+msgid "Threads"
+msgstr "Threads"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1449
+msgid ""
+"Threads are used to parallelize long-running tasks. Optimal threads number "
+"is slightly above the number of available cores/processors."
+msgstr ""
+"Threads are used to parallelize long-running tasks. Optimal threads number "
+"is slightly above the number of available cores/processors."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1458
+msgid "Tool change G-code"
+msgstr "Tool change G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1459
+msgid ""
+"This custom code is inserted right before every extruder change. Note that "
+"you can use placeholder variables for all Slic3r settings as well as "
+"[previous_extruder] and [next_extruder]."
+msgstr ""
+"This custom code is inserted right before every extruder change. Note that "
+"you can use placeholder variables for all Slic3r settings as well as "
+"[previous_extruder] and [next_extruder]."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1467 xs/src/libslic3r/PrintConfig.cpp:1488
+msgid "↳ top solid"
+msgstr "↳ top solid"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1471
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"top surfaces. You may want to use thinner extrudates to fill all narrow "
+"regions and get a smoother finish. If expressed as percentage (for example "
+"90%) it will be computed over layer height."
+msgstr ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"top surfaces. You may want to use thinner extrudates to fill all narrow "
+"regions and get a smoother finish. If expressed as percentage (for example "
+"90%) it will be computed over layer height."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1480 xs/src/libslic3r/PrintConfig.cpp:1502
+msgid "Top"
+msgstr "Top"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1483
+msgid ""
+"Infill pattern for top layers. This only affects the external visible layer, "
+"and not its adjacent solid shells."
+msgstr ""
+"Infill pattern for top layers. This only affects the external visible layer, "
+"and not its adjacent solid shells."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1492
+msgid ""
+"Speed for printing top solid layers (it only applies to the uppermost "
+"external layers and not to their internal solid layers). You may want to "
+"slow down this to get a nicer surface finish. This can be expressed as a "
+"percentage (for example: 80%) over the solid infill speed above."
+msgstr ""
+"Speed for printing top solid layers (it only applies to the uppermost "
+"external layers and not to their internal solid layers). You may want to "
+"slow down this to get a nicer surface finish. This can be expressed as a "
+"percentage (for example: 80%) over the solid infill speed above."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1504
+msgid "Number of solid layers to generate on top surfaces."
+msgstr "Number of solid layers to generate on top surfaces."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1511
+msgid "Travel"
+msgstr "Travel"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1513
+msgid "Speed for travel moves (jumps between distant extrusion points)."
+msgstr "Speed for travel moves (jumps between distant extrusion points)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1521
+msgid "Use firmware retraction"
+msgstr "Use firmware retraction"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1522
+msgid ""
+"This experimental setting uses G10 and G11 commands to have the firmware "
+"handle the retraction. This is only supported in recent Marlin."
+msgstr ""
+"This experimental setting uses G10 and G11 commands to have the firmware "
+"handle the retraction. This is only supported in recent Marlin."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1527
+msgid "Use relative E distances"
+msgstr "Use relative E distances"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1528
+msgid ""
+"If your firmware requires relative E values, check this, otherwise leave it "
+"unchecked. Most firmwares use absolute values."
+msgstr ""
+"If your firmware requires relative E values, check this, otherwise leave it "
+"unchecked. Most firmwares use absolute values."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1533
+msgid "Use volumetric E"
+msgstr "Use volumetric E"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1534
+msgid ""
+"This experimental setting uses outputs the E values in cubic millimeters "
+"instead of linear millimeters. If your firmware doesn't already know "
+"filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] "
+"T0' in your start G-code in order to turn volumetric mode on and use the "
+"filament diameter associated to the filament selected in Slic3r. This is "
+"only supported in recent Marlin."
+msgstr ""
+"This experimental setting uses outputs the E values in cubic millimeters "
+"instead of linear millimeters. If your firmware doesn't already know "
+"filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] "
+"T0' in your start G-code in order to turn volumetric mode on and use the "
+"filament diameter associated to the filament selected in Slic3r. This is "
+"only supported in recent Marlin."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1539
+msgid "Vibration limit (deprecated)"
+msgstr "Vibration limit (deprecated)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1540
+msgid ""
+"This experimental option will slow down those moves hitting the configured "
+"frequency limit. The purpose of limiting vibrations is to avoid mechanical "
+"resonance. Set zero to disable."
+msgstr ""
+"This experimental option will slow down those moves hitting the configured "
+"frequency limit. The purpose of limiting vibrations is to avoid mechanical "
+"resonance. Set zero to disable."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1547
+msgid "Wipe while retracting"
+msgstr "Wipe while retracting"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1549
+msgid ""
+"This flag will move the nozzle while retracting to minimize the possible "
+"blob on leaky extruders."
+msgstr ""
+"This flag will move the nozzle while retracting to minimize the possible "
+"blob on leaky extruders."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1558
+msgid "XY Size Compensation"
+msgstr "XY Size Compensation"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1560
+msgid ""
+"The object will be grown/shrunk in the XY plane by the configured value "
+"(negative = inwards, positive = outwards). This might be useful for fine-"
+"tuning hole sizes."
+msgstr ""
+"The object will be grown/shrunk in the XY plane by the configured value "
+"(negative = inwards, positive = outwards). This might be useful for fine-"
+"tuning hole sizes."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1566
+msgid "Z offset"
+msgstr "Z offset"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1567
+msgid ""
+"This value will be added (or subtracted) from all the Z coordinates in the "
+"output G-code. It is used to compensate for bad Z endstop position: for "
+"example, if your endstop zero actually leaves the nozzle 0.3mm far from the "
+"print bed, set this to -0.3 (or fix your endstop)."
+msgstr ""
+"This value will be added (or subtracted) from all the Z coordinates in the "
+"output G-code. It is used to compensate for bad Z endstop position: for "
+"example, if your endstop zero actually leaves the nozzle 0.3mm far from the "
+"print bed, set this to -0.3 (or fix your endstop)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1573
+msgid "Z full steps/mm"
+msgstr "Z full steps/mm"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1574
+msgid ""
+"Set this to the number of *full* steps (not microsteps) needed for moving "
+"the Z axis by 1mm; you can calculate this by dividing the number of "
+"microsteps configured in your firmware by the microstepping amount (8, 16, "
+"32). Slic3r will round your configured layer height to the nearest multiple "
+"of that value in order to ensure the best accuracy. This is most useful for "
+"machines with imperial leadscrews or belt-driven Z or for unusual layer "
+"heights with metric leadscrews. Set to zero to disable this experimental "
+"feature."
+msgstr ""
+"Set this to the number of *full* steps (not microsteps) needed for moving "
+"the Z axis by 1mm; you can calculate this by dividing the number of "
+"microsteps configured in your firmware by the microstepping amount (8, 16, "
+"32). Slic3r will round your configured layer height to the nearest multiple "
+"of that value in order to ensure the best accuracy. This is most useful for "
+"machines with imperial leadscrews or belt-driven Z or for unusual layer "
+"heights with metric leadscrews. Set to zero to disable this experimental "
+"feature."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1716 xs/src/libslic3r/PrintConfig.cpp:1722
+#: xs/src/libslic3r/PrintConfig.cpp:1728 xs/src/libslic3r/PrintConfig.cpp:1734
+msgid "Cut"
+msgstr "Cut"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1717
+msgid "Cut model at the given Z."
+msgstr "Cut model at the given Z."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1723
+msgid "Cut model in the XY plane into tiles of the specified max size."
+msgstr "Cut model in the XY plane into tiles of the specified max size."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1729
+msgid "Cut model at the given X."
+msgstr "Cut model at the given X."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1735
+msgid "Cut model at the given Y."
+msgstr "Cut model at the given Y."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1740 xs/src/libslic3r/PrintConfig.cpp:1752
+msgid "Export SVG"
+msgstr "Export SVG"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1741
+msgid "Export the model as OBJ."
+msgstr "Export the model as OBJ."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1746
+msgid "Export POV"
+msgstr "Export POV"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1747
+msgid "Export the model as POV-Ray definition."
+msgstr "Export the model as POV-Ray definition."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1753
+msgid "Slice the model and export slices as SVG."
+msgstr "Slice the model and export slices as SVG."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1758
+msgid "Output Model Info"
+msgstr "Output Model Info"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1759
+msgid "Write information about the model to the console."
+msgstr "Write information about the model to the console."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1764
+msgid "Load config file"
+msgstr "Load config file"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1765
+msgid ""
+"Load configuration from the specified file. It can be used more than once to "
+"load options from multiple files."
+msgstr ""
+"Load configuration from the specified file. It can be used more than once to "
+"load options from multiple files."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1770
+msgid "Output File"
+msgstr "Output File"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1771
+msgid ""
+"The file where the output will be written (if not specified, it will be "
+"based on the input file)."
+msgstr ""
+"The file where the output will be written (if not specified, it will be "
+"based on the input file)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1776
+msgid "Rotate"
+msgstr "Rotate"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1777
+msgid "Rotation angle around the Z axis in degrees (0-360, default: 0)."
+msgstr "Rotation angle around the Z axis in degrees (0-360, default: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1782
+msgid "Rotate around X"
+msgstr "Rotate around X"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1783
+msgid "Rotation angle around the X axis in degrees (0-360, default: 0)."
+msgstr "Rotation angle around the X axis in degrees (0-360, default: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1788
+msgid "Rotate around Y"
+msgstr "Rotate around Y"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1789
+msgid "Rotation angle around the Y axis in degrees (0-360, default: 0)."
+msgstr "Rotation angle around the Y axis in degrees (0-360, default: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1794
+msgid "Save config file"
+msgstr "Save config file"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1795
+msgid "Save configuration to the specified file."
+msgstr "Save configuration to the specified file."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1800
+msgid "Scale"
+msgstr "Scale"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1801
+msgid "Scaling factor (default: 1)."
+msgstr "Scaling factor (default: 1)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1806
+msgid "Scale to Fit"
+msgstr "Scale to Fit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1807
+msgid "Scale to fit the given volume."
+msgstr "Scale to fit the given volume."

--- a/translation/fr_FR.po
+++ b/translation/fr_FR.po
@@ -290,11 +290,11 @@ msgstr "Désactiver le ventilateur pour le(s) premier(s)"
 
 #: xs/src/libslic3r/PrintConfig.cpp:169
 msgid ""
-"You can set this to a positive value to disable fan at all during the first "
-"layers, so that it does not make adhesion worse."
+"This disables the fan completely for the first N layers "
+"to aid in the adhesion of media to the bed. (default 3)"
 msgstr ""
-"Vous pouvez mettre une valeur positive pour désactiver le ventilateur durant "
-"les premières couches, pour ne pas empirer les problèmes d'adhésion."
+"Cela désactive complètement le ventilateur pour les premières N couches "
+"Pour aider à l'adhésion des médias au lit. (par défaut 3)"
 
 #: xs/src/libslic3r/PrintConfig.cpp:170
 msgid "layers"

--- a/translation/fr_FR.po
+++ b/translation/fr_FR.po
@@ -1,0 +1,2148 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Slic3r\n"
+"POT-Creation-Date: 2017-03-29 00:02-0600\n"
+"PO-Revision-Date: 2017-04-01 23:32+0200\n"
+"Last-Translator: \n"
+"Language-Team: Joseph Lenox <lenox.joseph@gmail.com>\n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"X-Poedit-Basepath: ..\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __TRANS;__\n"
+"X-Poedit-SearchPath-0: xs/src/libslic3r\n"
+"X-Poedit-SearchPath-1: xs/xrc/slic3r/GUI\n"
+"X-Poedit-SearchPath-2: xs/xrc/slic3r\n"
+
+#: xs/src/libslic3r/PrintConfig.cpp:18
+msgid "Rectilinear"
+msgstr "Rectilinéaire"
+
+#: xs/src/libslic3r/PrintConfig.cpp:19
+msgid "Concentric"
+msgstr "Concentrique"
+
+#: xs/src/libslic3r/PrintConfig.cpp:20
+msgid "Hilbert Curve"
+msgstr "Courbe d'Hilbert"
+
+#: xs/src/libslic3r/PrintConfig.cpp:21
+msgid "Archimedean Chords"
+msgstr "Cordes d'Archimède"
+
+#: xs/src/libslic3r/PrintConfig.cpp:22
+msgid "Octagram Spiral"
+msgstr "Octagram Spiral"
+
+#: xs/src/libslic3r/PrintConfig.cpp:27
+msgid "Avoid crossing perimeters"
+msgstr "Eviter de croiser les périmètres"
+
+#: xs/src/libslic3r/PrintConfig.cpp:28 xs/src/libslic3r/PrintConfig.cpp:77
+#: xs/src/libslic3r/PrintConfig.cpp:252 xs/src/libslic3r/PrintConfig.cpp:259
+#: xs/src/libslic3r/PrintConfig.cpp:544 xs/src/libslic3r/PrintConfig.cpp:712
+#: xs/src/libslic3r/PrintConfig.cpp:726 xs/src/libslic3r/PrintConfig.cpp:820
+#: xs/src/libslic3r/PrintConfig.cpp:842 xs/src/libslic3r/PrintConfig.cpp:900
+#: xs/src/libslic3r/PrintConfig.cpp:1080 xs/src/libslic3r/PrintConfig.cpp:1230
+#: xs/src/libslic3r/PrintConfig.cpp:1442 xs/src/libslic3r/PrintConfig.cpp:1503
+msgid "Layers and Perimeters"
+msgstr "Couches et périmètres"
+
+#: xs/src/libslic3r/PrintConfig.cpp:29
+msgid ""
+"Optimize travel moves in order to minimize the crossing of perimeters. This "
+"is mostly useful with Bowden extruders which suffer from oozing. This "
+"feature slows down both the print and the G-code generation."
+msgstr ""
+"Optimise les déplacements afin de minimiser le franchissement des "
+"périmètres. Surtout utile avec les extruder Bowden qui sont sensible au "
+"Oozing. Cette fonctionnalité ralenti l'impression et la génération du G-Code."
+
+#: xs/src/libslic3r/PrintConfig.cpp:34
+msgid "Bed shape"
+msgstr "Forme du plateau"
+
+#: xs/src/libslic3r/PrintConfig.cpp:44
+msgid "Has heated bed"
+msgstr "Plateau chauffant"
+
+#: xs/src/libslic3r/PrintConfig.cpp:45
+msgid ""
+"Unselecting this will suppress automatic generation of bed heating gcode."
+msgstr ""
+"Désélectionner cette option supprimera le G-Code gérant le plateau chauffant."
+
+#: xs/src/libslic3r/PrintConfig.cpp:50 xs/src/libslic3r/PrintConfig.cpp:1428
+msgid "Other layers"
+msgstr "Autres couches"
+
+#: xs/src/libslic3r/PrintConfig.cpp:51
+msgid "Bed temperature for layers after the first one."
+msgstr "Température du plateau pour les couches suivant la première."
+
+#: xs/src/libslic3r/PrintConfig.cpp:53
+msgid "Bed temperature"
+msgstr "Température plateau"
+
+#: xs/src/libslic3r/PrintConfig.cpp:59
+msgid "Before layer change G-code"
+msgstr "G-Code avant changement de couche"
+
+#: xs/src/libslic3r/PrintConfig.cpp:60
+msgid ""
+"This custom code is inserted at every layer change, right before the Z move. "
+"Note that you can use placeholder variables for all Slic3r settings as well "
+"as [layer_num] and [layer_z]."
+msgstr ""
+"Ce code personnalisé sera inséré à chaque changement de couche, juste avant "
+"le mouvement en Z. Noter que vous pouvez utiliser des variables pour tous "
+"les réglages de Slic3r ainsi que [layer_num] et [layer_z]."
+
+#: xs/src/libslic3r/PrintConfig.cpp:68 xs/src/libslic3r/PrintConfig.cpp:76
+msgid "Bottom"
+msgstr "Inférieur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:69
+msgid "Bottom infill pattern"
+msgstr "Motif de remplissage inférieur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:70 xs/src/libslic3r/PrintConfig.cpp:216
+#: xs/src/libslic3r/PrintConfig.cpp:425 xs/src/libslic3r/PrintConfig.cpp:437
+#: xs/src/libslic3r/PrintConfig.cpp:475 xs/src/libslic3r/PrintConfig.cpp:482
+#: xs/src/libslic3r/PrintConfig.cpp:624 xs/src/libslic3r/PrintConfig.cpp:634
+#: xs/src/libslic3r/PrintConfig.cpp:651 xs/src/libslic3r/PrintConfig.cpp:664
+#: xs/src/libslic3r/PrintConfig.cpp:671 xs/src/libslic3r/PrintConfig.cpp:686
+#: xs/src/libslic3r/PrintConfig.cpp:1168 xs/src/libslic3r/PrintConfig.cpp:1185
+#: xs/src/libslic3r/PrintConfig.cpp:1482
+msgid "Infill"
+msgstr "Remplissage"
+
+#: xs/src/libslic3r/PrintConfig.cpp:71
+#, fuzzy
+msgid ""
+"Infill pattern for bottom layers. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+msgstr ""
+"Motif de remplissage pour les couches du bas. Ceci affecte seulement les "
+"couches externes visibles, et pas les contours solides adjacents."
+
+#: xs/src/libslic3r/PrintConfig.cpp:78
+msgid "Number of solid layers to generate on bottom surfaces."
+msgstr "Nombre de couches solides à générer sur les surfaces inférieures."
+
+#: xs/src/libslic3r/PrintConfig.cpp:80
+msgid "Bottom solid layers"
+msgstr "Couche solides inférieures"
+
+#: xs/src/libslic3r/PrintConfig.cpp:85
+msgid "Bridge"
+msgstr "Pont"
+
+#: xs/src/libslic3r/PrintConfig.cpp:86 xs/src/libslic3r/PrintConfig.cpp:160
+#: xs/src/libslic3r/PrintConfig.cpp:514 xs/src/libslic3r/PrintConfig.cpp:625
+#: xs/src/libslic3r/PrintConfig.cpp:857
+msgid "Speed > Acceleration"
+msgstr "Vitesse > Accélération"
+
+#: xs/src/libslic3r/PrintConfig.cpp:87
+msgid ""
+"This is the acceleration your printer will use for bridges. Set zero to "
+"disable acceleration control for bridges."
+msgstr ""
+"L'accélération qui sera utilisée par votre imprimante pour les ponts. Mettre "
+"zéro pour désactiver l'accélération pour les ponts."
+
+#: xs/src/libslic3r/PrintConfig.cpp:94
+msgid "Bridges fan speed"
+msgstr "Vitesse du ventilateur pour les ponts"
+
+#: xs/src/libslic3r/PrintConfig.cpp:95
+msgid "This fan speed is enforced during all bridges and overhangs."
+msgstr ""
+"Cette vitesse de ventilateur sera utilisée pour les ponts et les surplombs "
+"(overhangs)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:103
+msgid "Bridge flow ratio"
+msgstr "Flow ratio pour les ponts"
+
+#: xs/src/libslic3r/PrintConfig.cpp:104 xs/src/libslic3r/PrintConfig.cpp:147
+#: xs/src/libslic3r/PrintConfig.cpp:678 xs/src/libslic3r/PrintConfig.cpp:1559
+msgid "Advanced"
+msgstr "Avancé"
+
+#: xs/src/libslic3r/PrintConfig.cpp:105
+msgid ""
+"This factor affects the amount of plastic for bridging. You can decrease it "
+"slightly to pull the extrudates and prevent sagging, although default "
+"settings are usually good and you should experiment with cooling (use a fan) "
+"before tweaking this."
+msgstr ""
+"Ce facteur affecte la quantité de plastique pour les ponts. Vous pouvez le "
+"diminuer légèrement pour éviter l'affaissement. La valeur par défaut est "
+"généralement suffisante et vous devriez expérimenter avec le refroidissement "
+"(utiliser un ventilateur) avant de modifier ceci."
+
+#: xs/src/libslic3r/PrintConfig.cpp:111
+msgid "Bridges"
+msgstr "Ponts"
+
+#: xs/src/libslic3r/PrintConfig.cpp:113 xs/src/libslic3r/PrintConfig.cpp:240
+#: xs/src/libslic3r/PrintConfig.cpp:553 xs/src/libslic3r/PrintConfig.cpp:576
+#: xs/src/libslic3r/PrintConfig.cpp:688 xs/src/libslic3r/PrintConfig.cpp:744
+#: xs/src/libslic3r/PrintConfig.cpp:753 xs/src/libslic3r/PrintConfig.cpp:888
+#: xs/src/libslic3r/PrintConfig.cpp:1067 xs/src/libslic3r/PrintConfig.cpp:1105
+#: xs/src/libslic3r/PrintConfig.cpp:1156 xs/src/libslic3r/PrintConfig.cpp:1209
+#: xs/src/libslic3r/PrintConfig.cpp:1491 xs/src/libslic3r/PrintConfig.cpp:1512
+msgid "Speed"
+msgstr "Vitesse"
+
+#: xs/src/libslic3r/PrintConfig.cpp:114
+msgid "Speed for printing bridges."
+msgstr "Vitesse d'impression des ponts."
+
+#: xs/src/libslic3r/PrintConfig.cpp:124
+msgid "Brim connections width"
+msgstr "Largeur de connexion du débord"
+
+#: xs/src/libslic3r/PrintConfig.cpp:125 xs/src/libslic3r/PrintConfig.cpp:134
+#: xs/src/libslic3r/PrintConfig.cpp:701 xs/src/libslic3r/PrintConfig.cpp:779
+#: xs/src/libslic3r/PrintConfig.cpp:1118 xs/src/libslic3r/PrintConfig.cpp:1127
+#: xs/src/libslic3r/PrintConfig.cpp:1135
+msgid "Skirt and brim"
+msgstr "Contour et débord"
+
+#: xs/src/libslic3r/PrintConfig.cpp:126
+msgid ""
+"If set to a positive value, straight connections will be built on the first "
+"layer between adjacent objects."
+msgstr ""
+"Si réglé sur une valeur positive, des connexions directes seront faites sur "
+"la première couche des objets adjacents."
+
+#: xs/src/libslic3r/PrintConfig.cpp:133
+msgid "Exterior brim width"
+msgstr "Largeur du débord extérieur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:135
+msgid ""
+"Horizontal width of the brim that will be printed around each object on the "
+"first layer."
+msgstr ""
+"Largeur du débord qui sera imprimé autour de chaque objet sur la première "
+"couche."
+
+#: xs/src/libslic3r/PrintConfig.cpp:142
+msgid "Compatible printers"
+msgstr "Imprimantes compatibles"
+
+#: xs/src/libslic3r/PrintConfig.cpp:146
+msgid "Complete individual objects"
+msgstr "Imprimer les objets individuels"
+
+#: xs/src/libslic3r/PrintConfig.cpp:148
+msgid ""
+"When printing multiple objects or copies, this feature will complete each "
+"object before moving onto next one (and starting it from its bottom layer). "
+"This feature is useful to avoid the risk of ruined prints. Slic3r should "
+"warn and prevent you from extruder collisions, but beware."
+msgstr ""
+"Lorsque vous imprimez plusieurs objets ou copies, ce réglage permet de "
+"terminer un objet avant de passer au suivant (en repartant de sa première "
+"couche). Cette fonction est utile pour éviter les risques d'impression "
+"gâchée. Slic3r doit vous avertir et éviter les collisions entre les objets "
+"et l'extrudeur, mais soyez vigilent."
+
+#: xs/src/libslic3r/PrintConfig.cpp:153
+msgid "Enable auto cooling"
+msgstr "Activer le refroidissement automatique"
+
+#: xs/src/libslic3r/PrintConfig.cpp:154
+msgid ""
+"This flag enables the automatic cooling logic that adjusts print speed and "
+"fan speed according to layer printing time."
+msgstr ""
+"Cette option active la logique de refroidissement automatique, qui ajuste la "
+"vitesse d'impression et celle du ventilateur en fonction du temps "
+"d'impression de la couche."
+
+#: xs/src/libslic3r/PrintConfig.cpp:159
+msgid "Default"
+msgstr "Défaut"
+
+#: xs/src/libslic3r/PrintConfig.cpp:161
+msgid ""
+"This is the acceleration your printer will be reset to after the role-"
+"specific acceleration values are used (perimeter/infill). Set zero to "
+"prevent resetting acceleration at all."
+msgstr ""
+"Accélération à laquelle votre imprimante sera réinitialisée suite à une "
+"modification spécifique de l'accélération (périmètre, remplissage...). "
+"Mettre zéro pour ne pas réinitialiser l'accélération."
+
+#: xs/src/libslic3r/PrintConfig.cpp:168
+msgid "Disable fan for the first"
+msgstr "Désactiver le ventilateur pour le(s) premier(s)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:169
+msgid ""
+"You can set this to a positive value to disable fan at all during the first "
+"layers, so that it does not make adhesion worse."
+msgstr ""
+"Vous pouvez mettre une valeur positive pour désactiver le ventilateur durant "
+"les premières couches, pour ne pas empirer les problèmes d'adhésion."
+
+#: xs/src/libslic3r/PrintConfig.cpp:170
+msgid "layers"
+msgstr "couches"
+
+#: xs/src/libslic3r/PrintConfig.cpp:177
+msgid "Don't support bridges"
+msgstr "Ne pas supporter les ponts"
+
+#: xs/src/libslic3r/PrintConfig.cpp:178 xs/src/libslic3r/PrintConfig.cpp:933
+#: xs/src/libslic3r/PrintConfig.cpp:942 xs/src/libslic3r/PrintConfig.cpp:1270
+#: xs/src/libslic3r/PrintConfig.cpp:1277 xs/src/libslic3r/PrintConfig.cpp:1287
+#: xs/src/libslic3r/PrintConfig.cpp:1295 xs/src/libslic3r/PrintConfig.cpp:1308
+#: xs/src/libslic3r/PrintConfig.cpp:1325 xs/src/libslic3r/PrintConfig.cpp:1346
+#: xs/src/libslic3r/PrintConfig.cpp:1355 xs/src/libslic3r/PrintConfig.cpp:1367
+#: xs/src/libslic3r/PrintConfig.cpp:1379 xs/src/libslic3r/PrintConfig.cpp:1395
+#: xs/src/libslic3r/PrintConfig.cpp:1406 xs/src/libslic3r/PrintConfig.cpp:1408
+#: xs/src/libslic3r/PrintConfig.cpp:1419
+msgid "Support material"
+msgstr "Support"
+
+#: xs/src/libslic3r/PrintConfig.cpp:179
+msgid ""
+"Experimental option for preventing support material from being generated "
+"under bridged areas."
+msgstr ""
+"Option expérimentale pour empêcher la génération de support sous les ponts."
+
+#: xs/src/libslic3r/PrintConfig.cpp:184
+msgid "Distance between copies"
+msgstr "Distance entre les copies"
+
+#: xs/src/libslic3r/PrintConfig.cpp:185
+msgid "Distance used for the auto-arrange feature of the plater."
+msgstr ""
+"Distance minimale utilisée par la fonction d'agencement automatique sur le "
+"plateau."
+
+#: xs/src/libslic3r/PrintConfig.cpp:193 xs/src/libslic3r/PrintConfig.cpp:202
+msgid "End G-code"
+msgstr "G-Code de fin"
+
+#: xs/src/libslic3r/PrintConfig.cpp:194
+msgid ""
+"This end procedure is inserted at the end of the output file. Note that you "
+"can use placeholder variables for all Slic3r settings."
+msgstr ""
+"Ce code sera inséré à la fin du fichier G-Code. Notez que vous pouvez "
+"utiliser les variables pour toutes les réglages de Slic3r."
+
+#: xs/src/libslic3r/PrintConfig.cpp:203
+msgid ""
+"This end procedure is inserted at the end of the output file, before the "
+"printer end gcode. Note that you can use placeholder variables for all "
+"Slic3r settings. If you have multiple extruders, the gcode is processed in "
+"extruder order."
+msgstr ""
+"Cette procédure de fin est insérée à la fin du fichier G-Code, avant le code "
+"de finalisation de l'impression. Notez que vous pouvez  utiliser les "
+"variables pour toutes les réglages de Slic3r.. Si vous avez plusieurs "
+"extrudeurs, le G-Code sera analysé suivant l'ordre des extrudeurs."
+
+#: xs/src/libslic3r/PrintConfig.cpp:215
+msgid "Top/bottom fill pattern"
+msgstr "Motif de remplissage haut/bas"
+
+#: xs/src/libslic3r/PrintConfig.cpp:217
+msgid ""
+"Fill pattern for top/bottom infill. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+msgstr ""
+"Motif pour les remplissage haut/bas. Ceci affecte seulement la couche "
+"externe visible, et pas ses parties solides adjacentes."
+
+#: xs/src/libslic3r/PrintConfig.cpp:224 xs/src/libslic3r/PrintConfig.cpp:237
+msgid "↳ external"
+msgstr "↳ externe"
+
+#: xs/src/libslic3r/PrintConfig.cpp:225
+msgid "External perimeters extrusion width"
+msgstr "Largeur d'extrusion des périmètres externes"
+
+#: xs/src/libslic3r/PrintConfig.cpp:227 xs/src/libslic3r/PrintConfig.cpp:323
+#: xs/src/libslic3r/PrintConfig.cpp:532 xs/src/libslic3r/PrintConfig.cpp:653
+#: xs/src/libslic3r/PrintConfig.cpp:875 xs/src/libslic3r/PrintConfig.cpp:1196
+#: xs/src/libslic3r/PrintConfig.cpp:1327 xs/src/libslic3r/PrintConfig.cpp:1470
+msgid "Extrusion Width"
+msgstr "Largeur d'extrusion"
+
+#: xs/src/libslic3r/PrintConfig.cpp:228
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for external "
+"perimeters. If auto is chosen, a value will be used that maximizes accuracy "
+"of the external visible surfaces. If expressed as percentage (for example "
+"200%) it will be computed over layer height."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro, fixe manuellement la largeur "
+"d'extrusion pour le périmètre externe. Si auto est choisi, la valeur "
+"calculée maximisera la précision sur les surfaces externes visibles. if "
+"exprimé en pourcentage (par exemple: 200%), elle sera calculée en fonction "
+"de la hauteur de couche."
+
+#: xs/src/libslic3r/PrintConfig.cpp:238
+msgid "External perimeters speed"
+msgstr "Vitesse des périmètres externes"
+
+#: xs/src/libslic3r/PrintConfig.cpp:241
+msgid ""
+"This separate setting will affect the speed of external perimeters (the "
+"visible ones). If expressed as percentage (for example: 80%) it will be "
+"calculated on the perimeters speed setting above."
+msgstr ""
+"Ce réglage affecte la vitesse des périmètres externes (ceux qui sont "
+"visibles). Si exprimé en pourcentage (par exemple, 80%) il sera calculé en "
+"fonction de la vitesse des périmètres ci dessus.."
+
+#: xs/src/libslic3r/PrintConfig.cpp:251
+msgid "External perimeters first"
+msgstr "Périmètres externes d'abord"
+
+#: xs/src/libslic3r/PrintConfig.cpp:253
+msgid ""
+"Print contour perimeters from the outermost one to the innermost one instead "
+"of the default inverse order."
+msgstr ""
+"Imprimer les périmètres de l'extérieur vers l'intérieur au lieu de l'inverse."
+
+#: xs/src/libslic3r/PrintConfig.cpp:258
+msgid "Extra perimeters if needed"
+msgstr "Périmètres supplémentaires si nécessaire"
+
+#: xs/src/libslic3r/PrintConfig.cpp:260
+msgid "Add more perimeters when needed for avoiding gaps in sloping walls."
+msgstr ""
+"Ajouter des périmètres si besoin pour éviter des trous sur les surfaces "
+"inclinés."
+
+#: xs/src/libslic3r/PrintConfig.cpp:266 xs/src/libslic3r/PrintConfig.cpp:925
+msgid "Extruder"
+msgstr "Extrudeur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:267 xs/src/libslic3r/PrintConfig.cpp:644
+#: xs/src/libslic3r/PrintConfig.cpp:828 xs/src/libslic3r/PrintConfig.cpp:865
+#: xs/src/libslic3r/PrintConfig.cpp:1177 xs/src/libslic3r/PrintConfig.cpp:1238
+#: xs/src/libslic3r/PrintConfig.cpp:1318 xs/src/libslic3r/PrintConfig.cpp:1338
+msgid "Extruders"
+msgstr "Extrudeurs"
+
+#: xs/src/libslic3r/PrintConfig.cpp:268
+msgid ""
+"The extruder to use (unless more specific extruder settings are specified)."
+msgstr ""
+"L'extrudeur à utiliser (a moins que des réglages d'extrudeur spécifiques "
+"soit indiqués)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:278
+msgid "Height"
+msgstr "Hauteur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:279
+msgid ""
+"Set this to the vertical distance between your nozzle tip and (usually) the "
+"X carriage rods. In other words, this is the height of the clearance "
+"cylinder around your extruder, and it represents the maximum depth the "
+"extruder can peek before colliding with other printed objects."
+msgstr ""
+"Distance verticale entre la pointe de la buse et (habituellement) les barres "
+"du chariot X. En d'autres termes, il s'agit de la hauteur du cylindre de "
+"sécurité autour de l'extrudeur, et elle représente la profondeur maximum à "
+"laquelle peut descendre l'extrudeur avant d'entrer en collision avec "
+"d'autres objets imprimés."
+
+#: xs/src/libslic3r/PrintConfig.cpp:286
+msgid "Radius"
+msgstr "Rayon"
+
+#: xs/src/libslic3r/PrintConfig.cpp:287
+msgid ""
+"Set this to the clearance radius around your extruder. If the extruder is "
+"not centered, choose the largest value for safety. This setting is used to "
+"check for collisions and to display the graphical preview in the plater."
+msgstr ""
+"Rayon de sécurité autour de l'extrudeur. Si l'extrudeur n'est pas centré, "
+"choisissez une valeur plus large pour plus de sécurité. Ce réglage est "
+"utilisé pour éviter les collisions et afficher la marge dans la "
+"prévisualisation du plateau."
+
+#: xs/src/libslic3r/PrintConfig.cpp:294
+msgid "Extruder offset"
+msgstr "Décalage de l'extrudeur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:295
+msgid ""
+"If your firmware doesn't handle the extruder displacement you need the G-"
+"code to take it into account. This option lets you specify the displacement "
+"of each extruder with respect to the first one. It expects positive "
+"coordinates (they will be subtracted from the XY coordinate)."
+msgstr ""
+"Si le firmware de votre imprimante ne gère pas le décalage de l'extrudeur, "
+"c'est au G-Code d'en tenir compte. Cette option vous permet de spéficier le "
+"décalage de chaque extrudeur par rapport au premier. Seules des valeurs "
+"positives sont possibles (elles seront soustraites des coordonnées XY)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:305
+msgid "Extrusion axis"
+msgstr "Axe d'extrusion"
+
+#: xs/src/libslic3r/PrintConfig.cpp:306
+msgid ""
+"Use this option to set the axis letter associated to your printer's extruder "
+"(usually E but some printers use A)."
+msgstr ""
+"Utiliser cette option pour indiquer la lettre utilisée par l'extrudeur de "
+"votre imprimante (habituellement E, mais certaines imprimantes utilisent A)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:311
+msgid "Extrusion multiplier"
+msgstr "Multiplicateur d'extrusion"
+
+#: xs/src/libslic3r/PrintConfig.cpp:312
+msgid ""
+"This factor changes the amount of flow proportionally. You may need to tweak "
+"this setting to get nice surface finish and correct single wall widths. "
+"Usual values are between 0.9 and 1.1. If you think you need to change this "
+"more, check filament diameter and your firmware E steps."
+msgstr ""
+"Ce facteur modifie proportionnellement la quantité  d'extrudât. Vous pouvez "
+"avoir besoin de modifier ceci afin d'otenir un beau rendu de surface et une "
+"taille correcte pour les murs uniques. Les valeurs habituelles vont de 0,9 à "
+"1,1. Si vous pensez avoir besoin de changer d'avantage cette valeur, "
+"vérifiez le diamètre de votre filament et le E-Steps dans le firmware.."
+
+#: xs/src/libslic3r/PrintConfig.cpp:321
+msgid "Default extrusion width"
+msgstr "Largeur d'extrusion par défaut"
+
+#: xs/src/libslic3r/PrintConfig.cpp:324
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width. If expressed "
+"as percentage (for example: 230%) it will be computed over layer height."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro, fixe manuellement la largeur "
+"d'extrusion. Si exprimé en pourcentage (par exemple 230%), elle sera "
+"calculée en fonction de la hauteur de couche."
+
+#: xs/src/libslic3r/PrintConfig.cpp:333
+msgid "Keep fan always on"
+msgstr "Garder le ventillateur actif"
+
+#: xs/src/libslic3r/PrintConfig.cpp:334
+msgid ""
+"If this is enabled, fan will never be disabled and will be kept running at "
+"least at its minimum speed. Useful for PLA, harmful for ABS."
+msgstr ""
+"Si cette option est cochée, le ventilateur ne sera jamais arrêté et tournera "
+"au moins à sa vitesse minimum. Idéal pour le PLA, mais pas pour l'ABS."
+
+#: xs/src/libslic3r/PrintConfig.cpp:339
+msgid "Enable fan if layer print time is below"
+msgstr ""
+"Activer le ventilateur si le temps d'impression de la couche est inférieure à"
+
+#: xs/src/libslic3r/PrintConfig.cpp:340
+msgid ""
+"If layer print time is estimated below this number of seconds, fan will be "
+"enabled and its speed will be calculated by interpolating the minimum and "
+"maximum speeds."
+msgstr ""
+"Si le temps d'impression estimé de la couche est inférieure à ce nombre de "
+"secondes, le ventilateur sera activé et sa vitesse calculée par "
+"l'extrapolation des vitesses minimum et maximum."
+
+#: xs/src/libslic3r/PrintConfig.cpp:349
+msgid "Color"
+msgstr "Couleur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:350
+msgid "This is only used in the Slic3r interface as a visual help."
+msgstr ""
+"Ceci est uniquement utilisé dans l'interface de Slic3r comme indication "
+"visuelle."
+
+#: xs/src/libslic3r/PrintConfig.cpp:360
+msgid "Filament notes"
+msgstr "Notes de filament"
+
+#: xs/src/libslic3r/PrintConfig.cpp:361
+msgid "You can put your notes regarding the filament here."
+msgstr "Vous pouvez indiquer vos remarques concernant le filament ici."
+
+#: xs/src/libslic3r/PrintConfig.cpp:373 xs/src/libslic3r/PrintConfig.cpp:752
+msgid "Max volumetric speed"
+msgstr "Vitesse volumétrique max"
+
+#: xs/src/libslic3r/PrintConfig.cpp:374
+msgid ""
+"Maximum volumetric speed allowed for this filament. Limits the maximum "
+"volumetric speed of a print to the minimum of print and filament volumetric "
+"speed. Set to zero for no limit."
+msgstr ""
+"Vitesse volumétrique maximum autorisée pour ce filament. Limite la vitesse "
+"volumétrique d'une impression. Mettre à zéro pour enlever la limite."
+
+#: xs/src/libslic3r/PrintConfig.cpp:385
+msgid "Diameter"
+msgstr "Diamètre"
+
+#: xs/src/libslic3r/PrintConfig.cpp:386
+msgid ""
+"Enter your filament diameter here. Good precision is required, so use a "
+"caliper and do multiple measurements along the filament, then compute the "
+"average."
+msgstr ""
+"Entrez le diamètre de votre filament ici. Une bonne précision est requise, "
+"utilisez un pied à coulisse et calculez la moyenne de plusieurs mesures le "
+"long du filament."
+
+#: xs/src/libslic3r/PrintConfig.cpp:397
+msgid "Density"
+msgstr "Densité"
+
+#: xs/src/libslic3r/PrintConfig.cpp:398
+msgid ""
+"Enter your filament density here. This is only for statistical information. "
+"A decent way is to weigh a known length of filament and compute the ratio of "
+"the length to volume. Better is to calculate the volume directly through "
+"displacement."
+msgstr ""
+"Entrez la densité de votre filament. Uniquement pour des raisons "
+"statistiques. Un bon moyen d'avoir cette valeur est de peser un morceau "
+"d'une longueur connue de filament et de calculer le ratio longueur/poid. Le "
+"mieux est de calculer le volume directement par déplacement."
+
+#: xs/src/libslic3r/PrintConfig.cpp:409
+msgid "Cost"
+msgstr "Coût"
+
+#: xs/src/libslic3r/PrintConfig.cpp:410
+msgid ""
+"Enter your filament cost per kg here. This is only for statistical "
+"information."
+msgstr ""
+"Entrez le coût par Kilo de votre filament. Utiliser uniquement a des fins "
+"statistiques."
+
+# Set this to be the local currency symbol.
+#: xs/src/libslic3r/PrintConfig.cpp:411
+msgid "money/kg"
+msgstr "€/kg"
+
+#: xs/src/libslic3r/PrintConfig.cpp:424
+msgid "Fill angle"
+msgstr "Angle de remplissage"
+
+#: xs/src/libslic3r/PrintConfig.cpp:426
+msgid ""
+"Default base angle for infill orientation. Cross-hatching will be applied to "
+"this. Bridges will be infilled using the best direction Slic3r can detect, "
+"so this setting does not affect them."
+msgstr ""
+"Angle de base par défaut pour le remplissage. Des croisements seront "
+"appliqués à cette valeur. Les ponts seront remplis avec la direction idéale "
+"détectée par Slic3r, ce réglage ne les affecteront pas."
+
+#: xs/src/libslic3r/PrintConfig.cpp:436
+msgid "Fill density"
+msgstr "Densité de remplissage"
+
+#: xs/src/libslic3r/PrintConfig.cpp:438
+msgid "Density of internal infill, expressed in the range 0% - 100%."
+msgstr "Densité du remplissage interne, exprimé en pourcentage de 0% à 100%."
+
+#: xs/src/libslic3r/PrintConfig.cpp:474
+msgid "Fill gaps"
+msgstr "Remplir les trous"
+
+#: xs/src/libslic3r/PrintConfig.cpp:476
+msgid ""
+"If this is enabled, gaps will be filled with single passes. Enable this for "
+"better quality, disable it for shorter printing times."
+msgstr ""
+"Si coché, les trous seront remplis en un seul passage. A activer pour une "
+"meilleur qualité, à désactiver pour une impression plus rapide."
+
+#: xs/src/libslic3r/PrintConfig.cpp:481
+msgid "Fill pattern"
+msgstr "Motif de remplissage"
+
+#: xs/src/libslic3r/PrintConfig.cpp:483
+msgid "Fill pattern for general low-density infill."
+msgstr "Motif pour les remplissages de faible densité."
+
+#: xs/src/libslic3r/PrintConfig.cpp:513 xs/src/libslic3r/PrintConfig.cpp:522
+#: xs/src/libslic3r/PrintConfig.cpp:530 xs/src/libslic3r/PrintConfig.cpp:561
+msgid "First layer"
+msgstr "Première couche"
+
+#: xs/src/libslic3r/PrintConfig.cpp:515
+msgid ""
+"This is the acceleration your printer will use for first layer. Set zero to "
+"disable acceleration control for first layer."
+msgstr ""
+"L'accélération que l'imprimante utilisera pour la première couche. Mettre "
+"zéro pour désactiver l'accélération pour la première couche."
+
+#: xs/src/libslic3r/PrintConfig.cpp:523
+msgid ""
+"Heated build plate temperature for the first layer. Set this to zero to "
+"disable bed temperature control commands in the output."
+msgstr ""
+"Température du plateau chauffant pour la première couche. Mettre zéro pour "
+"désactiver les commandes de contrôle de température en sortie."
+
+#: xs/src/libslic3r/PrintConfig.cpp:533
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for first "
+"layer. You can use this to force fatter extrudates for better adhesion. If "
+"expressed as percentage (for example 120%) it will be computed over first "
+"layer height."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro, indique la largeur "
+"d'extrusion pour la première couche. Vous pouvez utiliser ce réglage pour "
+"forcer un extrudât plus large pour une meilleur adhésion. Si exprimé en "
+"pourcentage (par exemple 120%), elle sera calculée par rapport à l'épaisseur "
+"de la première couche."
+
+#: xs/src/libslic3r/PrintConfig.cpp:543
+msgid "First layer height"
+msgstr "Epaisseur de la première couche"
+
+#: xs/src/libslic3r/PrintConfig.cpp:545
+msgid ""
+"When printing with very low layer heights, you might still want to print a "
+"thicker bottom layer to improve adhesion and tolerance for non perfect build "
+"plates. This can be expressed as an absolute value or as a percentage (for "
+"example: 150%) over the default layer height."
+msgstr ""
+"Lors d'une impression avec de très faibles épaisseurs de couche, vous pouvez "
+"choisir d'imprimer la première couche plus épaisse pour améliorer l'adhésion "
+"et la tolérance pour les plateaux imparfaits. Ce réglage peut être exprimé "
+"comme une valeur absolue ou un pourcentage (par exemple 150%) par rapport à "
+"l'épaisseur de couche par défaut."
+
+#: xs/src/libslic3r/PrintConfig.cpp:552
+msgid "First layer speed"
+msgstr "Vitesse de la première couche"
+
+#: xs/src/libslic3r/PrintConfig.cpp:554
+msgid ""
+"If expressed as absolute value in mm/s, this speed will be applied to all "
+"the print moves of the first layer, regardless of their type. If expressed "
+"as a percentage (for example: 40%) it will scale the default speeds."
+msgstr ""
+"Si exprimé avec une valeur absolue en mm/s, cette vitesse sera appliquée à "
+"sur tous les déplacements d'impression de la première couche, quelle que "
+"soit leur type. Si exprimé comme un pourcentage (par exemple 40%), il "
+"modulera la vitesse par défaut.."
+
+#: xs/src/libslic3r/PrintConfig.cpp:562
+msgid ""
+"Extruder temperature for first layer. If you want to control temperature "
+"manually during print, set this to zero to disable temperature control "
+"commands in the output file."
+msgstr ""
+"Température d’extrudeur pour première couche. Si vous voulez contrôler "
+"manuellement la température au cours de l’impression, mettre à zéro pour "
+"désactiver les commandes de contrôle de température dans le fichier de "
+"sortie."
+
+#: xs/src/libslic3r/PrintConfig.cpp:573
+msgid "↳ gaps"
+msgstr "↳ trous"
+
+#: xs/src/libslic3r/PrintConfig.cpp:577
+msgid ""
+"Speed for filling gaps. Since these are usually single lines you might want "
+"to use a low speed for better sticking. If expressed as percentage (for "
+"example: 80%) it will be calculated on the infill speed setting above."
+msgstr ""
+"Vitesse pour remplir les trous. Puisque ce sont habituellement des lignes "
+"uniques, vous pouvez utiliser une vitesse lente pour une meilleur adhérence. "
+"Si exprimée en pourcentage (par exemple : 80 %) elle sera calculée en "
+"fonction du réglage de vitesse de remplissage au-dessus."
+
+#: xs/src/libslic3r/PrintConfig.cpp:587
+msgid "Use native G-code arcs"
+msgstr "Utiliser le G-Code natif pour les arcs"
+
+#: xs/src/libslic3r/PrintConfig.cpp:588
+msgid ""
+"This experimental feature tries to detect arcs from segments and generates "
+"G2/G3 arc commands instead of multiple straight G1 commands."
+msgstr ""
+"Cette fonction expérimentale essaye de détecter les arcs à partir des "
+"segments et génère les commandes G2/G3 au lieu de multiples commandes G1."
+
+#: xs/src/libslic3r/PrintConfig.cpp:593
+msgid "Verbose G-code"
+msgstr "G-code commenté"
+
+#: xs/src/libslic3r/PrintConfig.cpp:594
+msgid ""
+"Enable this to get a commented G-code file, with each line explained by a "
+"descriptive text. If you print from SD card, the additional weight of the "
+"file could make your firmware slow down."
+msgstr ""
+"Cocher pour obtenir un fichier de G-code commenté, avec chaque ligne "
+"expliquée par un texte descriptif. Si vous imprimez depuis une carte SD, le "
+"poids supplémentaire du fichier pourrait ralentir le firmware de votre "
+"imprimante."
+
+#: xs/src/libslic3r/PrintConfig.cpp:599
+msgid "G-code flavor"
+msgstr "Version du G-code"
+
+#: xs/src/libslic3r/PrintConfig.cpp:600
+msgid ""
+"Some G/M-code commands, including temperature control and others, are not "
+"universal. Set this option to your printer's firmware to get a compatible "
+"output. The \"No extrusion\" flavor prevents Slic3r from exporting any "
+"extrusion value at all."
+msgstr ""
+"Certaines commandes G/M, dont le contrôle de température et autres, ne sont "
+"pas universelles. Réglez cette option sur le firmware de votre imprimante "
+"pour obtenir un fichier compatible. La version \"sans extrusion\" indique à "
+"Slic3r de ne pas générer les commandes d'extrusion."
+
+#: xs/src/libslic3r/PrintConfig.cpp:626
+msgid ""
+"This is the acceleration your printer will use for infill. Set zero to "
+"disable acceleration control for infill."
+msgstr ""
+"Il s'agit de l'accélération que votre imprimante utilisera pour le "
+"remplissage. Mettre à zéro pour désactiver le contrôle de l'accélération "
+"pour les remplissage."
+
+#: xs/src/libslic3r/PrintConfig.cpp:633
+msgid "Combine infill every"
+msgstr "Combiner le remplissage toute les"
+
+#: xs/src/libslic3r/PrintConfig.cpp:635
+msgid ""
+"This feature allows to combine infill and speed up your print by extruding "
+"thicker infill layers while preserving thin perimeters, thus accuracy."
+msgstr ""
+"Cette fonction permet de combiner le remplissage afin d'accélérer "
+"l'impression, en extrudant un remplissage plus épais tout en conservant les "
+"périmètres fins, et donc précis."
+
+#: xs/src/libslic3r/PrintConfig.cpp:643
+msgid "Infill extruder"
+msgstr "Extrudeur pour remplissage"
+
+#: xs/src/libslic3r/PrintConfig.cpp:645
+msgid "The extruder to use when printing infill."
+msgstr "L'extrudeur à utiliser lors de l'impression du remplissage."
+
+#: xs/src/libslic3r/PrintConfig.cpp:654
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill. You "
+"may want to use fatter extrudates to speed up the infill and make your parts "
+"stronger. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro, indique la largeur "
+"d'extrusion pour le remplissage. Vous pouvez utiliser un extrudât plus large "
+"pour accélérer l'impression et rendre vos pièces plus solides. Si exprimé en "
+"pourcentage (par exemple: 90%), elle sera calculée en fonction de "
+"l'épaisseur des couches."
+
+#: xs/src/libslic3r/PrintConfig.cpp:663
+msgid "Infill before perimeters"
+msgstr "Remplissage avant périmètres"
+
+#: xs/src/libslic3r/PrintConfig.cpp:665
+msgid ""
+"This option will switch the print order of perimeters and infill, making the "
+"latter first."
+msgstr ""
+"Cette option inverse l'ordre d'impression des périmètres et du remplissage, "
+"qui sera imprimé en premier."
+
+#: xs/src/libslic3r/PrintConfig.cpp:670
+msgid "Only infill where needed"
+msgstr "Remplissage seulement où nécessaire"
+
+#: xs/src/libslic3r/PrintConfig.cpp:672
+msgid ""
+"This option will limit infill to the areas actually needed for supporting "
+"ceilings (it will act as internal support material). If enabled, slows down "
+"the G-code generation due to the multiple checks involved."
+msgstr ""
+"Cette option limitera le remplissage aux zones nécessaires pour supporter "
+"les couches supérieures (cela agira comme un support interne). Si activé, la "
+"génération du G-Code prendra plus de temps à cause des calculs "
+"supplémentaires requis."
+
+#: xs/src/libslic3r/PrintConfig.cpp:677
+msgid "Infill/perimeters overlap"
+msgstr "Recouvrement remplissage/périmètres"
+
+#: xs/src/libslic3r/PrintConfig.cpp:679
+msgid ""
+"This setting applies an additional overlap between infill and perimeters for "
+"better bonding. Theoretically this shouldn't be needed, but backlash might "
+"cause gaps. If expressed as percentage (example: 15%) it is calculated over "
+"perimeter extrusion width."
+msgstr ""
+"Cette option applique un recouvrement supplémentaire entre les périmètres et "
+"le remplissage pour une meilleur fusion. En théorie, cela ne devrait pas "
+"être nécessaire, mais le jeu mécanique peut causer des trous. Si exprimé en "
+"pourcentage (par exemple 15%), il sera calculé en fonction de la largeur "
+"d'extrusion du périmètre."
+
+#: xs/src/libslic3r/PrintConfig.cpp:689
+msgid "Speed for printing the internal fill."
+msgstr "Vitesse pour l'impression du remplissage interne."
+
+#: xs/src/libslic3r/PrintConfig.cpp:700
+msgid "Interior brim width"
+msgstr "Largeur du débord intérieur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:702
+msgid ""
+"Horizontal width of the brim that will be printed inside object holes on the "
+"first layer."
+msgstr ""
+"Largeur du débord qui sera imprimé dans les trous des objets, sur la "
+"première couche."
+
+#: xs/src/libslic3r/PrintConfig.cpp:709
+msgid "Interface shells"
+msgstr "Parois intercalaire"
+
+#: xs/src/libslic3r/PrintConfig.cpp:710
+msgid ""
+"Force the generation of solid shells between adjacent materials/volumes. "
+"Useful for multi-extruder prints with translucent materials or manual "
+"soluble support material."
+msgstr ""
+"Force la génération de parois solides entre des volumes/matériaux adjacents. "
+"Utile pour des impressions multi-extrudeur avec des matériaux translucides, "
+"ou avec un support soluble."
+
+#: xs/src/libslic3r/PrintConfig.cpp:716
+msgid "After layer change G-code"
+msgstr "G-Code après changement de couche"
+
+#: xs/src/libslic3r/PrintConfig.cpp:717
+msgid ""
+"This custom code is inserted at every layer change, right after the Z move "
+"and before the extruder moves to the first layer point. Note that you can "
+"use placeholder variables for all Slic3r settings as well as [layer_num] and "
+"[layer_z]."
+msgstr ""
+"Ce code personnalisé est inséré à chaque changement de couche, juste après "
+"le mouvement Z et avant le déplacement de l'extrudeur au point de départ de "
+"la couche suivante. Notez que vous pouvez utiliser des variables pour tous "
+"les réglages de Slic3r en plus de [layer_num] et [layer_z]."
+
+#: xs/src/libslic3r/PrintConfig.cpp:725
+msgid "Layer height"
+msgstr "Épaisseur de couche"
+
+#: xs/src/libslic3r/PrintConfig.cpp:727
+msgid ""
+"This setting controls the height (and thus the total number) of the slices/"
+"layers. Thinner layers give better accuracy but take more time to print."
+msgstr ""
+"Cette option contrôle l'épaisseur (et donc le nombre total) de couches. Des "
+"couches plus fines donneront une meilleure précision mais l'impression sera "
+"plus longue."
+
+#: xs/src/libslic3r/PrintConfig.cpp:734
+msgid "Max"
+msgstr "Max"
+
+#: xs/src/libslic3r/PrintConfig.cpp:735
+msgid "This setting represents the maximum speed of your fan."
+msgstr "Cette option représente la vitesse maximum du ventilateur."
+
+#: xs/src/libslic3r/PrintConfig.cpp:743
+msgid "Max print speed"
+msgstr "Vitesse d'impression Max"
+
+#: xs/src/libslic3r/PrintConfig.cpp:745
+msgid ""
+"When setting other speed settings to 0 Slic3r will autocalculate the optimal "
+"speed in order to keep constant extruder pressure. This experimental setting "
+"is used to set the highest print speed you want to allow."
+msgstr ""
+"Lorsque vous réglez les autres vitesses à 0, Slic3r calculera "
+"automatiquement la vitesse optimale de façon à garder une pression constante "
+"dans l'extrudeur. Cette fonction expérimentale est utilisée pour régler la "
+"plus haute vitesse que votre imprimante puisse supporter."
+
+#: xs/src/libslic3r/PrintConfig.cpp:754
+msgid ""
+"This experimental setting is used to set the maximum volumetric speed your "
+"extruder supports."
+msgstr ""
+"Cette option expérimentale est utilisée pour régler la vitesse volumétrique "
+"maximum supportée par votre extrudeur."
+
+#: xs/src/libslic3r/PrintConfig.cpp:761
+msgid "Min"
+msgstr "Min"
+
+#: xs/src/libslic3r/PrintConfig.cpp:762
+msgid "This setting represents the minimum PWM your fan needs to work."
+msgstr ""
+"Cette option représente le PWM minimum dont votre ventilateur a besoin pour "
+"tourner."
+
+#: xs/src/libslic3r/PrintConfig.cpp:770
+msgid "Min print speed"
+msgstr "Vitesse d'impression minimum"
+
+#: xs/src/libslic3r/PrintConfig.cpp:771
+msgid "Slic3r will not scale speed down below this speed."
+msgstr "Slic3r ne descendra pas en dessous de cette vitesse."
+
+#: xs/src/libslic3r/PrintConfig.cpp:778
+msgid "Minimum extrusion length"
+msgstr "Longueur d'extrusion minimum"
+
+#: xs/src/libslic3r/PrintConfig.cpp:780
+msgid ""
+"Generate no less than the number of skirt loops required to consume the "
+"specified amount of filament on the bottom layer. For multi-extruder "
+"machines, this minimum applies to each extruder."
+msgstr ""
+"Nombre minimum de contours à génére afin de consommer la distance de "
+"filament spécifiée sur la couche du bas. Pour des machines à extrudeurs "
+"multiples, ce minimum s'applique à chacun d'entre eux."
+
+#: xs/src/libslic3r/PrintConfig.cpp:787
+msgid "Configuration notes"
+msgstr "Commentaires de configuration"
+
+#: xs/src/libslic3r/PrintConfig.cpp:788
+msgid ""
+"You can put here your personal notes. This text will be added to the G-code "
+"header comments."
+msgstr ""
+"Vous pouvez inscrire ici vos commentaires personnels. Ce texte sera ajouté à "
+"l'entête du G-Code généré."
+
+#: xs/src/libslic3r/PrintConfig.cpp:796
+msgid "Nozzle diameter"
+msgstr "Diamètre de la buse"
+
+#: xs/src/libslic3r/PrintConfig.cpp:797
+msgid ""
+"This is the diameter of your extruder nozzle (for example: 0.5, 0.35 etc.)"
+msgstr ""
+"Il s'agit du diamètre de la buse de votre extrudeur (par exemple: 0.5, 0.35, "
+"etc.)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:807
+msgid "API Key"
+msgstr "Clé API"
+
+#: xs/src/libslic3r/PrintConfig.cpp:808
+msgid ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"API Key required for authentication."
+msgstr ""
+"Slic3r peut envoyer le G-Code sur un serveur OctoPrint. Ce champs doit "
+"contenir la clé d'API requise pour l'authentification."
+
+#: xs/src/libslic3r/PrintConfig.cpp:813
+msgid "Host or IP"
+msgstr "Hôte ou IP"
+
+#: xs/src/libslic3r/PrintConfig.cpp:814
+msgid ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"hostname or IP address of the OctoPrint instance."
+msgstr ""
+"Slic3r peut envoyer le G-Code sur un serveur OctoPrint. Ce champs doit "
+"contenir le nom d'hôte ou l'adresse IP du serveur OctoPrint."
+
+#: xs/src/libslic3r/PrintConfig.cpp:819
+msgid "Only retract when crossing perimeters"
+msgstr "Rétracter uniquement lors du franchissement des périmètres"
+
+#: xs/src/libslic3r/PrintConfig.cpp:821
+msgid ""
+"Disables retraction when the travel path does not exceed the upper layer's "
+"perimeters (and thus any ooze will be probably invisible)."
+msgstr ""
+"Désactiver la rétractation lorsque la distance à parcourir ne franchi pas le "
+"périmètre  des couches supérieures (et donc les coulures seront certainement "
+"invisibles)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:826
+msgid "Enable"
+msgstr "Activé"
+
+#: xs/src/libslic3r/PrintConfig.cpp:829
+#, fuzzy
+msgid ""
+"During multi-extruder prints, this option will drop the temperature of the "
+"inactive extruders to prevent oozing. It will enable a tall skirt "
+"automatically and move extruders outside such skirt when changing "
+"temperatures."
+msgstr ""
+"Lors d'impression avec de multiples extrudeurs, cette option abaisse la "
+"température des extrudeurs inactifs pour empêcher les coulures. Cela "
+"activera un contour automatique et déplacera l'extrudeur au delà de ce "
+"contour lors des changements de température."
+
+#: xs/src/libslic3r/PrintConfig.cpp:834
+msgid "Output filename format"
+msgstr "Format du nom de fichier"
+
+#: xs/src/libslic3r/PrintConfig.cpp:835
+msgid ""
+"You can use all configuration options as variables inside this template. For "
+"example: [layer_height], [fill_density] etc. You can also use [timestamp], "
+"[year], [month], [day], [hour], [minute], [second], [version], "
+"[input_filename], [input_filename_base]."
+msgstr ""
+"Vous pouvez utiliser toutes les options de configuration comme variables "
+"dans ce gabarit. Par exemple :  [layer_height], [fill_density] etc. Vous "
+"pouvez aussi utiliser [timestamp], [year], [month], [day], [hour], [minute], "
+"[second], [version], [input_filename], [input_filename_base]."
+
+#: xs/src/libslic3r/PrintConfig.cpp:841
+msgid "Detect bridging perimeters"
+msgstr "Détecter les périmètres faisant des ponts"
+
+#: xs/src/libslic3r/PrintConfig.cpp:843
+msgid ""
+"Experimental option to adjust flow for overhangs (bridge flow will be used), "
+"to apply bridge speed to them and enable fan."
+msgstr ""
+"Option expérimentale qui ajuste le débit pour les débordements, cela leur "
+"appliquera le débit des ponts et activera le ventilateur."
+
+#: xs/src/libslic3r/PrintConfig.cpp:848
+msgid "Overridable options"
+msgstr "Options redéfinissables"
+
+#: xs/src/libslic3r/PrintConfig.cpp:856 xs/src/libslic3r/PrintConfig.cpp:873
+#: xs/src/libslic3r/PrintConfig.cpp:886 xs/src/libslic3r/PrintConfig.cpp:899
+msgid "Perimeters"
+msgstr "Périmètres"
+
+#: xs/src/libslic3r/PrintConfig.cpp:858
+msgid ""
+"This is the acceleration your printer will use for perimeters. A high value "
+"like 9000 usually gives good results if your hardware is up to the job. Set "
+"zero to disable acceleration control for perimeters."
+msgstr ""
+"L'accélération que votre imprimante utilisera pour les périmètres. Une "
+"grande valeur comme 9000  donne généralement de bons résultats si votre "
+"matériel le permet. Régler à zéro pour désactiver le contrôle de "
+"l'accélération pour les périmètres."
+
+#: xs/src/libslic3r/PrintConfig.cpp:864
+msgid "Perimeter extruder"
+msgstr "Extrudeur pour le périmètre"
+
+#: xs/src/libslic3r/PrintConfig.cpp:866
+msgid ""
+"The extruder to use when printing perimeters and brim. First extruder is 1."
+msgstr ""
+"L'extrudeur à utiliser lors de l'impression des périmètres et du débord. Le "
+"premier extrudeur a le numéro 1."
+
+#: xs/src/libslic3r/PrintConfig.cpp:876
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for perimeters. "
+"You may want to use thinner extrudates to get more accurate surfaces. If "
+"expressed as percentage (for example 200%) it will be computed over layer "
+"height."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro, indique la largeur "
+"d'extrusion pour les périmètres. Vous pourriez avoir besoin d'extrudât plus "
+"fin pour avoir une surface plus précise. Si exprimée en pourcentage (par "
+"exemple: 200%) elle sera calculée en fonction de l'épaisseur des couches."
+
+#: xs/src/libslic3r/PrintConfig.cpp:889
+msgid "Speed for perimeters (contours, aka vertical shells)."
+msgstr "Vitesse pour les périmètres (contours, ou parois verticales)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:901
+msgid ""
+"This option sets the number of perimeters to generate for each layer. Note "
+"that Slic3r may increase this number automatically when it detects sloping "
+"surfaces which benefit from a higher number of perimeters if the Extra "
+"Perimeters option is enabled."
+msgstr ""
+"Cette option indique le nombre maximum de périmètres à générer pour chaque "
+"couche. Notez que Slic3r peut augmenter cette valeur automatiquement si il "
+"détecte une surface inclinée qui nécessite un plus grand nombre de "
+"périmètres, si l'option \"Périmètres supplémentaires\" est cochée."
+
+#: xs/src/libslic3r/PrintConfig.cpp:909
+msgid "Post-processing scripts"
+msgstr "Script de Post-processing"
+
+#: xs/src/libslic3r/PrintConfig.cpp:910
+msgid ""
+"If you want to process the output G-code through custom scripts, just list "
+"their absolute paths here. Separate multiple scripts on individual lines. "
+"Scripts will be passed the absolute path to the G-code file as the first "
+"argument, and they can access the Slic3r config settings by reading "
+"environment variables."
+msgstr ""
+"Si vous voulez modifier le G-Code généré à travers des scripts "
+"personnalisés, indiquez simplement leurs chemins absolus ici. Indiquer un "
+"seul script par ligne. Le chemin absolu du G-Code sera passé aux scripts "
+"comme premier argument, et ils peuvent accéder aux options de Slic3r à "
+"travers les variables d'environnement."
+
+#: xs/src/libslic3r/PrintConfig.cpp:924
+#, fuzzy
+msgid "Pressure advance"
+msgstr "Pressure advance"
+
+#: xs/src/libslic3r/PrintConfig.cpp:926
+msgid ""
+"When set to a non-zero value, this experimental option enables pressure "
+"regulation. It's the K constant for the advance algorithm that pushes more "
+"or less filament upon speed changes. It's useful for Bowden-tube extruders. "
+"Reasonable values are in range 0-10."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro, cette option expérimentale "
+"active la régulation de pression. Il s'agit de la constante K pour "
+"l'algorithme qui pousse plus ou moins de filament lors des changement de "
+"vitesse. C'est utile pour les extrudeur de Bowden (à tube). Les valeurs "
+"raisonnables s'étendent de 0 à 10."
+
+#: xs/src/libslic3r/PrintConfig.cpp:932
+msgid "Raft layers"
+msgstr "Couches de raft"
+
+#: xs/src/libslic3r/PrintConfig.cpp:934
+msgid ""
+"The object will be raised by this number of layers, and support material "
+"will be generated under it."
+msgstr ""
+"L'objet sera surélevé de ce nombre de couches, et le support sera généré en "
+"dessous."
+
+#: xs/src/libslic3r/PrintConfig.cpp:941
+msgid "Raft offset"
+msgstr "Décalage du raft"
+
+#: xs/src/libslic3r/PrintConfig.cpp:943
+msgid "Horizontal margin between object base layer and raft contour."
+msgstr ""
+"Marge horizontale entre la première couche de l'objet et le contour du raft."
+
+#: xs/src/libslic3r/PrintConfig.cpp:950
+msgid "Resolution (deprecated)"
+msgstr "Résolution (obsolète)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:951
+msgid ""
+"Minimum detail resolution, used to simplify the input file for speeding up "
+"the slicing job and reducing memory usage. High-resolution models often "
+"carry more detail than printers can render. Set to zero to disable any "
+"simplification and use full resolution from input."
+msgstr ""
+"Résolution minimum pour les détails, utilisée pour simplifier le fichier "
+"d'entrée afin d'augmenter la génération des couches et de réduire "
+"l'utilisation de la mémoire. Les modèles de haute résolution possèdent "
+"souvent des détails que les imprimantes ne peuvent pas imprimer. Mettre à "
+"zéro pour désactiver la simplification et utiliser la résolution maximale."
+
+#: xs/src/libslic3r/PrintConfig.cpp:958
+msgid "Minimum travel after retraction"
+msgstr "Trajet minimum après une rétractation"
+
+#: xs/src/libslic3r/PrintConfig.cpp:959 xs/src/libslic3r/PrintConfig.cpp:971
+#: xs/src/libslic3r/PrintConfig.cpp:982 xs/src/libslic3r/PrintConfig.cpp:1007
+#: xs/src/libslic3r/PrintConfig.cpp:1020 xs/src/libslic3r/PrintConfig.cpp:1033
+#: xs/src/libslic3r/PrintConfig.cpp:1045 xs/src/libslic3r/PrintConfig.cpp:1068
+#: xs/src/libslic3r/PrintConfig.cpp:1548
+msgid "Retraction"
+msgstr "Rétractation"
+
+#: xs/src/libslic3r/PrintConfig.cpp:960
+msgid ""
+"Retraction is not triggered when travel moves are shorter than this length."
+msgstr ""
+"La rétractation n'est pas déclenchée lorsque le déplacement est plus court "
+"que cette distance."
+
+#: xs/src/libslic3r/PrintConfig.cpp:970
+msgid "Retract on layer change"
+msgstr "Rétracter lors des changement de couche"
+
+#: xs/src/libslic3r/PrintConfig.cpp:972
+msgid "This flag enforces a retraction whenever a Z move is done."
+msgstr "Cette option active la rétractation lors d'un déplacement sur l'axe Z."
+
+#: xs/src/libslic3r/PrintConfig.cpp:981 xs/src/libslic3r/PrintConfig.cpp:994
+msgid "Length"
+msgstr "Longueur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:984
+msgid ""
+"When retraction is triggered, filament is pulled back by the specified "
+"amount (the length is measured on raw filament, before it enters the "
+"extruder)."
+msgstr ""
+"Lorsque la rétractation est déclenchée, le filament est retiré par la "
+"longueur indiquée (la longueur est mesurée sur le filament brut, avant qu'il "
+"entre dans l'extrudeur)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:996
+msgid ""
+"When retraction is triggered before changing tool, filament is pulled back "
+"by the specified amount (the length is measured on raw filament, before it "
+"enters the extruder)."
+msgstr ""
+"Lorsque la rétractation est déclenchée avant un changement d'outil, le "
+"filament est retiré par la longueur indiquée (la longueur est mesurée sur le "
+"filament brut, avant qu'il entre dans l'extrudeur)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1006
+msgid "Lift Z"
+msgstr "Sursaut Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1008
+msgid ""
+"If you set this to a positive value, Z is quickly raised every time a "
+"retraction is triggered. When using multiple extruders, only the setting for "
+"the first extruder will be considered."
+msgstr ""
+"Si vous indiquez une valeur positive, l'axe Z est rapidement élevé à chaque "
+"rétractation. Lorsque vous utiliser plusieurs extrudeurs, seuls les réglages "
+"du premier seront pris en compte."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1018
+msgid "Above Z"
+msgstr "Au delà de Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1021
+msgid ""
+"If you set this to a positive value, Z lift will only take place above the "
+"specified absolute Z. You can tune this setting for skipping lift on the "
+"first layers."
+msgstr ""
+"Si vous indiquez une valeur positive, le sursaut Z ne sera déclenché qu'à "
+"partir de la valeur absolue indiquée pour l'axe Z. Vous pouvez modifier ce "
+"réglage pour éviter un sursaut Z sur les premières couches."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1031
+msgid "Below Z"
+msgstr "En deçà de Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1034
+msgid ""
+"If you set this to a positive value, Z lift will only take place below the "
+"specified absolute Z. You can tune this setting for limiting lift to the "
+"first layers."
+msgstr ""
+"Si vous indiquez une valeur positive, le sursaut Z ne sera déclenché que "
+"jusqu'à  la valeur absolue indiquée pour l'axe Z. Vous pouvez modifier ce "
+"réglage pour limiter les sursauts Z aux premières couches."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1044 xs/src/libslic3r/PrintConfig.cpp:1056
+msgid "Extra length on restart"
+msgstr "Longueur supplémentaire à la reprise"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1046
+msgid ""
+"When the retraction is compensated after the travel move, the extruder will "
+"push this additional amount of filament. This setting is rarely needed."
+msgstr ""
+"Lorsque la rétractation est compensée après un déplacement, l'extruder "
+"poussera cette quantité de filament en plus. Ce réglage est rarement "
+"nécessaire."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1057
+msgid ""
+"When the retraction is compensated after changing tool, the extruder will "
+"push this additional amount of filament."
+msgstr ""
+"Lorsque la rétractation est compensée lors d'un changement d'outil, "
+"l'extrudeur poussera cette quantité de filament en plus."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1069
+msgid ""
+"The speed for retractions (it only applies to the extruder motor). If you "
+"use the Firmware Retraction option, please note this value still affects the "
+"auto-speed pressure regulator."
+msgstr ""
+"La vitesse de la rétractation (ne s'applique qu'au moteur de l'extrudeur). "
+"Si vous utiliser la rétractation par firmware, notez que ce réglage "
+"affectera la régulation de pression automatique."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1079
+msgid "Seam position"
+msgstr "Position de la jonction"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1081
+msgid "Position of perimeters starting points."
+msgstr "Position du point de départ des périmètres."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1098
+msgid "USB/serial port for printer connection."
+msgstr "Port USB/Série pour la connexion à l'imprimante."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1107
+msgid "Speed (baud) of USB/serial port for printer connection."
+msgstr "Vitesse (baud) du port USB/Série pour la connexion de l'imprimante."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1117
+msgid "Distance from object"
+msgstr "Distance de l'objet"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1119
+msgid ""
+"Distance between skirt and object(s). Set this to zero to attach the skirt "
+"to the object(s) and get a brim for better adhesion."
+msgstr ""
+"Distance entre le ou les objet(s) et le contour. Mettez zéro pour attacher "
+"le contour a(ux) objet(s) et obtenir un rebord pour une meilleur adhésion."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1126
+msgid "Skirt height"
+msgstr "Hauteur du contour"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1128
+msgid ""
+"Height of skirt expressed in layers. Set this to a tall value to use skirt "
+"as a shield against drafts."
+msgstr ""
+"Hauteur du contour exprimé en couches. Mettez une valeur élevée pour "
+"utiliser le contour comme un bouclier contre les dépots."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1134
+msgid "Loops (minimum)"
+msgstr "Tours (minimum)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1137
+msgid ""
+"Number of loops for the skirt. If the Minimum Extrusion Length option is "
+"set, the number of loops might be greater than the one configured here. Set "
+"this to zero to disable skirt completely."
+msgstr ""
+"Nombre de tours pour le contour. Si la longueur minimum d'extrusion est "
+"indiquée, le nombre de tours minimum sera plus grand que celui configuré "
+"ici. Mettez zéro pour désactiver la génération des contours."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1143
+msgid "Slow down if layer print time is below"
+msgstr "Ralentir si le temps d'impression de la couche est inférieure à"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1144
+msgid ""
+"If layer print time is estimated below this number of seconds, print moves "
+"speed will be scaled down to extend duration to this value."
+msgstr ""
+"Si le temps d'impression de la couche est estimée inférieur au nombre de "
+"secondes indiquées, la vitesse des déplacements sera réduite afin d'arriver "
+"à cette valeur."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1153
+msgid "↳ small"
+msgstr "↳ petit"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1157
+msgid ""
+"This separate setting will affect the speed of perimeters having radius <= "
+"6.5mm (usually holes). If expressed as percentage (for example: 80%) it will "
+"be calculated on the perimeters speed setting above."
+msgstr ""
+"Ce réglage distinct affectera la vitesse des périmètres ayant un rayon <= "
+"6,5mm (habituellement les trous). Si exprimé en pourcentage (par exemple: "
+"80%), elle sera calculée en fonction de la vitesse des périmètres ci-dessus."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1167
+msgid "Solid infill threshold area"
+msgstr "Surface min. pour remplissage solide "
+
+#: xs/src/libslic3r/PrintConfig.cpp:1169
+msgid ""
+"Force solid infill for regions having a smaller area than the specified "
+"threshold."
+msgstr ""
+"Force un remplissage solide pour les zones ayant une surface plus petite que "
+"la valeur indiquée."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1176
+msgid "Solid infill extruder"
+msgstr "Extrudeur pour remplissage solide"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1178
+msgid "The extruder to use when printing solid infill."
+msgstr "L'extrudeur à utiliser lors des remplissages solides."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1184
+msgid "Solid infill every"
+msgstr "Remplissage solide toutes les"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1186
+msgid ""
+"This feature allows to force a solid layer every given number of layers. "
+"Zero to disable. You can set this to any value (for example 9999); Slic3r "
+"will automatically choose the maximum possible number of layers to combine "
+"according to nozzle diameter and layer height."
+msgstr ""
+"Cette fonction permet de forcer un remplissage solide après le nombre de "
+"couches indiqué. Mettez à zéro pour la désactiver. Vous pouvez indiquée "
+"n'importe quelle valeur (par exemple 9999); Slic3r choisira automatiquement "
+"le nombre maximum de couches a combiner en fonction du diamètre de la buse "
+"et de l'épaisseur des couches."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1193 xs/src/libslic3r/PrintConfig.cpp:1206
+msgid "↳ solid"
+msgstr "↳ solide"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1197
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"solid surfaces. If expressed as percentage (for example 90%) it will be "
+"computed over layer height."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro pour indiquée la largeur "
+"d'extrusion pour les remplissages solides. Si exprimé en pourcentage (par "
+"exemple 90%), elle sera calculée en fonction de l'épaisseur des couches."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1210
+msgid ""
+"Speed for printing solid regions (top/bottom/internal horizontal shells). "
+"This can be expressed as a percentage (for example: 80%) over the default "
+"infill speed above."
+msgstr ""
+"Vitesse pour les remplissages solides (haut, bas, parois internes). Si "
+"exprimée en pourcentage (par exemple: 80%), la valeur sera calculée en "
+"fonction de la vitesse de remplissage."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1221
+msgid "Solid layers"
+msgstr "Couches solides"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1222
+msgid "Number of solid layers to generate on top and bottom surfaces."
+msgstr "Nombre de couches solides à générer en haut et en bas."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1229
+msgid "Spiral vase"
+msgstr "Vase spiral"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1231
+msgid ""
+"This feature will raise Z gradually while printing a single-walled object in "
+"order to remove any visible seam. This option requires a single perimeter, "
+"no infill, no top solid layers and no support material. You can still set "
+"any number of bottom solid layers as well as skirt/brim loops. It won't work "
+"when printing more than an object."
+msgstr ""
+"Cette fonction élèvera le Z graduellement tout en imprimant un mur unique, "
+"afin d'enlever toute jonction. Cette option requiert d'avoir un seul "
+"périmètre, pas de remplissage, pas de  surface solide en haut et pas de "
+"support. Vous pouvez toujours choisir n'importe quel nombre de surface "
+"solides en bas ainsi que des contours ou débords. Cela ne fonctionnera pas "
+"si vous imprimez plus d'un objet a la fois."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1236
+msgid "Temperature variation"
+msgstr "Variation de température"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1239
+msgid ""
+"Temperature difference to be applied when an extruder is not active.  "
+"Enables a full-height \"sacrificial\" skirt on which the nozzles are "
+"periodically wiped."
+msgstr ""
+"Différence de température à appliquer lorsqu'un extrudeur est inactif. "
+"Active un contour \"sacrificiel\" sur toute la hauteur de l'objet, sur "
+"lequel les buses sont régulièrement nettoyées."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1247 xs/src/libslic3r/PrintConfig.cpp:1256
+msgid "Start G-code"
+msgstr "G-code de début"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1248
+msgid ""
+"This start procedure is inserted at the beginning, after bed has reached the "
+"target temperature and extruder just started heating, and before extruder "
+"has finished heating. If Slic3r detects M104, M109, M140 or M190 in your "
+"custom codes, such commands will not be prepended automatically so you're "
+"free to customize the order of heating commands and other custom actions. "
+"Note that you can use placeholder variables for all Slic3r settings, so you "
+"can put a \"M109 S[first_layer_temperature]\" command wherever you want."
+msgstr ""
+"Cette procédure est insérée au début, après que le plateau ai atteint sa "
+"température cible et que la chauffe de l'extrudeur ai commencé et avant que "
+"celui-ci n'atteigne sa température cible. Si Slic3r détecte des commandes "
+"M104, M109, M140 ou M190 dans le code personnalisé, de telles commandes ne "
+"seront pas générées ailleur, vous permettant de personnaliser la procédure "
+"de chauffe et autres actions. Vous pouvez utiliser des variables pour tous "
+"les réglages de Slic3r, donc vous pouvez inscrire une commande \"M109 "
+"S[first_layer_temperature]\" où vous voulez."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1257
+msgid ""
+"This start procedure is inserted at the beginning, after any printer start "
+"gcode. This is used to override settings for a specific filament. If Slic3r "
+"detects M104, M109, M140 or M190 in your custom codes, such commands will "
+"not be prepended automatically so you're free to customize the order of "
+"heating commands and other custom actions. Note that you can use placeholder "
+"variables for all Slic3r settings, so you can put a \"M109 "
+"S[first_layer_temperature]\" command wherever you want. If you have multiple "
+"extruders, the gcode is processed in extruder order."
+msgstr ""
+"Cette procédure est insérée au début. Après un code de démarrage de "
+"l'imprimante. Elle est utilisée pour remplacer des réglages pour un filament "
+"spécifique. Si Slic3r détecte des commandes M104, M109, M140 ou M190 dans le "
+"code personnalisé, de telles commandes ne seront pas générées ailleur, vous "
+"permettant de personnaliser la procédure de chauffe et autres actions. Vous "
+"pouvez utiliser des variables pour tous les réglages de Slic3r, donc vous "
+"pouvez inscrire une commande \"M109 S[first_layer_temperature]\" où vous "
+"voulez. Si vous avez plusieurs extrudeurs, le G-Code sera executé dans "
+"l'ordre des extrudeurs."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1269
+msgid "Generate support material"
+msgstr "Générer un support"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1271
+msgid "Enable support material generation."
+msgstr "Active la génération du support"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1276
+msgid "Pattern angle"
+msgstr "Angle du motif"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1278
+msgid ""
+"Use this setting to rotate the support material pattern on the horizontal "
+"plane."
+msgstr ""
+"Utiliser ce réglage pour orienter le motif du support sur le plan horizontal."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1286
+msgid "Support on build plate only"
+msgstr "Support sur le plateau uniquement"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1288
+msgid ""
+"Only create support if it lies on a build plate. Don't create support on a "
+"print."
+msgstr ""
+"Ne crée le support que s'il est posé sur le plateau. Ne crée pas de support "
+"sur l'objet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1294
+msgid "Contact Z distance"
+msgstr "Distance de contact Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1296
+msgid ""
+"The vertical distance between object and support material interface. Setting "
+"this to 0 will also prevent Slic3r from using bridge flow and speed for the "
+"first object layer."
+msgstr ""
+"Distance verticale entre l'objet et l'interface du support. Mettre zéro "
+"empêchera Slic3r d'utiliser la vitesse et le débit pour les ponts pour la "
+"première couche de l'objet."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1307
+msgid "Enforce support for the first"
+msgstr "Forcer le support sur le(s) première(s)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1309
+msgid ""
+"Generate support material for the specified number of layers counting from "
+"bottom, regardless of whether normal support material is enabled or not and "
+"regardless of any angle threshold. This is useful for getting more adhesion "
+"of objects having a very thin or poor footprint on the build plate."
+msgstr ""
+"Génère le support pour le nombre de couches spéficiée a partir du bas, que "
+"les supports soient activés ou non et sans tenir compte de seuils "
+"d'inclinaison. Utile pour obtenir une meilleur adhésion sur des objets ayant "
+"une surface de contact très fine sur le plateau."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1317
+msgid "Support material/raft/skirt extruder"
+msgstr "Extrudeur pour Support/raft/contour extruder"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1319
+msgid "The extruder to use when printing support material, raft and skirt."
+msgstr "L'extrudeur à utiliser pour imprimer les supports, raft et contours."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1328
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for support "
+"material. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro pour indiquer une largeur "
+"d'extrusion pour les supports. Si exprimé en pourcentage (par exemple 90%), "
+"elle sera calculée en fonction de l'épaisseur des couches."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1337
+msgid "Support material/raft interface extruder"
+msgstr "Extrudeur pour les intercalaires du support/raft"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1339
+msgid ""
+"The extruder to use when printing support material interface. This affects "
+"raft too."
+msgstr ""
+"L'extrudeur à utiliser pour imprimer les intercalaire du support. Ceci "
+"affecte également le raft."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1345
+msgid "Interface layers"
+msgstr "Couches intercalaire "
+
+#: xs/src/libslic3r/PrintConfig.cpp:1347
+msgid ""
+"Number of interface layers to insert between the object(s) and support "
+"material."
+msgstr ""
+"Nombre de couches intercalaires à insérer entre objet(s) et le support."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1354
+msgid "Interface pattern spacing"
+msgstr "Espacement du motifs des intercalaires"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1356
+msgid "Spacing between interface lines. Set zero to get a solid interface."
+msgstr ""
+"Espacement entre les lignes de l'intercalaire. Mettre à zéro pour obtenir "
+"une intercalaire solide."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1363
+msgid "↳ interface"
+msgstr "↳ intercalaire"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1364
+msgid "Interface Speed"
+msgstr "Vitesse des intercalaires"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1365
+msgid "Support material interface speed"
+msgstr "Vitesse pour les intercalaires"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1368
+msgid ""
+"Speed for printing support material interface layers. If expressed as "
+"percentage (for example 50%) it will be calculated over support material "
+"speed."
+msgstr ""
+"Vitesse d'impression pour les couches intercalaires. Si exprimée en "
+"pourcentage (par exemple 50%), sera calculée en fonction de la vitesse du "
+"support."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1378
+msgid "Pattern"
+msgstr "Motif"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1380
+msgid "Pattern used to generate support material."
+msgstr "Motif utilisé pour générer le support."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1394
+msgid "Pattern spacing"
+msgstr "Espacement du motif"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1396
+msgid "Spacing between support material lines."
+msgstr "Espacement entre les lignes du motif du support."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1409
+msgid "Speed for printing support material."
+msgstr "Vitesse d'impression du support."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1418
+msgid "Overhang threshold"
+msgstr "Seuil de débord"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1420
+#, c-format
+msgid ""
+"Support material will not be generated for overhangs whose slope angle (90° "
+"= vertical) is above the given threshold. In other words, this value "
+"represent the most horizontal slope (measured from the horizontal plane) "
+"that you can print without support material. Set to a percentage to "
+"automatically detect based on some % of overhanging perimeter width instead "
+"(recommended)."
+msgstr ""
+"Support material will not be generated for overhangs whose slope angle (90° "
+"= vertical) is above the given threshold. In other words, this value "
+"represent the most horizontal slope (measured from the horizontal plane) "
+"that you can print without support material. Set to a percentage to "
+"automatically detect based on some % of overhanging perimeter width instead "
+"(recommended)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1429
+msgid ""
+"Extruder temperature for layers after the first one. Set this to zero to "
+"disable temperature control commands in the output."
+msgstr ""
+"Température de l'extrudeur pour les couches suivant la première. Mettre zéro "
+"pour désactiver les commandes de contrôle de la température dans le fichier "
+"de sortie."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1441
+msgid "Detect thin walls"
+msgstr "Détecter les parois fines"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1443
+msgid ""
+"Detect single-width walls (parts where two extrusions don't fit and we need "
+"to collapse them into a single trace)."
+msgstr ""
+"Détecter les murs de largeur unique (où deux extrusions côte à côte ne "
+"rentrent pas et qui doivent êtres fusionnées en une seule trace)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1448
+msgid "Threads"
+msgstr "Threads"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1449
+msgid ""
+"Threads are used to parallelize long-running tasks. Optimal threads number "
+"is slightly above the number of available cores/processors."
+msgstr ""
+"Les Threads sont utilisés pour paralléliser les calculs. Le nombre optimal "
+"de Threads est largement supérieur au nombre disponibles de coeurs/"
+"processeurs."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1458
+msgid "Tool change G-code"
+msgstr "G-Code changement d'outil"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1459
+msgid ""
+"This custom code is inserted right before every extruder change. Note that "
+"you can use placeholder variables for all Slic3r settings as well as "
+"[previous_extruder] and [next_extruder]."
+msgstr ""
+"Ce code personnalisé est inséré juste avant chaque changement d'extrudeur. "
+"Notez que vous pouvez utiliser des variables pour tous les réglages de "
+"Slic3r ainsi que [previous_extruder] et [next_extruder]."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1467 xs/src/libslic3r/PrintConfig.cpp:1488
+msgid "↳ top solid"
+msgstr "↳ solide supérieur"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1471
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"top surfaces. You may want to use thinner extrudates to fill all narrow "
+"regions and get a smoother finish. If expressed as percentage (for example "
+"90%) it will be computed over layer height."
+msgstr ""
+"Lorsque réglé à une valeur différente de zéro, indique la largeur "
+"d'extrusion pour le remplissage sur les surfaces supérieures. Vous pourriez "
+"vouloir utiliser un extrudât plus fin pour remplir des zones étroites et "
+"obtenir une surface plus précise. Si exprimée en pourcentage (par exemple "
+"90%), elle sera calculée par rapport à l'épaisseur des couches."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1480 xs/src/libslic3r/PrintConfig.cpp:1502
+msgid "Top"
+msgstr "Haut"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1483
+msgid ""
+"Infill pattern for top layers. This only affects the external visible layer, "
+"and not its adjacent solid shells."
+msgstr ""
+"Motif de remplissage pour les couches supérieures. Ceci affecte uniquement "
+"les couches extérieures visibles, et pas les parois solides adjacentes."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1492
+msgid ""
+"Speed for printing top solid layers (it only applies to the uppermost "
+"external layers and not to their internal solid layers). You may want to "
+"slow down this to get a nicer surface finish. This can be expressed as a "
+"percentage (for example: 80%) over the solid infill speed above."
+msgstr ""
+"Vitesse d'impression des couches solides supérieures (elle ne s'applique "
+"qu'a la couche externe et pas aux couches solides internes). Vous pourriez "
+"vouloir ralentir cette zone pour obtenir une surface plus jolie. Elle peut "
+"être exprimée en pourcentage (par exemple 80%) par rapport à la vitesse de "
+"remplissage."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1504
+msgid "Number of solid layers to generate on top surfaces."
+msgstr "Nombre de couches solides à générer sur les surfaces supérieures."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1511
+msgid "Travel"
+msgstr "Déplacement"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1513
+msgid "Speed for travel moves (jumps between distant extrusion points)."
+msgstr ""
+"Vitesse pour les déplacements (trajet entre deux points d'extrusion "
+"distants)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1521
+msgid "Use firmware retraction"
+msgstr "Utiliser la rétractation du firmware"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1522
+msgid ""
+"This experimental setting uses G10 and G11 commands to have the firmware "
+"handle the retraction. This is only supported in recent Marlin."
+msgstr ""
+"Ce réglage expérimental utilise les commandes G10 et G11 pour laisser le "
+"firmware gérer la rétractation. Supporté seulement par les versions récentes "
+"de Marlin."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1527
+msgid "Use relative E distances"
+msgstr "Utiliser des valeurs E relatives"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1528
+msgid ""
+"If your firmware requires relative E values, check this, otherwise leave it "
+"unchecked. Most firmwares use absolute values."
+msgstr ""
+"Si votre firmware requiert des valeurs relatives pour E, cochez cette case. "
+"Sinon laissez-la décochée. La plupart des firmware utilisent des valeurs "
+"absolues."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1533
+msgid "Use volumetric E"
+msgstr "E Volumetrique"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1534
+msgid ""
+"This experimental setting uses outputs the E values in cubic millimeters "
+"instead of linear millimeters. If your firmware doesn't already know "
+"filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] "
+"T0' in your start G-code in order to turn volumetric mode on and use the "
+"filament diameter associated to the filament selected in Slic3r. This is "
+"only supported in recent Marlin."
+msgstr ""
+"Cette fonction expérimentale génère des valeurs de E en milimètres cubique "
+"au lieu de milimètres linéaires. Si votre firmware ne connait pas déjà le "
+"diamètre du filament, vous pouvez écrire une commande comme 'M200 "
+"D[filament_diameter_0] T0'  dans votre G-Code de début pour activer le mode "
+"volumétrique, et utiliser le diamètres du filament associé à celui choisi "
+"dans Slic3r. Seules les versions récentes de Marlin supporte cette fonction."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1539
+msgid "Vibration limit (deprecated)"
+msgstr "Limite de vibration (obsolète)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1540
+msgid ""
+"This experimental option will slow down those moves hitting the configured "
+"frequency limit. The purpose of limiting vibrations is to avoid mechanical "
+"resonance. Set zero to disable."
+msgstr ""
+"Cette fonction expérimentale ralentira les mouvements atteignant la "
+"vibration indiquée. L'intérêt de limiter la vibration est d'éviter une "
+"résonance mécanique. Mettre à zéro pour désactiver."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1547
+msgid "Wipe while retracting"
+msgstr "Essuyer lors des rétractations"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1549
+msgid ""
+"This flag will move the nozzle while retracting to minimize the possible "
+"blob on leaky extruders."
+msgstr ""
+"Cette option déplacement la buse lors des rétractations, minimisant les "
+"création de blob sur des extrudeurs sensibles aux coulures."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1558
+msgid "XY Size Compensation"
+msgstr "Compensation de taille XY"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1560
+msgid ""
+"The object will be grown/shrunk in the XY plane by the configured value "
+"(negative = inwards, positive = outwards). This might be useful for fine-"
+"tuning hole sizes."
+msgstr ""
+"L'objet sera augmenté/réduit sur les plans XY selon la valeur indiquée "
+"(négatif = réduit, positif = agrandi). Ce réglage peut être utile pour un "
+"réglage fin des tailles de trous."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1566
+msgid "Z offset"
+msgstr "Décalage Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1567
+msgid ""
+"This value will be added (or subtracted) from all the Z coordinates in the "
+"output G-code. It is used to compensate for bad Z endstop position: for "
+"example, if your endstop zero actually leaves the nozzle 0.3mm far from the "
+"print bed, set this to -0.3 (or fix your endstop)."
+msgstr ""
+"Cette valeur sera ajoutée (ou soustraite) de toutes les coordonnées Z dans "
+"le G-Code. Elle est utilisée pour compenser une mauvaise position du fin de "
+"course Z: par exemple si votre fin de course place votre buse à 0,3mm au "
+"dessus du plateau, mettez cette valeur a -0.3 (ou corrigez votre fin de "
+"course)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1573
+msgid "Z full steps/mm"
+msgstr "Pas complet/mm pour Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1574
+msgid ""
+"Set this to the number of *full* steps (not microsteps) needed for moving "
+"the Z axis by 1mm; you can calculate this by dividing the number of "
+"microsteps configured in your firmware by the microstepping amount (8, 16, "
+"32). Slic3r will round your configured layer height to the nearest multiple "
+"of that value in order to ensure the best accuracy. This is most useful for "
+"machines with imperial leadscrews or belt-driven Z or for unusual layer "
+"heights with metric leadscrews. Set to zero to disable this experimental "
+"feature."
+msgstr ""
+"Indiquez le nombre de pas complet (pas les micro-steps) pour déplacer l'axe "
+"Z de 1mm; vous pouvez calculer ceci en divisant le nombre de micro-steps "
+"configuré dans votre firmware par le taux de microsteps (8, 16, 32). Slic3r "
+"arrondira l'épaisseur des couches au multiple le plus proche de cette valeur "
+"afin d'assurer une bonne précision. Ceci est principalement utile pour les "
+"machines avec des vis impériales, des axes Z entrainés par courroie ou des "
+"épaisseurs de couches inhabituelle avec des vis métriques. Mettre à zéro "
+"pour désactiver cette fonctionnalité."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1716 xs/src/libslic3r/PrintConfig.cpp:1722
+#: xs/src/libslic3r/PrintConfig.cpp:1728 xs/src/libslic3r/PrintConfig.cpp:1734
+msgid "Cut"
+msgstr "Couper"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1717
+msgid "Cut model at the given Z."
+msgstr "Couper le modèle à la valeur Z indiquée."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1723
+msgid "Cut model in the XY plane into tiles of the specified max size."
+msgstr "Couper le modèle sur les plans XY en morceaux de la taille spécifiée."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1729
+msgid "Cut model at the given X."
+msgstr "Couper le modèle à la valeur X indiquée."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1735
+msgid "Cut model at the given Y."
+msgstr "Couper le modèle à la valeur Y indiquée."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1740 xs/src/libslic3r/PrintConfig.cpp:1752
+msgid "Export SVG"
+msgstr "Exporter en SVG"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1741
+msgid "Export the model as OBJ."
+msgstr "Exporter le modèle en OBJ."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1746
+msgid "Export POV"
+msgstr "Exporter en POV"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1747
+msgid "Export the model as POV-Ray definition."
+msgstr "Exporter le modèle en définitions POV-Ray."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1753
+msgid "Slice the model and export slices as SVG."
+msgstr "Découper le modèle et exporter les tranches en SVG."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1758
+msgid "Output Model Info"
+msgstr "Infos sur le modèle final"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1759
+msgid "Write information about the model to the console."
+msgstr "Écrire des informations sur le modèle dans la console."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1764
+msgid "Load config file"
+msgstr "Charger un fichier de configuration"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1765
+msgid ""
+"Load configuration from the specified file. It can be used more than once to "
+"load options from multiple files."
+msgstr ""
+"Charger un fichier de configuration depuis le disque. Il peut être utilisé "
+"plusieurs fois afin de charger les options depuis plusieurs fichiers."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1770
+msgid "Output File"
+msgstr "Fichier de sortie"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1771
+msgid ""
+"The file where the output will be written (if not specified, it will be "
+"based on the input file)."
+msgstr ""
+"Le fichier où le G-Code sera écrit (si non spéficié, il sera basé sur le "
+"fichier d'entrée)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1776
+msgid "Rotate"
+msgstr "Pivoter"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1777
+msgid "Rotation angle around the Z axis in degrees (0-360, default: 0)."
+msgstr "Angle de rotation autour de l'axe Z en degrés (0-360, défaut: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1782
+msgid "Rotate around X"
+msgstr "Pivoter autour de l'axe X"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1783
+msgid "Rotation angle around the X axis in degrees (0-360, default: 0)."
+msgstr "Angle de rotation autour de l'axe X en degrés (0-360, défaut: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1788
+msgid "Rotate around Y"
+msgstr "Pivoter autour de l'axe Y"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1789
+msgid "Rotation angle around the Y axis in degrees (0-360, default: 0)."
+msgstr "Angle de rotation autour de l'axe Y en degrés (0-360, défaut: 0)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1794
+msgid "Save config file"
+msgstr "Enregistrer fichier de configuration"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1795
+msgid "Save configuration to the specified file."
+msgstr "Enregistre la configuration dans le fichier indiqué."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1800
+msgid "Scale"
+msgstr "Redimensionner"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1801
+msgid "Scaling factor (default: 1)."
+msgstr "Facteur de redimensionnement (défaut: 1)."
+
+#: xs/src/libslic3r/PrintConfig.cpp:1806
+msgid "Scale to Fit"
+msgstr "Redimensionner au volume"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1807
+msgid "Scale to fit the given volume."
+msgstr "Redimensionne afin de rentrer dans le volume indiqué"

--- a/translation/zh_CN.po
+++ b/translation/zh_CN.po
@@ -1,0 +1,1921 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Slic3r\n"
+"POT-Creation-Date: 2017-03-29 00:02-0600\n"
+"PO-Revision-Date: 2017-04-24 10:26+0800\n"
+"Language-Team: Joseph Lenox <lenox.joseph@gmail.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.1\n"
+"X-Poedit-Basepath: ..\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __TRANS;__\n"
+"Last-Translator: \n"
+"Language: zh_CN\n"
+"X-Poedit-SearchPath-0: xs/src/libslic3r\n"
+"X-Poedit-SearchPath-1: xs/xrc/slic3r/GUI\n"
+"X-Poedit-SearchPath-2: xs/xrc/slic3r\n"
+
+#: xs/src/libslic3r/PrintConfig.cpp:18
+msgid "Rectilinear"
+msgstr "折线式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:19
+msgid "Concentric"
+msgstr "同轴式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:20
+msgid "Hilbert Curve"
+msgstr "希尔伯特曲线式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:21
+msgid "Archimedean Chords"
+msgstr "阿基米德和铉式"
+
+# Not so sure about how to put "Octagram Spiral"  in Chinese. Or maybe "Octagram螺旋“ is good.
+#: xs/src/libslic3r/PrintConfig.cpp:22
+msgid "Octagram Spiral"
+msgstr "八角星螺旋式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:27
+msgid "Avoid crossing perimeters"
+msgstr "避免跨越轮廓"
+
+#: xs/src/libslic3r/PrintConfig.cpp:28 xs/src/libslic3r/PrintConfig.cpp:77
+#: xs/src/libslic3r/PrintConfig.cpp:252 xs/src/libslic3r/PrintConfig.cpp:259
+#: xs/src/libslic3r/PrintConfig.cpp:544 xs/src/libslic3r/PrintConfig.cpp:712
+#: xs/src/libslic3r/PrintConfig.cpp:726 xs/src/libslic3r/PrintConfig.cpp:820
+#: xs/src/libslic3r/PrintConfig.cpp:842 xs/src/libslic3r/PrintConfig.cpp:900
+#: xs/src/libslic3r/PrintConfig.cpp:1080 xs/src/libslic3r/PrintConfig.cpp:1230
+#: xs/src/libslic3r/PrintConfig.cpp:1442 xs/src/libslic3r/PrintConfig.cpp:1503
+msgid "Layers and Perimeters"
+msgstr "层和轮廓"
+
+#: xs/src/libslic3r/PrintConfig.cpp:29
+msgid ""
+"Optimize travel moves in order to minimize the crossing of perimeters. This "
+"is mostly useful with Bowden extruders which suffer from oozing. This "
+"feature slows down both the print and the G-code generation."
+msgstr ""
+"为了尽量减少跨越轮廓，优化空程的移动方式。这非常适用于受渗漏问题影响的鲍登挤"
+"出头。此功能会减慢打印速度和 G 代码生成速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:34
+msgid "Bed shape"
+msgstr "机床形状"
+
+#: xs/src/libslic3r/PrintConfig.cpp:44
+msgid "Has heated bed"
+msgstr "有热床"
+
+#: xs/src/libslic3r/PrintConfig.cpp:45
+msgid ""
+"Unselecting this will suppress automatic generation of bed heating gcode."
+msgstr "不勾选此项将不自动生成机床加热的G代码。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:50 xs/src/libslic3r/PrintConfig.cpp:1428
+msgid "Other layers"
+msgstr "其它层"
+
+#: xs/src/libslic3r/PrintConfig.cpp:51
+msgid "Bed temperature for layers after the first one."
+msgstr "第一层之后的机床温度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:53
+msgid "Bed temperature"
+msgstr "机床温度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:59
+msgid "Before layer change G-code"
+msgstr "层改变前的G代码"
+
+#: xs/src/libslic3r/PrintConfig.cpp:60
+msgid ""
+"This custom code is inserted at every layer change, right before the Z move. "
+"Note that you can use placeholder variables for all Slic3r settings as well "
+"as [layer_num] and [layer_z]."
+msgstr ""
+"这段自定义代码在层改变，即Z轴移动前插入。注意除了可以使用[layer_num]和"
+"[layer_z]，也可以使用占位符变量替代所有的slic3r设置。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:68 xs/src/libslic3r/PrintConfig.cpp:76
+msgid "Bottom"
+msgstr "底部"
+
+#: xs/src/libslic3r/PrintConfig.cpp:69
+msgid "Bottom infill pattern"
+msgstr "底部填充样式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:70 xs/src/libslic3r/PrintConfig.cpp:216
+#: xs/src/libslic3r/PrintConfig.cpp:425 xs/src/libslic3r/PrintConfig.cpp:437
+#: xs/src/libslic3r/PrintConfig.cpp:475 xs/src/libslic3r/PrintConfig.cpp:482
+#: xs/src/libslic3r/PrintConfig.cpp:624 xs/src/libslic3r/PrintConfig.cpp:634
+#: xs/src/libslic3r/PrintConfig.cpp:651 xs/src/libslic3r/PrintConfig.cpp:664
+#: xs/src/libslic3r/PrintConfig.cpp:671 xs/src/libslic3r/PrintConfig.cpp:686
+#: xs/src/libslic3r/PrintConfig.cpp:1168 xs/src/libslic3r/PrintConfig.cpp:1185
+#: xs/src/libslic3r/PrintConfig.cpp:1482
+msgid "Infill"
+msgstr "填充"
+
+#: xs/src/libslic3r/PrintConfig.cpp:71
+msgid ""
+"Infill pattern for bottom layers. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+msgstr "底层的填充样式。此项仅影响外部可见层，不影响其相邻的可靠层。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:78
+msgid "Number of solid layers to generate on bottom surfaces."
+msgstr "底部表面生成的可靠层数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:80
+msgid "Bottom solid layers"
+msgstr "底部可靠层"
+
+#: xs/src/libslic3r/PrintConfig.cpp:85
+msgid "Bridge"
+msgstr "桥"
+
+#: xs/src/libslic3r/PrintConfig.cpp:86 xs/src/libslic3r/PrintConfig.cpp:160
+#: xs/src/libslic3r/PrintConfig.cpp:514 xs/src/libslic3r/PrintConfig.cpp:625
+#: xs/src/libslic3r/PrintConfig.cpp:857
+msgid "Speed > Acceleration"
+msgstr "速度 > 加速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:87
+msgid ""
+"This is the acceleration your printer will use for bridges. Set zero to "
+"disable acceleration control for bridges."
+msgstr "此项为打印机在打印桥时的加速度。设为0可以禁用打印桥的加速度控制。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:94
+msgid "Bridges fan speed"
+msgstr "桥风扇速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:95
+msgid "This fan speed is enforced during all bridges and overhangs."
+msgstr "此项为在打印所有桥和悬垂部位时的风扇速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:103
+msgid "Bridge flow ratio"
+msgstr "桥流量比"
+
+#: xs/src/libslic3r/PrintConfig.cpp:104 xs/src/libslic3r/PrintConfig.cpp:147
+#: xs/src/libslic3r/PrintConfig.cpp:678 xs/src/libslic3r/PrintConfig.cpp:1559
+msgid "Advanced"
+msgstr "高级"
+
+#: xs/src/libslic3r/PrintConfig.cpp:105
+msgid ""
+"This factor affects the amount of plastic for bridging. You can decrease it "
+"slightly to pull the extrudates and prevent sagging, although default "
+"settings are usually good and you should experiment with cooling (use a fan) "
+"before tweaking this."
+msgstr ""
+"此因素影响桥接部位的塑料用量。可以略微减少该值以回撤挤出物避免滴垂。但默认设"
+"置通常来说已经可以满足使用，在修改前需通过冷却（使用风扇）进行测试。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:111
+msgid "Bridges"
+msgstr "桥接处"
+
+#: xs/src/libslic3r/PrintConfig.cpp:113 xs/src/libslic3r/PrintConfig.cpp:240
+#: xs/src/libslic3r/PrintConfig.cpp:553 xs/src/libslic3r/PrintConfig.cpp:576
+#: xs/src/libslic3r/PrintConfig.cpp:688 xs/src/libslic3r/PrintConfig.cpp:744
+#: xs/src/libslic3r/PrintConfig.cpp:753 xs/src/libslic3r/PrintConfig.cpp:888
+#: xs/src/libslic3r/PrintConfig.cpp:1067 xs/src/libslic3r/PrintConfig.cpp:1105
+#: xs/src/libslic3r/PrintConfig.cpp:1156 xs/src/libslic3r/PrintConfig.cpp:1209
+#: xs/src/libslic3r/PrintConfig.cpp:1491 xs/src/libslic3r/PrintConfig.cpp:1512
+msgid "Speed"
+msgstr "速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:114
+msgid "Speed for printing bridges."
+msgstr "打印桥接处的速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:124
+msgid "Brim connections width"
+msgstr "裙边连接宽度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:125 xs/src/libslic3r/PrintConfig.cpp:134
+#: xs/src/libslic3r/PrintConfig.cpp:701 xs/src/libslic3r/PrintConfig.cpp:779
+#: xs/src/libslic3r/PrintConfig.cpp:1118 xs/src/libslic3r/PrintConfig.cpp:1127
+#: xs/src/libslic3r/PrintConfig.cpp:1135
+msgid "Skirt and brim"
+msgstr "环边和裙边"
+
+#: xs/src/libslic3r/PrintConfig.cpp:126
+msgid ""
+"If set to a positive value, straight connections will be built on the first "
+"layer between adjacent objects."
+msgstr "如果设为正值，第一层相邻的物体间将建立直接连接。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:133
+msgid "Exterior brim width"
+msgstr "外围裙边宽度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:135
+msgid ""
+"Horizontal width of the brim that will be printed around each object on the "
+"first layer."
+msgstr "第一层每个物体周围打印的裙边水平宽度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:142
+msgid "Compatible printers"
+msgstr "兼容的打印机"
+
+#: xs/src/libslic3r/PrintConfig.cpp:146
+msgid "Complete individual objects"
+msgstr "打印完成单个物体"
+
+#: xs/src/libslic3r/PrintConfig.cpp:148
+msgid ""
+"When printing multiple objects or copies, this feature will complete each "
+"object before moving onto next one (and starting it from its bottom layer). "
+"This feature is useful to avoid the risk of ruined prints. Slic3r should "
+"warn and prevent you from extruder collisions, but beware."
+msgstr ""
+"勾选此项表示当打印多个物体或复制体时，先打印完一整个物体再继续打印后续物体"
+"（从底层开始）。此选项利于避免打毁掉物体。Slic3r应该给出警示，避免挤出头碰"
+"撞，但请小心。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:153
+msgid "Enable auto cooling"
+msgstr "自动冷却使能"
+
+#: xs/src/libslic3r/PrintConfig.cpp:154
+msgid ""
+"This flag enables the automatic cooling logic that adjusts print speed and "
+"fan speed according to layer printing time."
+msgstr "该选项启动自动冷却，使得可根据层打印时间调整打印速度和风扇速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:159
+msgid "Default"
+msgstr "默认"
+
+#: xs/src/libslic3r/PrintConfig.cpp:161
+msgid ""
+"This is the acceleration your printer will be reset to after the role-"
+"specific acceleration values are used (perimeter/infill). Set zero to "
+"prevent resetting acceleration at all."
+msgstr ""
+"该值为打印机在使用了特定的加速度值（如轮廓/填充）后将重置的加速度值。设为0以"
+"防止重置加速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:168
+msgid "Disable fan for the first"
+msgstr "前几层禁用风扇"
+
+#: xs/src/libslic3r/PrintConfig.cpp:169
+msgid ""
+"This disables the fan completely for the first N layers to aid in the "
+"adhesion of media to the bed. (default 3)"
+msgstr "此项在打印前N层时完全禁用风扇，以帮助材料更好地黏合热床。(默认3)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:170
+msgid "layers"
+msgstr "层"
+
+#: xs/src/libslic3r/PrintConfig.cpp:177
+msgid "Don't support bridges"
+msgstr "不支持桥接"
+
+#: xs/src/libslic3r/PrintConfig.cpp:178 xs/src/libslic3r/PrintConfig.cpp:933
+#: xs/src/libslic3r/PrintConfig.cpp:942 xs/src/libslic3r/PrintConfig.cpp:1270
+#: xs/src/libslic3r/PrintConfig.cpp:1277 xs/src/libslic3r/PrintConfig.cpp:1287
+#: xs/src/libslic3r/PrintConfig.cpp:1295 xs/src/libslic3r/PrintConfig.cpp:1308
+#: xs/src/libslic3r/PrintConfig.cpp:1325 xs/src/libslic3r/PrintConfig.cpp:1346
+#: xs/src/libslic3r/PrintConfig.cpp:1355 xs/src/libslic3r/PrintConfig.cpp:1367
+#: xs/src/libslic3r/PrintConfig.cpp:1379 xs/src/libslic3r/PrintConfig.cpp:1395
+#: xs/src/libslic3r/PrintConfig.cpp:1406 xs/src/libslic3r/PrintConfig.cpp:1408
+#: xs/src/libslic3r/PrintConfig.cpp:1419
+msgid "Support material"
+msgstr "支撑材料"
+
+#: xs/src/libslic3r/PrintConfig.cpp:179
+msgid ""
+"Experimental option for preventing support material from being generated "
+"under bridged areas."
+msgstr "试验项，在桥接处禁止生成支撑材料。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:184
+msgid "Distance between copies"
+msgstr "复制物体之间的距离"
+
+#: xs/src/libslic3r/PrintConfig.cpp:185
+msgid "Distance used for the auto-arrange feature of the plater."
+msgstr "自动分布时所使用的距离。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:193 xs/src/libslic3r/PrintConfig.cpp:202
+msgid "End G-code"
+msgstr "结尾G代码"
+
+#: xs/src/libslic3r/PrintConfig.cpp:194
+msgid ""
+"This end procedure is inserted at the end of the output file. Note that you "
+"can use placeholder variables for all Slic3r settings."
+msgstr "该部分将插入到输出文件的结尾。注意可对所有的Slic3r参数使用占位符变量。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:203
+msgid ""
+"This end procedure is inserted at the end of the output file, before the "
+"printer end gcode. Note that you can use placeholder variables for all "
+"Slic3r settings. If you have multiple extruders, the gcode is processed in "
+"extruder order."
+msgstr ""
+"该部分将被插入输出文件的结尾，但在打印机结尾G代码之前。注意可以对所有Slic3r参"
+"数使用占位符变量代替。如果有多个打印头，G代码将按打印头的顺序来处理。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:215
+msgid "Top/bottom fill pattern"
+msgstr "顶部/底部填充样式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:217
+msgid ""
+"Fill pattern for top/bottom infill. This only affects the external visible "
+"layer, and not its adjacent solid shells."
+msgstr "对顶部/底部内部填充的类型。这将影响外围可见层，不影响其相邻的可靠层。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:224 xs/src/libslic3r/PrintConfig.cpp:237
+msgid "↳ external"
+msgstr "↳外部的"
+
+#: xs/src/libslic3r/PrintConfig.cpp:225
+msgid "External perimeters extrusion width"
+msgstr "外围轮廓挤出宽度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:227 xs/src/libslic3r/PrintConfig.cpp:323
+#: xs/src/libslic3r/PrintConfig.cpp:532 xs/src/libslic3r/PrintConfig.cpp:653
+#: xs/src/libslic3r/PrintConfig.cpp:875 xs/src/libslic3r/PrintConfig.cpp:1196
+#: xs/src/libslic3r/PrintConfig.cpp:1327 xs/src/libslic3r/PrintConfig.cpp:1470
+msgid "Extrusion Width"
+msgstr "挤出宽度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:228
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for external "
+"perimeters. If auto is chosen, a value will be used that maximizes accuracy "
+"of the external visible surfaces. If expressed as percentage (for example "
+"200%) it will be computed over layer height."
+msgstr ""
+"该值若非0，意为外围轮廓的手动挤出宽度。如果选择自动，将使用一个使得外围可见层"
+"精度最高的值。如果表示为百分数（如200%），则该值以层高为基准。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:238
+msgid "External perimeters speed"
+msgstr "外围轮廓速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:241
+msgid ""
+"This separate setting will affect the speed of external perimeters (the "
+"visible ones). If expressed as percentage (for example: 80%) it will be "
+"calculated on the perimeters speed setting above."
+msgstr ""
+"该参数将影响外围可见层的打印速度。如果表示为百分数（如80%），数值将以上面设置"
+"的外围速度参数为基准。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:251
+msgid "External perimeters first"
+msgstr "先打印外围轮廓"
+
+#: xs/src/libslic3r/PrintConfig.cpp:253
+msgid ""
+"Print contour perimeters from the outermost one to the innermost one instead "
+"of the default inverse order."
+msgstr "从最外围轮廓向最内部的轮廓打印，而不是反方向。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:258
+msgid "Extra perimeters if needed"
+msgstr "如果需要的话，打印外围轮廓"
+
+#: xs/src/libslic3r/PrintConfig.cpp:260
+msgid "Add more perimeters when needed for avoiding gaps in sloping walls."
+msgstr "为避免在打印倾斜的外墙中产生间隙，有必要时增加更多的轮廓。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:266 xs/src/libslic3r/PrintConfig.cpp:925
+msgid "Extruder"
+msgstr "挤出头"
+
+#: xs/src/libslic3r/PrintConfig.cpp:267 xs/src/libslic3r/PrintConfig.cpp:644
+#: xs/src/libslic3r/PrintConfig.cpp:828 xs/src/libslic3r/PrintConfig.cpp:865
+#: xs/src/libslic3r/PrintConfig.cpp:1177 xs/src/libslic3r/PrintConfig.cpp:1238
+#: xs/src/libslic3r/PrintConfig.cpp:1318 xs/src/libslic3r/PrintConfig.cpp:1338
+msgid "Extruders"
+msgstr "挤出头"
+
+#: xs/src/libslic3r/PrintConfig.cpp:268
+msgid ""
+"The extruder to use (unless more specific extruder settings are specified)."
+msgstr "使用的挤出头（除非指明了更多详细的挤出头参数）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:278
+msgid "Height"
+msgstr "高度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:279
+msgid ""
+"Set this to the vertical distance between your nozzle tip and (usually) the "
+"X carriage rods. In other words, this is the height of the clearance "
+"cylinder around your extruder, and it represents the maximum depth the "
+"extruder can peek before colliding with other printed objects."
+msgstr ""
+"设置为喷嘴尖端和（通常）X架杆之间的垂直距离。换句话说，这是在你的挤出机周围的"
+"空隙气缸的高度，它代表了挤出头在与其他印打印物体碰撞前科达到的最大深度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:286
+msgid "Radius"
+msgstr "半径"
+
+#: xs/src/libslic3r/PrintConfig.cpp:287
+msgid ""
+"Set this to the clearance radius around your extruder. If the extruder is "
+"not centered, choose the largest value for safety. This setting is used to "
+"check for collisions and to display the graphical preview in the plater."
+msgstr ""
+"设置为挤出头周围的空隙半径。如果挤出头未置中，安全起见请选择最大值。该参数用"
+"于检查碰撞，并在界面中显示图形预览。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:294
+msgid "Extruder offset"
+msgstr "挤出头偏置"
+
+#: xs/src/libslic3r/PrintConfig.cpp:295
+msgid ""
+"If your firmware doesn't handle the extruder displacement you need the G-"
+"code to take it into account. This option lets you specify the displacement "
+"of each extruder with respect to the first one. It expects positive "
+"coordinates (they will be subtracted from the XY coordinate)."
+msgstr ""
+"如果你的固件不能处理挤出头的位移量，需要使用G代码将其考虑进去。该选项可让你细"
+"化每个挤出头相对第一个挤出头的位移量。一般为正坐标（它们将从XY坐标相减得"
+"到）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:305
+msgid "Extrusion axis"
+msgstr "挤出轴"
+
+#: xs/src/libslic3r/PrintConfig.cpp:306
+msgid ""
+"Use this option to set the axis letter associated to your printer's extruder "
+"(usually E but some printers use A)."
+msgstr ""
+"使用该项设置你的打印机挤出头的轴所用字母（一般为E，但有的打印机使用A)。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:311
+msgid "Extrusion multiplier"
+msgstr "挤出倍数"
+
+#: xs/src/libslic3r/PrintConfig.cpp:312
+msgid ""
+"This factor changes the amount of flow proportionally. You may need to tweak "
+"this setting to get nice surface finish and correct single wall widths. "
+"Usual values are between 0.9 and 1.1. If you think you need to change this "
+"more, check filament diameter and your firmware E steps."
+msgstr ""
+"该选项按比例改变流量。你可能需要调整该设置来获取更好的表面尾处理，更正单层墙"
+"的宽度。通常值范围在0.9到1.1之间。如果你觉得有必要更改幅度更大，检查丝料直径"
+"和你的固件E步骤。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:321
+msgid "Default extrusion width"
+msgstr "默认挤出宽度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:324
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width. If expressed "
+"as percentage (for example: 230%) it will be computed over layer height."
+msgstr ""
+"该值若为非0，则代表手动挤出宽度。如果设为百分数（如230%），则值是以层高为基"
+"准。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:333
+msgid "Keep fan always on"
+msgstr "保持风扇总是打开"
+
+#: xs/src/libslic3r/PrintConfig.cpp:334
+msgid ""
+"If this is enabled, fan will never be disabled and will be kept running at "
+"least at its minimum speed. Useful for PLA, harmful for ABS."
+msgstr ""
+"勾选此项，风扇将不会被关闭，在整个打印过程中将持续以不低于最低速开启。对于PLA"
+"材料有用，对ABS材料不适用。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:339
+msgid "Enable fan if layer print time is below"
+msgstr "如果打印时间低于该值，则气动风扇"
+
+#: xs/src/libslic3r/PrintConfig.cpp:340
+msgid ""
+"If layer print time is estimated below this number of seconds, fan will be "
+"enabled and its speed will be calculated by interpolating the minimum and "
+"maximum speeds."
+msgstr ""
+"如果估算的打印时间低于该数值（单位为秒），风扇将启用，而且速度值根据插补最小"
+"速度值和最大速度值来计算。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:349
+msgid "Color"
+msgstr "颜色"
+
+#: xs/src/libslic3r/PrintConfig.cpp:350
+msgid "This is only used in the Slic3r interface as a visual help."
+msgstr "仅提供Slic3r界面的视觉帮助。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:360
+msgid "Filament notes"
+msgstr "丝料备注"
+
+#: xs/src/libslic3r/PrintConfig.cpp:361
+msgid "You can put your notes regarding the filament here."
+msgstr "关于材料的备注可放这里。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:373 xs/src/libslic3r/PrintConfig.cpp:752
+msgid "Max volumetric speed"
+msgstr "最大体积速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:374
+msgid ""
+"Maximum volumetric speed allowed for this filament. Limits the maximum "
+"volumetric speed of a print to the minimum of print and filament volumetric "
+"speed. Set to zero for no limit."
+msgstr ""
+"该材料所允许的最大体积速度。把最大体积速度限定为打印速度和材料体积速度的最小"
+"值。设为0则无限制。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:385
+msgid "Diameter"
+msgstr "直径"
+
+#: xs/src/libslic3r/PrintConfig.cpp:386
+msgid ""
+"Enter your filament diameter here. Good precision is required, so use a "
+"caliper and do multiple measurements along the filament, then compute the "
+"average."
+msgstr ""
+"在这里输入你的材料直径。需要较高精度，所以请使用卡尺，沿着材料长丝做多次测"
+"量，计算平均值。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:397
+msgid "Density"
+msgstr "密度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:398
+msgid ""
+"Enter your filament density here. This is only for statistical information. "
+"A decent way is to weigh a known length of filament and compute the ratio of "
+"the length to volume. Better is to calculate the volume directly through "
+"displacement."
+msgstr ""
+"在这里输入你的丝料密度。此仅为统计信息。一个不错的方法是测量一段已知长度丝料"
+"的重量，然后计算体积。更好的方法式直接通过位移计算体积。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:409
+msgid "Cost"
+msgstr "单价"
+
+#: xs/src/libslic3r/PrintConfig.cpp:410
+msgid ""
+"Enter your filament cost per kg here. This is only for statistical "
+"information."
+msgstr "在这里输入丝料每公斤的价格。仅用于统计信息。"
+
+# Set this to be the local currency symbol.
+#: xs/src/libslic3r/PrintConfig.cpp:411
+msgid "money/kg"
+msgstr "¥/kg"
+
+#: xs/src/libslic3r/PrintConfig.cpp:424
+msgid "Fill angle"
+msgstr "填充角度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:426
+msgid ""
+"Default base angle for infill orientation. Cross-hatching will be applied to "
+"this. Bridges will be infilled using the best direction Slic3r can detect, "
+"so this setting does not affect them."
+msgstr ""
+"填充的默认基础方向角。交叉引线适用于此。桥接处将使用Slic3r所侦测的最好方向来"
+"填充，所以此参数不影响它们。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:436
+msgid "Fill density"
+msgstr "填充密度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:438
+msgid "Density of internal infill, expressed in the range 0% - 100%."
+msgstr "内部填充的密度，以0% - 100% 表示。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:474
+msgid "Fill gaps"
+msgstr "填充间隙"
+
+#: xs/src/libslic3r/PrintConfig.cpp:476
+msgid ""
+"If this is enabled, gaps will be filled with single passes. Enable this for "
+"better quality, disable it for shorter printing times."
+msgstr ""
+"如果勾选该项，间隙将被单通道填充。启用该项可优化打印质量，禁用则可以节省时"
+"间。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:481
+msgid "Fill pattern"
+msgstr "填充样式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:483
+msgid "Fill pattern for general low-density infill."
+msgstr "一般低密度填充的填充样式。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:513 xs/src/libslic3r/PrintConfig.cpp:522
+#: xs/src/libslic3r/PrintConfig.cpp:530 xs/src/libslic3r/PrintConfig.cpp:561
+msgid "First layer"
+msgstr "首层"
+
+#: xs/src/libslic3r/PrintConfig.cpp:515
+msgid ""
+"This is the acceleration your printer will use for first layer. Set zero to "
+"disable acceleration control for first layer."
+msgstr "此项为打印机对首层使用的加速度。设为0则对首层禁用加速控制。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:523
+msgid ""
+"Heated build plate temperature for the first layer. Set this to zero to "
+"disable bed temperature control commands in the output."
+msgstr "首层的加热板温度。设为0，可在输出中禁用机床温度控制指令。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:533
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for first "
+"layer. You can use this to force fatter extrudates for better adhesion. If "
+"expressed as percentage (for example 120%) it will be computed over first "
+"layer height."
+msgstr ""
+"若为非0，则表示首层手动挤出宽度。可用于强制更宽的挤出量便于黏着。如果表示为百"
+"分数（如120%），则该值是相对于首层高度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:543
+msgid "First layer height"
+msgstr "首层高度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:545
+msgid ""
+"When printing with very low layer heights, you might still want to print a "
+"thicker bottom layer to improve adhesion and tolerance for non perfect build "
+"plates. This can be expressed as an absolute value or as a percentage (for "
+"example: 150%) over the default layer height."
+msgstr ""
+"当以非常低的层高打印时，对于不太理想的热床来说可能需要打印较厚的底层来提高粘"
+"附效果。该值可被表示为一个绝对值，或者一个相对于默认层高的百分数（如150%）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:552
+msgid "First layer speed"
+msgstr "首层速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:554
+msgid ""
+"If expressed as absolute value in mm/s, this speed will be applied to all "
+"the print moves of the first layer, regardless of their type. If expressed "
+"as a percentage (for example: 40%) it will scale the default speeds."
+msgstr ""
+"如果表示为mm/s的数值，该值将被用于首层的打印动作，无关动作的类型。如果表示为"
+"百分数（如40%），则以默认速度值为基准。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:562
+msgid ""
+"Extruder temperature for first layer. If you want to control temperature "
+"manually during print, set this to zero to disable temperature control "
+"commands in the output file."
+msgstr ""
+"首层挤出头温度。如果要在打印过程中手动控制温度，将该项设为0来禁止输出文件中的"
+"控制命令。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:573
+msgid "↳ gaps"
+msgstr "↳ 间隙"
+
+#: xs/src/libslic3r/PrintConfig.cpp:577
+msgid ""
+"Speed for filling gaps. Since these are usually single lines you might want "
+"to use a low speed for better sticking. If expressed as percentage (for "
+"example: 80%) it will be calculated on the infill speed setting above."
+msgstr ""
+"填充间隙的速度。由于这些通常是独立的直线，所以尽量使用低速来保证黏着。如果表"
+"示为百分数（如80%），则以上面设置的填充速度为基准。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:587
+msgid "Use native G-code arcs"
+msgstr "使用本地的G代码弧线"
+
+#: xs/src/libslic3r/PrintConfig.cpp:588
+msgid ""
+"This experimental feature tries to detect arcs from segments and generates "
+"G2/G3 arc commands instead of multiple straight G1 commands."
+msgstr ""
+"这个试验性能尝试从段中侦测出弧线，生成 G2/G3 弧线指令，而不是生成多个G1直线指"
+"令。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:593
+msgid "Verbose G-code"
+msgstr "详细的G代码"
+
+#: xs/src/libslic3r/PrintConfig.cpp:594
+msgid ""
+"Enable this to get a commented G-code file, with each line explained by a "
+"descriptive text. If you print from SD card, the additional weight of the "
+"file could make your firmware slow down."
+msgstr ""
+"启动该项可获得带注释的G代码文件，每一行都有对应的解释性文字。如果从SD卡打印，"
+"文件冗余部分可能减缓你的固件运行速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:599
+msgid "G-code flavor"
+msgstr "G代码风格"
+
+#: xs/src/libslic3r/PrintConfig.cpp:600
+msgid ""
+"Some G/M-code commands, including temperature control and others, are not "
+"universal. Set this option to your printer's firmware to get a compatible "
+"output. The \"No extrusion\" flavor prevents Slic3r from exporting any "
+"extrusion value at all."
+msgstr ""
+"一些 G/M 代码的指令，包括温度控制和其他，但不通用。将此项设为打印机的固件来获"
+"取兼容性的输出。“无挤出”选项使得Slic3r不输出任何挤出值。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:626
+msgid ""
+"This is the acceleration your printer will use for infill. Set zero to "
+"disable acceleration control for infill."
+msgstr "打印机填充加速度。设为0可禁用填充加速控制。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:633
+msgid "Combine infill every"
+msgstr "每几层联合填充"
+
+#: xs/src/libslic3r/PrintConfig.cpp:635
+msgid ""
+"This feature allows to combine infill and speed up your print by extruding "
+"thicker infill layers while preserving thin perimeters, thus accuracy."
+msgstr ""
+"该功能可通过挤出更厚的填充层来实现联合填充，并加速打印，同时保留了薄壁，也就"
+"保证了精度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:643
+msgid "Infill extruder"
+msgstr "填充挤出头"
+
+#: xs/src/libslic3r/PrintConfig.cpp:645
+msgid "The extruder to use when printing infill."
+msgstr "打印填充时使用的挤出头。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:654
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill. You "
+"may want to use fatter extrudates to speed up the infill and make your parts "
+"stronger. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+msgstr ""
+"该值若为非0，则表示填充的手动挤出宽度。可使用较宽的挤出来加速填充并使部件牢"
+"固。如果表示为百分数（如90%），则该值以层高为基准。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:663
+msgid "Infill before perimeters"
+msgstr "先填充后打印轮廓"
+
+#: xs/src/libslic3r/PrintConfig.cpp:665
+msgid ""
+"This option will switch the print order of perimeters and infill, making the "
+"latter first."
+msgstr "该选项将打印轮廓和填充的方式对调，使后者提前。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:670
+msgid "Only infill where needed"
+msgstr "仅在需要时填充"
+
+#: xs/src/libslic3r/PrintConfig.cpp:672
+msgid ""
+"This option will limit infill to the areas actually needed for supporting "
+"ceilings (it will act as internal support material). If enabled, slows down "
+"the G-code generation due to the multiple checks involved."
+msgstr ""
+"该选项将把填充限定用于支撑天花板（将充当内部支撑材料的作用）。如果启用，由于"
+"多个包含的选项将使G代码生成速度变慢。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:677
+msgid "Infill/perimeters overlap"
+msgstr "填充/轮廓重叠"
+
+#: xs/src/libslic3r/PrintConfig.cpp:679
+msgid ""
+"This setting applies an additional overlap between infill and perimeters for "
+"better bonding. Theoretically this shouldn't be needed, but backlash might "
+"cause gaps. If expressed as percentage (example: 15%) it is calculated over "
+"perimeter extrusion width."
+msgstr ""
+"使得填充和轮廓间有额外的重叠部分，便于结合。理论上并不需要，但偏移可能会导致"
+"间隙。如果表示为百分数（如15%），则以轮廓挤出宽度为基准。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:689
+msgid "Speed for printing the internal fill."
+msgstr "打印内部填充的速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:700
+msgid "Interior brim width"
+msgstr "内部裙边宽度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:702
+msgid ""
+"Horizontal width of the brim that will be printed inside object holes on the "
+"first layer."
+msgstr "第一层打印于物件孔洞内部的裙边宽度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:709
+msgid "Interface shells"
+msgstr "表面外壳"
+
+#: xs/src/libslic3r/PrintConfig.cpp:710
+msgid ""
+"Force the generation of solid shells between adjacent materials/volumes. "
+"Useful for multi-extruder prints with translucent materials or manual "
+"soluble support material."
+msgstr ""
+"在相邻的材料/包围体之间强制生成可靠外壳层。适用于使用半透明材料或手工可溶性支"
+"撑材料的多挤出头打印。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:716
+msgid "After layer change G-code"
+msgstr "层变化后G代码"
+
+#: xs/src/libslic3r/PrintConfig.cpp:717
+msgid ""
+"This custom code is inserted at every layer change, right after the Z move "
+"and before the extruder moves to the first layer point. Note that you can "
+"use placeholder variables for all Slic3r settings as well as [layer_num] and "
+"[layer_z]."
+msgstr ""
+"这段G代码在每一层变化后，即Z轴移动后，挤出头移动到第一层的点之前插入。注意除"
+"了使用如[layer_num]和[layer_z]，也可以使用占位符变量来代替Slic3r的参数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:725
+msgid "Layer height"
+msgstr "层高"
+
+#: xs/src/libslic3r/PrintConfig.cpp:727
+msgid ""
+"This setting controls the height (and thus the total number) of the slices/"
+"layers. Thinner layers give better accuracy but take more time to print."
+msgstr ""
+"该参数控制切片的高度（因此也控制总层数）。较薄的切片可以使精度更高，但花费的"
+"打印时间也更长。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:734
+msgid "Max"
+msgstr "最大值"
+
+#: xs/src/libslic3r/PrintConfig.cpp:735
+msgid "This setting represents the maximum speed of your fan."
+msgstr "该值表示风扇的最大速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:743
+msgid "Max print speed"
+msgstr "最大打印速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:745
+msgid ""
+"When setting other speed settings to 0 Slic3r will autocalculate the optimal "
+"speed in order to keep constant extruder pressure. This experimental setting "
+"is used to set the highest print speed you want to allow."
+msgstr ""
+"当将其他速度参数设为0时，Slic3r会自动计算最优速度以保证挤出头压力稳定。该试验"
+"参数用于设置所允许的最大打印速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:754
+msgid ""
+"This experimental setting is used to set the maximum volumetric speed your "
+"extruder supports."
+msgstr "该实验参数用于设置你的挤出头所支持的最大体积速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:761
+msgid "Min"
+msgstr "最小值"
+
+#: xs/src/libslic3r/PrintConfig.cpp:762
+msgid "This setting represents the minimum PWM your fan needs to work."
+msgstr "该参数表示你的风扇工作的最小PWM。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:770
+msgid "Min print speed"
+msgstr "最小打印速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:771
+msgid "Slic3r will not scale speed down below this speed."
+msgstr "Slic3r的最小打印速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:778
+msgid "Minimum extrusion length"
+msgstr "最大挤出长度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:780
+msgid ""
+"Generate no less than the number of skirt loops required to consume the "
+"specified amount of filament on the bottom layer. For multi-extruder "
+"machines, this minimum applies to each extruder."
+msgstr ""
+"在底层上消耗指定材料量生成环边。对于多挤出头的机器，该最小值适用于每个挤出"
+"头。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:787
+msgid "Configuration notes"
+msgstr "配置备注"
+
+#: xs/src/libslic3r/PrintConfig.cpp:788
+msgid ""
+"You can put here your personal notes. This text will be added to the G-code "
+"header comments."
+msgstr ""
+"你可以在这里输入你的个人备注。该段文字内容将被添加到G代码文件开头的注释里。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:796
+msgid "Nozzle diameter"
+msgstr "喷嘴直径"
+
+#: xs/src/libslic3r/PrintConfig.cpp:797
+msgid ""
+"This is the diameter of your extruder nozzle (for example: 0.5, 0.35 etc.)"
+msgstr "这是你的挤出头喷嘴的直径(：0.5,0.35等。)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:807
+msgid "API Key"
+msgstr "API密钥"
+
+#: xs/src/libslic3r/PrintConfig.cpp:808
+msgid ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"API Key required for authentication."
+msgstr ""
+"Slic3r可以把G代码文件上传至Octoprint。此字段应包含API密钥，用于身份验证。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:813
+msgid "Host or IP"
+msgstr "主机名或IP"
+
+#: xs/src/libslic3r/PrintConfig.cpp:814
+msgid ""
+"Slic3r can upload G-code files to OctoPrint. This field should contain the "
+"hostname or IP address of the OctoPrint instance."
+msgstr ""
+"Slic3r可以把G代码文件上传至Octoprint。此字段应包含OctoPrint实例的主机名称或IP"
+"地址。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:819
+msgid "Only retract when crossing perimeters"
+msgstr "仅在越过轮廓时回缩"
+
+#: xs/src/libslic3r/PrintConfig.cpp:821
+msgid ""
+"Disables retraction when the travel path does not exceed the upper layer's "
+"perimeters (and thus any ooze will be probably invisible)."
+msgstr "当空程不超过上层轮廓时禁用回撤（这样滴垂现象可能会看不见）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:826
+msgid "Enable"
+msgstr "使能"
+
+#: xs/src/libslic3r/PrintConfig.cpp:829
+msgid ""
+"During multi-extruder prints, this option will drop the temperature of the "
+"inactive extruders to prevent oozing. It will enable a tall skirt "
+"automatically and move extruders outside such skirt when changing "
+"temperatures."
+msgstr ""
+"在多挤出头的打印过程中，该选项将降低非活跃挤出头的温度以避免滴垂现象。启动它"
+"将自动使能一个高环边，并在改变温度时将挤出头移除该环边。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:834
+msgid "Output filename format"
+msgstr "输出文件名称格式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:835
+msgid ""
+"You can use all configuration options as variables inside this template. For "
+"example: [layer_height], [fill_density] etc. You can also use [timestamp], "
+"[year], [month], [day], [hour], [minute], [second], [version], "
+"[input_filename], [input_filename_base]."
+msgstr ""
+"可以使用所有的配置选项。如： [layer_height], [fill_density] 等。你也可以使用 "
+"[timestamp], [year], [month], [day], [hour], [minute], [second], [version], "
+"[input_filename], [input_filename_base]。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:841
+msgid "Detect bridging perimeters"
+msgstr "侦测桥接轮廓"
+
+#: xs/src/libslic3r/PrintConfig.cpp:843
+msgid ""
+"Experimental option to adjust flow for overhangs (bridge flow will be used), "
+"to apply bridge speed to them and enable fan."
+msgstr ""
+"试验选项，用于调整悬空部位的流量（使用桥接流量），将桥接速度用于它们并启用风"
+"扇。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:848
+msgid "Overridable options"
+msgstr "可覆盖的选项"
+
+#: xs/src/libslic3r/PrintConfig.cpp:856 xs/src/libslic3r/PrintConfig.cpp:873
+#: xs/src/libslic3r/PrintConfig.cpp:886 xs/src/libslic3r/PrintConfig.cpp:899
+msgid "Perimeters"
+msgstr "轮廓"
+
+#: xs/src/libslic3r/PrintConfig.cpp:858
+msgid ""
+"This is the acceleration your printer will use for perimeters. A high value "
+"like 9000 usually gives good results if your hardware is up to the job. Set "
+"zero to disable acceleration control for perimeters."
+msgstr ""
+"打印机将用于打印轮廓的加速度。如果你的硬件性能足够，一个9000这样的高数值通常"
+"会给出很好的打印效果。设为0将禁用轮廓加速度控制。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:864
+msgid "Perimeter extruder"
+msgstr "轮廓挤出头"
+
+#: xs/src/libslic3r/PrintConfig.cpp:866
+msgid ""
+"The extruder to use when printing perimeters and brim. First extruder is 1."
+msgstr "打印轮廓和裙边所使用的挤出头。第一个挤出头是1。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:876
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for perimeters. "
+"You may want to use thinner extrudates to get more accurate surfaces. If "
+"expressed as percentage (for example 200%) it will be computed over layer "
+"height."
+msgstr ""
+"该值若非0，则表示轮廓的手动基础宽度。可以使用更细的挤出宽度来获得更精确的表"
+"面。如果表示为百分数（如200%），则该值以层高为基准。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:889
+msgid "Speed for perimeters (contours, aka vertical shells)."
+msgstr "轮廓的打印速度（轮廓，又名垂直外壳）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:901
+msgid ""
+"This option sets the number of perimeters to generate for each layer. Note "
+"that Slic3r may increase this number automatically when it detects sloping "
+"surfaces which benefit from a higher number of perimeters if the Extra "
+"Perimeters option is enabled."
+msgstr ""
+"该选项设置每一层生成的轮廓个数。注意，如果”额外轮廓“选项被启动，Slic3r在侦测"
+"到斜坡表面时可能会自动增加该数值，因为较多的轮廓有利于斜坡表面的打印。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:909
+msgid "Post-processing scripts"
+msgstr "后处理脚本"
+
+#: xs/src/libslic3r/PrintConfig.cpp:910
+msgid ""
+"If you want to process the output G-code through custom scripts, just list "
+"their absolute paths here. Separate multiple scripts on individual lines. "
+"Scripts will be passed the absolute path to the G-code file as the first "
+"argument, and they can access the Slic3r config settings by reading "
+"environment variables."
+msgstr ""
+"如果你想要通过自定义脚本来处理输出G代码，在这里列出它们的绝对路径即可。将多个"
+"脚本分行输入。脚本的绝对路径将被以第一个参数传递给G代码文件，而且它们可以通过"
+"读取环境变量来获取Slic3r的配置参数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:924
+msgid "Pressure advance"
+msgstr "压力高级设置"
+
+#: xs/src/libslic3r/PrintConfig.cpp:926
+msgid ""
+"When set to a non-zero value, this experimental option enables pressure "
+"regulation. It's the K constant for the advance algorithm that pushes more "
+"or less filament upon speed changes. It's useful for Bowden-tube extruders. "
+"Reasonable values are in range 0-10."
+msgstr ""
+"若为非0，该试验选项启用压力调节。该值为一个高级算法的K常数。这个算法根据速度"
+"变化来改变推动丝料多少。适用于鲍登管挤出头。合理的值范围是0-10."
+
+#: xs/src/libslic3r/PrintConfig.cpp:932
+msgid "Raft layers"
+msgstr "筏板层"
+
+#: xs/src/libslic3r/PrintConfig.cpp:934
+msgid ""
+"The object will be raised by this number of layers, and support material "
+"will be generated under it."
+msgstr "物体将被该数目的层数抬起，而支撑材料将在其下方生成。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:941
+msgid "Raft offset"
+msgstr "筏偏置"
+
+#: xs/src/libslic3r/PrintConfig.cpp:943
+msgid "Horizontal margin between object base layer and raft contour."
+msgstr "物体基层和筏轮廓之间的水平距离。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:950
+msgid "Resolution (deprecated)"
+msgstr "精度(不赞成)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:951
+msgid ""
+"Minimum detail resolution, used to simplify the input file for speeding up "
+"the slicing job and reducing memory usage. High-resolution models often "
+"carry more detail than printers can render. Set to zero to disable any "
+"simplification and use full resolution from input."
+msgstr ""
+"最小细节分辨率，用来简化输入文件，加速切片，减少内存占用。打印机通常很难渲染"
+"出高精度模型的细节。设为0则禁用任何简化，完全依照输入文件的精度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:958
+msgid "Minimum travel after retraction"
+msgstr "回缩后最小空程"
+
+#: xs/src/libslic3r/PrintConfig.cpp:959 xs/src/libslic3r/PrintConfig.cpp:971
+#: xs/src/libslic3r/PrintConfig.cpp:982 xs/src/libslic3r/PrintConfig.cpp:1007
+#: xs/src/libslic3r/PrintConfig.cpp:1020 xs/src/libslic3r/PrintConfig.cpp:1033
+#: xs/src/libslic3r/PrintConfig.cpp:1045 xs/src/libslic3r/PrintConfig.cpp:1068
+#: xs/src/libslic3r/PrintConfig.cpp:1548
+msgid "Retraction"
+msgstr "回缩"
+
+#: xs/src/libslic3r/PrintConfig.cpp:960
+msgid ""
+"Retraction is not triggered when travel moves are shorter than this length."
+msgstr "当空程短于此长度时不会触发回缩。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:970
+msgid "Retract on layer change"
+msgstr "层变化时回缩"
+
+#: xs/src/libslic3r/PrintConfig.cpp:972
+msgid "This flag enforces a retraction whenever a Z move is done."
+msgstr "该项强制在Z轴移动完成时回缩。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:981 xs/src/libslic3r/PrintConfig.cpp:994
+msgid "Length"
+msgstr "长度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:984
+msgid ""
+"When retraction is triggered, filament is pulled back by the specified "
+"amount (the length is measured on raw filament, before it enters the "
+"extruder)."
+msgstr ""
+"当触发回缩时，丝料以指定值往回收缩（长度以在进入挤出头之前的原始材料为基础进"
+"行计算）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:996
+msgid ""
+"When retraction is triggered before changing tool, filament is pulled back "
+"by the specified amount (the length is measured on raw filament, before it "
+"enters the extruder)."
+msgstr ""
+"当在改变工具前触发回缩时，丝料以指定值回缩（长度以进入挤出头前的原始材料为基"
+"础测量）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1006
+msgid "Lift Z"
+msgstr "抬高Z"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1008
+msgid ""
+"If you set this to a positive value, Z is quickly raised every time a "
+"retraction is triggered. When using multiple extruders, only the setting for "
+"the first extruder will be considered."
+msgstr ""
+"如果设为正值，每当回缩触发时Z轴会快速抬升。当使用多个挤出头时，仅会考虑第一个"
+"挤出头的该参数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1018
+msgid "Above Z"
+msgstr "在Z上方"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1021
+msgid ""
+"If you set this to a positive value, Z lift will only take place above the "
+"specified absolute Z. You can tune this setting for skipping lift on the "
+"first layers."
+msgstr ""
+"如果设为正值，仅在指定的绝对Z值上方才会抬高Z。可以调整该参数，用于跳过在前几"
+"层时跳过Z抬高的步骤。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1031
+msgid "Below Z"
+msgstr "Z下方"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1034
+msgid ""
+"If you set this to a positive value, Z lift will only take place below the "
+"specified absolute Z. You can tune this setting for limiting lift to the "
+"first layers."
+msgstr ""
+"如果设为正值，仅在指定的绝对Z值选房可以调整该参数，用于将抬高Z的动作限制在前"
+"几层时。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1044 xs/src/libslic3r/PrintConfig.cpp:1056
+msgid "Extra length on restart"
+msgstr "重启时额外长度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1046
+msgid ""
+"When the retraction is compensated after the travel move, the extruder will "
+"push this additional amount of filament. This setting is rarely needed."
+msgstr ""
+"当在空程后回缩被补偿时，挤出头会基础额外的指定量丝料。该参数一般不需设置。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1057
+msgid ""
+"When the retraction is compensated after changing tool, the extruder will "
+"push this additional amount of filament."
+msgstr "当在切换工具后回缩被补偿时，挤出头会基础额外的指定量丝料。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1069
+msgid ""
+"The speed for retractions (it only applies to the extruder motor). If you "
+"use the Firmware Retraction option, please note this value still affects the "
+"auto-speed pressure regulator."
+msgstr ""
+"回缩速度（仅适用于挤出头电机）。如果试用了固件回缩选项，请注意该值仍影响自动"
+"速度电压调节器。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1079
+msgid "Seam position"
+msgstr "接合位置"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1081
+msgid "Position of perimeters starting points."
+msgstr "轮廓开始点的位置。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1098
+msgid "USB/serial port for printer connection."
+msgstr "用于打印机连接的USB/串口。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1107
+msgid "Speed (baud) of USB/serial port for printer connection."
+msgstr "用于打印机连接的USB/串口速度（波特率）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1117
+msgid "Distance from object"
+msgstr "离物体的距离"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1119
+msgid ""
+"Distance between skirt and object(s). Set this to zero to attach the skirt "
+"to the object(s) and get a brim for better adhesion."
+msgstr "环边与物体间的距离。设为0，则使环边紧贴物体，可获得裙边利于粘附。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1126
+msgid "Skirt height"
+msgstr "环边高度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1128
+msgid ""
+"Height of skirt expressed in layers. Set this to a tall value to use skirt "
+"as a shield against drafts."
+msgstr "图层中表示的环边高度。设为一个较高值，可将环边用作。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1134
+msgid "Loops (minimum)"
+msgstr "圈数(最小)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1137
+msgid ""
+"Number of loops for the skirt. If the Minimum Extrusion Length option is "
+"set, the number of loops might be greater than the one configured here. Set "
+"this to zero to disable skirt completely."
+msgstr ""
+"环边的圈数。如果设置了最小挤出长度，那么圈数必须比这里设置的值要大。设为0则完"
+"全禁用环边。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1143
+msgid "Slow down if layer print time is below"
+msgstr "如果图层打印时间低于该值则减速"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1144
+msgid ""
+"If layer print time is estimated below this number of seconds, print moves "
+"speed will be scaled down to extend duration to this value."
+msgstr ""
+"如果预计打印时间低于该值（单位为秒），则打印速度将降低以使打印时间延长到该"
+"值。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1153
+msgid "↳ small"
+msgstr "↳ 小"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1157
+msgid ""
+"This separate setting will affect the speed of perimeters having radius <= "
+"6.5mm (usually holes). If expressed as percentage (for example: 80%) it will "
+"be calculated on the perimeters speed setting above."
+msgstr ""
+"该参数影响半径 <= 6.5mm（通常是孔洞）的轮廓打印速度。如果表示为百分比（如"
+"80%），则以上面设置的轮廓速度为基准计算。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1167
+msgid "Solid infill threshold area"
+msgstr "可靠填充阈值区域"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1169
+msgid ""
+"Force solid infill for regions having a smaller area than the specified "
+"threshold."
+msgstr "对于比指定阈值小的区域强制进行可靠填充。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1176
+msgid "Solid infill extruder"
+msgstr "可靠填充挤出头"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1178
+msgid "The extruder to use when printing solid infill."
+msgstr "当打印可靠填充时使用的挤出头。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1184
+msgid "Solid infill every"
+msgstr "每几层可靠填充"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1186
+msgid ""
+"This feature allows to force a solid layer every given number of layers. "
+"Zero to disable. You can set this to any value (for example 9999); Slic3r "
+"will automatically choose the maximum possible number of layers to combine "
+"according to nozzle diameter and layer height."
+msgstr ""
+"该功能使得每指定数目层强制进行一次可靠填充。设为0禁用该功能。可以设为任意值"
+"（如9999）；Slic3r会根据喷嘴直径和层高来自动选择图层的最大可能个数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1193 xs/src/libslic3r/PrintConfig.cpp:1206
+msgid "↳ solid"
+msgstr "↳ 可靠的"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1197
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"solid surfaces. If expressed as percentage (for example 90%) it will be "
+"computed over layer height."
+msgstr ""
+"设为非0值，则表示可靠表面填充的手动挤出宽度。若表示为百分数（如90%），将以层"
+"高为基准计算。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1210
+msgid ""
+"Speed for printing solid regions (top/bottom/internal horizontal shells). "
+"This can be expressed as a percentage (for example: 80%) over the default "
+"infill speed above."
+msgstr ""
+"打印可靠区域的速度（顶部的/底部的/内部水平外壳）。以百分数（如80%）表示，则以"
+"上述的默认填充速度为基准计算。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1221
+msgid "Solid layers"
+msgstr "可靠层数"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1222
+msgid "Number of solid layers to generate on top and bottom surfaces."
+msgstr "在顶部和底部表面生成的可靠层数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1229
+msgid "Spiral vase"
+msgstr "螺旋式容器"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1231
+msgid ""
+"This feature will raise Z gradually while printing a single-walled object in "
+"order to remove any visible seam. This option requires a single perimeter, "
+"no infill, no top solid layers and no support material. You can still set "
+"any number of bottom solid layers as well as skirt/brim loops. It won't work "
+"when printing more than an object."
+msgstr ""
+"该功能使得在打印单壁物体时会逐渐抬升Z，以便移除可见的缝合点。该选项要求单轮"
+"廓，无填充，无顶部可靠层，无支撑。仍可以设置环边、裙边圈数，和底部可靠层。但"
+"在打印多个物体时不适用。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1236
+msgid "Temperature variation"
+msgstr "温度变化"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1239
+msgid ""
+"Temperature difference to be applied when an extruder is not active.  "
+"Enables a full-height \"sacrificial\" skirt on which the nozzles are "
+"periodically wiped."
+msgstr ""
+"当挤出头处于非活跃状态时用到的温度差。启用一个全高度的环边，纯用于定期给喷嘴"
+"擦拭。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1247 xs/src/libslic3r/PrintConfig.cpp:1256
+msgid "Start G-code"
+msgstr "起始G代码"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1248
+msgid ""
+"This start procedure is inserted at the beginning, after bed has reached the "
+"target temperature and extruder just started heating, and before extruder "
+"has finished heating. If Slic3r detects M104, M109, M140 or M190 in your "
+"custom codes, such commands will not be prepended automatically so you're "
+"free to customize the order of heating commands and other custom actions. "
+"Note that you can use placeholder variables for all Slic3r settings, so you "
+"can put a \"M109 S[first_layer_temperature]\" command wherever you want."
+msgstr ""
+"该段代码放在G代码开头，在热床达到目标温度、挤出头开始加热后，挤出头完成加热前"
+"插入。如果其中不包含有M104, M109, M140 或 M190，这段指令就会在Slic3r自动放置"
+"的M指令之后；否则Slic3r将不会自动生成M指令，这样你可以自由定义加热命令和其他"
+"自定义动作的顺序。注意可以使用占位符变量替代所有Slic3r参数，所以你可以把一"
+"个“M109 S[ first_layer_temperature ]”命令放在任意处。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1257
+msgid ""
+"This start procedure is inserted at the beginning, after any printer start "
+"gcode. This is used to override settings for a specific filament. If Slic3r "
+"detects M104, M109, M140 or M190 in your custom codes, such commands will "
+"not be prepended automatically so you're free to customize the order of "
+"heating commands and other custom actions. Note that you can use placeholder "
+"variables for all Slic3r settings, so you can put a \"M109 "
+"S[first_layer_temperature]\" command wherever you want. If you have multiple "
+"extruders, the gcode is processed in extruder order."
+msgstr ""
+"该段代码放在G代码开头，在所有打印机起始G代码后插入。用于覆盖指定材料的参数。"
+"该段代码放在G代码开头，在热床达到目标温度、挤出头开始加热后，挤出头完成加热前"
+"插入。如果其中不包含有M104, M109, M140 或 M190，这段指令就会在Slic3r自动放置"
+"的M指令之后；否则Slic3r将不会自动生成M指令，这样你可以自由定义加热命令和其他"
+"自定义动作的顺序。注意可以使用占位符变量替代所有Slic3r参数，所以你可以把一"
+"个“M109 S[ first_layer_temperature ]”命令放在任意处。如果你有多个挤出头，G代"
+"码将按挤出头顺序处理。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1269
+msgid "Generate support material"
+msgstr "生成支撑材料"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1271
+msgid "Enable support material generation."
+msgstr "启用支撑材料生成功能。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1276
+msgid "Pattern angle"
+msgstr "样式角度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1278
+msgid ""
+"Use this setting to rotate the support material pattern on the horizontal "
+"plane."
+msgstr "使用该参数对支撑材料的样子在水平面上进行旋转。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1286
+msgid "Support on build plate only"
+msgstr "仅在热床上生成支撑"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1288
+msgid ""
+"Only create support if it lies on a build plate. Don't create support on a "
+"print."
+msgstr "仅在热床上生成支撑，不在打印出来的物体上生成。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1294
+msgid "Contact Z distance"
+msgstr "接触Z值"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1296
+msgid ""
+"The vertical distance between object and support material interface. Setting "
+"this to 0 will also prevent Slic3r from using bridge flow and speed for the "
+"first object layer."
+msgstr ""
+"物体和支撑材料平面之间的垂直距离。设为0，则表面上第一层不会被当做桥来处理。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1307
+msgid "Enforce support for the first"
+msgstr "前几层增强支撑"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1309
+msgid ""
+"Generate support material for the specified number of layers counting from "
+"bottom, regardless of whether normal support material is enabled or not and "
+"regardless of any angle threshold. This is useful for getting more adhesion "
+"of objects having a very thin or poor footprint on the build plate."
+msgstr ""
+"从底部开始，对指定数目的图层生成支撑材料，无论正常的支撑材料是否启用，也不管"
+"任何角度阈值。适用于在热床上脚太细、站不住的物件，便于更好的粘附。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1317
+msgid "Support material/raft/skirt extruder"
+msgstr "支撑材料/筏/环边挤出头"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1319
+msgid "The extruder to use when printing support material, raft and skirt."
+msgstr "打印支撑材料、筏和环边时使用的挤出头。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1328
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for support "
+"material. If expressed as percentage (for example 90%) it will be computed "
+"over layer height."
+msgstr ""
+"设为非0值，表示对支撑材料的手动挤出宽度。如果表示为百分数（如90%），则以层高"
+"为基准计算。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1337
+msgid "Support material/raft interface extruder"
+msgstr "支撑材料/筏表面挤出头"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1339
+msgid ""
+"The extruder to use when printing support material interface. This affects "
+"raft too."
+msgstr "打印支撑材料表面时使用的挤出头。也影响筏。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1345
+msgid "Interface layers"
+msgstr "表面层数"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1347
+msgid ""
+"Number of interface layers to insert between the object(s) and support "
+"material."
+msgstr "在物体和支撑材料中间插入的表面层数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1354
+msgid "Interface pattern spacing"
+msgstr "表面样式间隔"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1356
+msgid "Spacing between interface lines. Set zero to get a solid interface."
+msgstr "表面直线间的间隔。设为0获得可靠表面。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1363
+msgid "↳ interface"
+msgstr "↳ 表面"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1364
+msgid "Interface Speed"
+msgstr "表面速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1365
+msgid "Support material interface speed"
+msgstr "支撑材料表面速度"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1368
+msgid ""
+"Speed for printing support material interface layers. If expressed as "
+"percentage (for example 50%) it will be calculated over support material "
+"speed."
+msgstr ""
+"打印支撑材料表面层的速度。若表示为百分数（如50%），则以支撑材料速度为基准计"
+"算。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1378
+msgid "Pattern"
+msgstr "样式"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1380
+msgid "Pattern used to generate support material."
+msgstr "生成支撑材料的样式。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1394
+msgid "Pattern spacing"
+msgstr "样式间隔"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1396
+msgid "Spacing between support material lines."
+msgstr "支撑材料直线间的间隙。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1409
+msgid "Speed for printing support material."
+msgstr "打印支撑材料的速度。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1418
+msgid "Overhang threshold"
+msgstr "悬空阈值"
+
+# "% o“ format mistake?
+#: xs/src/libslic3r/PrintConfig.cpp:1420
+#, c-format
+msgid ""
+"Support material will not be generated for overhangs whose slope angle (90° "
+"= vertical) is above the given threshold. In other words, this value "
+"represent the most horizontal slope (measured from the horizontal plane) "
+"that you can print without support material. Set to a percentage to "
+"automatically detect based on some % of overhanging perimeter width instead "
+"(recommended)."
+msgstr ""
+"对于倾斜度（90° = 垂直）高于指定阈值的悬空部位，不生成相应的支撑材料。换句话"
+"说，该值表示不用支撑材料所能打印的最水平的角度。设为百分数，则以悬空轮廓宽度"
+"的 % o自动计算（推荐）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1429
+msgid ""
+"Extruder temperature for layers after the first one. Set this to zero to "
+"disable temperature control commands in the output."
+msgstr "第一层之后的挤出头温度。设为0以在输出文件中禁用温度控制指令。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1441
+msgid "Detect thin walls"
+msgstr "检测薄壁"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1443
+msgid ""
+"Detect single-width walls (parts where two extrusions don't fit and we need "
+"to collapse them into a single trace)."
+msgstr ""
+"检测单一厚度的薄壁（两个挤出量不吻合，以至于需要把它们压缩成一条轨迹的地"
+"方）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1448
+msgid "Threads"
+msgstr "线程"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1449
+msgid ""
+"Threads are used to parallelize long-running tasks. Optimal threads number "
+"is slightly above the number of available cores/processors."
+msgstr "线程用于并行处理长时间任务。最优的线程数应比可用核/处理器的数目略多。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1458
+msgid "Tool change G-code"
+msgstr "切换工具G代码"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1459
+msgid ""
+"This custom code is inserted right before every extruder change. Note that "
+"you can use placeholder variables for all Slic3r settings as well as "
+"[previous_extruder] and [next_extruder]."
+msgstr ""
+"该段自定义代码在每次挤出头切换前插入。注意可以使用占位符变量代替Slic3r的所有"
+"参数，如 [previous_extruder] 和 [next_extruder]。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1467 xs/src/libslic3r/PrintConfig.cpp:1488
+msgid "↳ top solid"
+msgstr "↳ 顶部可靠层"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1471
+msgid ""
+"Set this to a non-zero value to set a manual extrusion width for infill for "
+"top surfaces. You may want to use thinner extrudates to fill all narrow "
+"regions and get a smoother finish. If expressed as percentage (for example "
+"90%) it will be computed over layer height."
+msgstr ""
+"设为非0值，表示顶层表面填充的手动挤出宽度。可以使用较细的挤出宽度来对所有的狭"
+"长区域进行填充并获得较光滑的尾部。如果表示为百分数（如90%），则以层高为基准计"
+"算。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1480 xs/src/libslic3r/PrintConfig.cpp:1502
+msgid "Top"
+msgstr "顶部"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1483
+msgid ""
+"Infill pattern for top layers. This only affects the external visible layer, "
+"and not its adjacent solid shells."
+msgstr "顶层填充样式。仅影响外部可见层，不影响其相邻可靠层。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1492
+msgid ""
+"Speed for printing top solid layers (it only applies to the uppermost "
+"external layers and not to their internal solid layers). You may want to "
+"slow down this to get a nicer surface finish. This can be expressed as a "
+"percentage (for example: 80%) over the solid infill speed above."
+msgstr ""
+"打印顶部可靠层的速度（仅适用于最外部的顶层，而非它们的内部可靠填充层）。可降"
+"低该速度值以获得较好的表面尾处理。若表示为百分数（如80%），则以可靠填充速度为"
+"基准计算。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1504
+msgid "Number of solid layers to generate on top surfaces."
+msgstr "在顶部表面上生成的可靠层数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1511
+msgid "Travel"
+msgstr "空程"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1513
+msgid "Speed for travel moves (jumps between distant extrusion points)."
+msgstr "空程移动的速度（从一个挤出点结束调到另一个挤出点开始）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1521
+msgid "Use firmware retraction"
+msgstr "使用固件回缩"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1522
+msgid ""
+"This experimental setting uses G10 and G11 commands to have the firmware "
+"handle the retraction. This is only supported in recent Marlin."
+msgstr ""
+"该试验参数使用G10和G11指令来使固件处理回缩。仅在最新的Marlin中支持该功能。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1527
+msgid "Use relative E distances"
+msgstr "使用相对E距离"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1528
+msgid ""
+"If your firmware requires relative E values, check this, otherwise leave it "
+"unchecked. Most firmwares use absolute values."
+msgstr "如果固件需要相对E值，勾选此项，否则不要勾选。大部分固件使用绝对值。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1533
+msgid "Use volumetric E"
+msgstr "使用体积E"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1534
+msgid ""
+"This experimental setting uses outputs the E values in cubic millimeters "
+"instead of linear millimeters. If your firmware doesn't already know "
+"filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] "
+"T0' in your start G-code in order to turn volumetric mode on and use the "
+"filament diameter associated to the filament selected in Slic3r. This is "
+"only supported in recent Marlin."
+msgstr ""
+"该试验参数在E值中使用立方米为单位，而非毫米。如果固件不知道丝料直径，你可以在"
+"起始G代码中输入如'M200 D[filament_diameter_0] T0' 以开启体积模式，并使用在"
+"Slic3r中已选的丝料直径。仅在最新Marlin中支持该功能。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1539
+msgid "Vibration limit (deprecated)"
+msgstr "振动限制(赞成)"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1540
+msgid ""
+"This experimental option will slow down those moves hitting the configured "
+"frequency limit. The purpose of limiting vibrations is to avoid mechanical "
+"resonance. Set zero to disable."
+msgstr ""
+"该试验选项将减缓达到指定频率值的打印动作。目的为避免机械共振。设为0以禁用。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1547
+msgid "Wipe while retracting"
+msgstr "回缩时擦拭"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1549
+msgid ""
+"This flag will move the nozzle while retracting to minimize the possible "
+"blob on leaky extruders."
+msgstr "在回缩时移动喷嘴以避免挤出头滴漏。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1558
+msgid "XY Size Compensation"
+msgstr "XY尺寸补偿"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1560
+msgid ""
+"The object will be grown/shrunk in the XY plane by the configured value "
+"(negative = inwards, positive = outwards). This might be useful for fine-"
+"tuning hole sizes."
+msgstr ""
+"该物体将以指定值（负=往内，正=往外）变大/收缩。对于精确调节孔洞尺寸可能有用。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1566
+msgid "Z offset"
+msgstr "Z补偿"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1567
+msgid ""
+"This value will be added (or subtracted) from all the Z coordinates in the "
+"output G-code. It is used to compensate for bad Z endstop position: for "
+"example, if your endstop zero actually leaves the nozzle 0.3mm far from the "
+"print bed, set this to -0.3 (or fix your endstop)."
+msgstr ""
+"在输出G代码中，所有Z坐标将在原基础上增大（或减少）该数值。用来对糟糕的Z终点挡"
+"板位置进行补偿，如果你的终点挡板为零时，喷嘴离打印热床还有0.3毫米，将该值设"
+"为-0.3（或者调整你的终点挡板）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1573
+msgid "Z full steps/mm"
+msgstr "Z全部步数/毫米"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1574
+msgid ""
+"Set this to the number of *full* steps (not microsteps) needed for moving "
+"the Z axis by 1mm; you can calculate this by dividing the number of "
+"microsteps configured in your firmware by the microstepping amount (8, 16, "
+"32). Slic3r will round your configured layer height to the nearest multiple "
+"of that value in order to ensure the best accuracy. This is most useful for "
+"machines with imperial leadscrews or belt-driven Z or for unusual layer "
+"heights with metric leadscrews. Set to zero to disable this experimental "
+"feature."
+msgstr ""
+"将该值设为移动Z轴1毫米所需的*全部*步数（而不是细分）；可以这样计算：把固件中"
+"已配置的细分数除以倍增系数（8，16，32）。Sli3r会把你设置的层高四舍五入到该值"
+"的最近倍数以确保精度。此项设置对于使用英制丝杠、皮带传动Z轴的机器，或者机器使"
+"用公制丝杠且层高值特别时比较适用。设为0以禁用该功能。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1716 xs/src/libslic3r/PrintConfig.cpp:1722
+#: xs/src/libslic3r/PrintConfig.cpp:1728 xs/src/libslic3r/PrintConfig.cpp:1734
+msgid "Cut"
+msgstr "切割"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1717
+msgid "Cut model at the given Z."
+msgstr "在给定Z处切割模型。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1723
+msgid "Cut model in the XY plane into tiles of the specified max size."
+msgstr "将XY面的模型切割成指定最大尺寸的小块。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1729
+msgid "Cut model at the given X."
+msgstr "在指定X处切割模型。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1735
+msgid "Cut model at the given Y."
+msgstr "在指定Y处切割模型。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1740 xs/src/libslic3r/PrintConfig.cpp:1752
+msgid "Export SVG"
+msgstr "导出SVG"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1741
+msgid "Export the model as OBJ."
+msgstr "将模型以OBJ格式导出。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1746
+msgid "Export POV"
+msgstr "导出POV"
+
+# POV-Ray?
+#: xs/src/libslic3r/PrintConfig.cpp:1747
+msgid "Export the model as POV-Ray definition."
+msgstr ""
+"将模型以POV-Ray定义导出。（参见开源射线描迹软件：http://www.povray.org/）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1753
+msgid "Slice the model and export slices as SVG."
+msgstr "切割模型并以SVG格式导出切片结果。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1758
+msgid "Output Model Info"
+msgstr "输出模型信息"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1759
+msgid "Write information about the model to the console."
+msgstr "给控制台写入模型的信息。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1764
+msgid "Load config file"
+msgstr "加载配置文件"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1765
+msgid ""
+"Load configuration from the specified file. It can be used more than once to "
+"load options from multiple files."
+msgstr "从指定文件加载配置。可多次使用以从多个文件中加载参数。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1770
+msgid "Output File"
+msgstr "输出文件"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1771
+msgid ""
+"The file where the output will be written (if not specified, it will be "
+"based on the input file)."
+msgstr "输出的文件（如果未指定，则将依据输入文件）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1776
+msgid "Rotate"
+msgstr "旋转"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1777
+msgid "Rotation angle around the Z axis in degrees (0-360, default: 0)."
+msgstr "绕Z轴旋转角度（0-360，默认：0）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1782
+msgid "Rotate around X"
+msgstr "绕X轴旋转"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1783
+msgid "Rotation angle around the X axis in degrees (0-360, default: 0)."
+msgstr "绕X轴旋转角度（0-360，默认：0）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1788
+msgid "Rotate around Y"
+msgstr "绕Y轴旋转"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1789
+msgid "Rotation angle around the Y axis in degrees (0-360, default: 0)."
+msgstr "绕Y轴旋转角度（0-360，默认：0）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1794
+msgid "Save config file"
+msgstr "保存配置文件"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1795
+msgid "Save configuration to the specified file."
+msgstr "将配置参数保存到指定文件。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1800
+msgid "Scale"
+msgstr "缩放"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1801
+msgid "Scaling factor (default: 1)."
+msgstr "缩放比例（默认：1）。"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1806
+msgid "Scale to Fit"
+msgstr "缩放到合适大小"
+
+#: xs/src/libslic3r/PrintConfig.cpp:1807
+msgid "Scale to fit the given volume."
+msgstr "缩放到适合于给定体积。"

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -15,23 +15,23 @@ PrintConfigDef::PrintConfigDef()
     external_fill_pattern.enum_values.push_back("hilbertcurve");
     external_fill_pattern.enum_values.push_back("archimedeanchords");
     external_fill_pattern.enum_values.push_back("octagramspiral");
-    external_fill_pattern.enum_labels.push_back("Rectilinear");
-    external_fill_pattern.enum_labels.push_back("Concentric");
-    external_fill_pattern.enum_labels.push_back("Hilbert Curve");
-    external_fill_pattern.enum_labels.push_back("Archimedean Chords");
-    external_fill_pattern.enum_labels.push_back("Octagram Spiral");
+    external_fill_pattern.enum_labels.push_back(__TRANS("Rectilinear"));
+    external_fill_pattern.enum_labels.push_back(__TRANS("Concentric"));
+    external_fill_pattern.enum_labels.push_back(__TRANS("Hilbert Curve"));
+    external_fill_pattern.enum_labels.push_back(__TRANS("Archimedean Chords"));
+    external_fill_pattern.enum_labels.push_back(__TRANS("Octagram Spiral"));
     
     ConfigOptionDef* def;
     
     def = this->add("avoid_crossing_perimeters", coBool);
-    def->label = "Avoid crossing perimeters";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Optimize travel moves in order to minimize the crossing of perimeters. This is mostly useful with Bowden extruders which suffer from oozing. This feature slows down both the print and the G-code generation.";
+    def->label = __TRANS("Avoid crossing perimeters");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Optimize travel moves in order to minimize the crossing of perimeters. This is mostly useful with Bowden extruders which suffer from oozing. This feature slows down both the print and the G-code generation.");
     def->cli = "avoid-crossing-perimeters!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("bed_shape", coPoints);
-    def->label = "Bed shape";
+    def->label = __TRANS("Bed shape");
     {
         ConfigOptionPoints* opt = new ConfigOptionPoints();
         opt->values.push_back(Pointf(0,0));
@@ -41,23 +41,23 @@ PrintConfigDef::PrintConfigDef()
         def->default_value = opt;
     }
     def = this->add("has_heatbed", coBool);
-    def->label = "Has heated bed";
-    def->tooltip = "Unselecting this will suppress automatic generation of bed heating gcode.";
+    def->label = __TRANS("Has heated bed");
+    def->tooltip = __TRANS("Unselecting this will suppress automatic generation of bed heating gcode.");
     def->cli = "has_heatbed!";
     def->default_value = new ConfigOptionBool(true);
     
     def = this->add("bed_temperature", coInt);
-    def->label = "Other layers";
-    def->tooltip = "Bed temperature for layers after the first one.";
+    def->label = __TRANS("Other layers");
+    def->tooltip = __TRANS("Bed temperature for layers after the first one.");
     def->cli = "bed-temperature=i";
-    def->full_label = "Bed temperature";
+    def->full_label = __TRANS("Bed temperature");
     def->min = 0;
     def->max = 300;
     def->default_value = new ConfigOptionInt(0);
 
     def = this->add("before_layer_gcode", coString);
-    def->label = "Before layer change G-code";
-    def->tooltip = "This custom code is inserted at every layer change, right before the Z move. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num] and [layer_z].";
+    def->label = __TRANS("Before layer change G-code");
+    def->tooltip = __TRANS("This custom code is inserted at every layer change, right before the Z move. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num] and [layer_z].");
     def->cli = "before-layer-gcode=s";
     def->multiline = true;
     def->full_width = true;
@@ -65,34 +65,34 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionString("");
 
     def = this->add("bottom_infill_pattern", external_fill_pattern);
-    def->label = "Bottom";
-    def->full_label = "Bottom infill pattern";
-    def->category = "Infill";
-    def->tooltip = "Infill pattern for bottom layers. This only affects the external visible layer, and not its adjacent solid shells.";
+    def->label = __TRANS("Bottom");
+    def->full_label = __TRANS("Bottom infill pattern");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("Infill pattern for bottom layers. This only affects the external visible layer, and not its adjacent solid shells.");
     def->cli = "bottom-infill-pattern=s";
     def->default_value = new ConfigOptionEnum<InfillPattern>(ipRectilinear);
 
     def = this->add("bottom_solid_layers", coInt);
-    def->label = "Bottom";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Number of solid layers to generate on bottom surfaces.";
+    def->label = __TRANS("Bottom");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Number of solid layers to generate on bottom surfaces.");
     def->cli = "bottom-solid-layers=i";
-    def->full_label = "Bottom solid layers";
+    def->full_label = __TRANS("Bottom solid layers");
     def->min = 0;
     def->default_value = new ConfigOptionInt(3);
 
     def = this->add("bridge_acceleration", coFloat);
-    def->label = "Bridge";
-    def->category = "Speed > Acceleration";
-    def->tooltip = "This is the acceleration your printer will use for bridges. Set zero to disable acceleration control for bridges.";
+    def->label = __TRANS("Bridge");
+    def->category = __TRANS("Speed > Acceleration");
+    def->tooltip = __TRANS("This is the acceleration your printer will use for bridges. Set zero to disable acceleration control for bridges.");
     def->sidetext = "mm/s²";
     def->cli = "bridge-acceleration=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("bridge_fan_speed", coInt);
-    def->label = "Bridges fan speed";
-    def->tooltip = "This fan speed is enforced during all bridges and overhangs.";
+    def->label = __TRANS("Bridges fan speed");
+    def->tooltip = __TRANS("This fan speed is enforced during all bridges and overhangs.");
     def->sidetext = "%";
     def->cli = "bridge-fan-speed=i";
     def->min = 0;
@@ -100,18 +100,18 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(100);
 
     def = this->add("bridge_flow_ratio", coFloat);
-    def->label = "Bridge flow ratio";
-    def->category = "Advanced";
-    def->tooltip = "This factor affects the amount of plastic for bridging. You can decrease it slightly to pull the extrudates and prevent sagging, although default settings are usually good and you should experiment with cooling (use a fan) before tweaking this.";
+    def->label = __TRANS("Bridge flow ratio");
+    def->category = __TRANS("Advanced");
+    def->tooltip = __TRANS("This factor affects the amount of plastic for bridging. You can decrease it slightly to pull the extrudates and prevent sagging, although default settings are usually good and you should experiment with cooling (use a fan) before tweaking this.");
     def->cli = "bridge-flow-ratio=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(1);
 
     def = this->add("bridge_speed", coFloat);
-    def->label = "Bridges";
+    def->label = __TRANS("Bridges");
     def->gui_type = "f_enum_open";
-    def->category = "Speed";
-    def->tooltip = "Speed for printing bridges.";
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("Speed for printing bridges.");
     def->sidetext = "mm/s";
     def->cli = "bridge-speed=f";
     def->aliases.push_back("bridge_feed_rate");
@@ -121,68 +121,68 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloat(60);
 
     def = this->add("brim_connections_width", coFloat);
-    def->label = "Brim connections width";
-    def->category = "Skirt and brim";
-    def->tooltip = "If set to a positive value, straight connections will be built on the first layer between adjacent objects.";
+    def->label = __TRANS("Brim connections width");
+    def->category = __TRANS("Skirt and brim");
+    def->tooltip = __TRANS("If set to a positive value, straight connections will be built on the first layer between adjacent objects.");
     def->sidetext = "mm";
     def->cli = "brim-connections-width=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("brim_width", coFloat);
-    def->label = "Exterior brim width";
-    def->category = "Skirt and brim";
-    def->tooltip = "Horizontal width of the brim that will be printed around each object on the first layer.";
+    def->label = __TRANS("Exterior brim width");
+    def->category = __TRANS("Skirt and brim");
+    def->tooltip = __TRANS("Horizontal width of the brim that will be printed around each object on the first layer.");
     def->sidetext = "mm";
     def->cli = "brim-width=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
     
     def = this->add("compatible_printers", coStrings);
-    def->label = "Compatible printers";
+    def->label = __TRANS("Compatible printers");
     def->default_value = new ConfigOptionStrings();
 
     def = this->add("complete_objects", coBool);
-    def->label = "Complete individual objects";
-    def->category = "Advanced";
-    def->tooltip = "When printing multiple objects or copies, this feature will complete each object before moving onto next one (and starting it from its bottom layer). This feature is useful to avoid the risk of ruined prints. Slic3r should warn and prevent you from extruder collisions, but beware.";
+    def->label = __TRANS("Complete individual objects");
+    def->category = __TRANS("Advanced");
+    def->tooltip = __TRANS("When printing multiple objects or copies, this feature will complete each object before moving onto next one (and starting it from its bottom layer). This feature is useful to avoid the risk of ruined prints. Slic3r should warn and prevent you from extruder collisions, but beware.");
     def->cli = "complete-objects!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("cooling", coBool);
-    def->label = "Enable auto cooling";
-    def->tooltip = "This flag enables the automatic cooling logic that adjusts print speed and fan speed according to layer printing time.";
+    def->label = __TRANS("Enable auto cooling");
+    def->tooltip = __TRANS("This flag enables the automatic cooling logic that adjusts print speed and fan speed according to layer printing time.");
     def->cli = "cooling!";
     def->default_value = new ConfigOptionBool(true);
 
     def = this->add("default_acceleration", coFloat);
-    def->label = "Default";
-    def->category = "Speed > Acceleration";
-    def->tooltip = "This is the acceleration your printer will be reset to after the role-specific acceleration values are used (perimeter/infill). Set zero to prevent resetting acceleration at all.";
+    def->label = __TRANS("Default");
+    def->category = __TRANS("Speed > Acceleration");
+    def->tooltip = __TRANS("This is the acceleration your printer will be reset to after the role-specific acceleration values are used (perimeter/infill). Set zero to prevent resetting acceleration at all.");
     def->sidetext = "mm/s²";
     def->cli = "default-acceleration=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("disable_fan_first_layers", coInt);
-    def->label = "Disable fan for the first";
-    def->tooltip = "You can set this to a positive value to disable fan at all during the first layers, so that it does not make adhesion worse.";
-    def->sidetext = "layers";
+    def->label = __TRANS("Disable fan for the first");
+    def->tooltip = __TRANS("You can set this to a positive value to disable fan at all during the first layers, so that it does not make adhesion worse.");
+    def->sidetext = __TRANS("layers");
     def->cli = "disable-fan-first-layers=i";
     def->min = 0;
     def->max = 1000;
     def->default_value = new ConfigOptionInt(3);
 
     def = this->add("dont_support_bridges", coBool);
-    def->label = "Don't support bridges";
-    def->category = "Support material";
-    def->tooltip = "Experimental option for preventing support material from being generated under bridged areas.";
+    def->label = __TRANS("Don't support bridges");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Experimental option for preventing support material from being generated under bridged areas.");
     def->cli = "dont-support-bridges!";
     def->default_value = new ConfigOptionBool(true);
 
     def = this->add("duplicate_distance", coFloat);
-    def->label = "Distance between copies";
-    def->tooltip = "Distance used for the auto-arrange feature of the plater.";
+    def->label = __TRANS("Distance between copies");
+    def->tooltip = __TRANS("Distance used for the auto-arrange feature of the plater.");
     def->sidetext = "mm";
     def->cli = "duplicate-distance=f";
     def->aliases.push_back("multiply_distance");
@@ -190,8 +190,8 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloat(6);
 
     def = this->add("end_gcode", coString);
-    def->label = "End G-code";
-    def->tooltip = "This end procedure is inserted at the end of the output file. Note that you can use placeholder variables for all Slic3r settings.";
+    def->label = __TRANS("End G-code");
+    def->tooltip = __TRANS("This end procedure is inserted at the end of the output file. Note that you can use placeholder variables for all Slic3r settings.");
     def->cli = "end-gcode=s";
     def->multiline = true;
     def->full_width = true;
@@ -199,8 +199,8 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionString("M104 S0 ; turn off temperature\nG28 X0  ; home X axis\nM84     ; disable motors\n");
 
     def = this->add("end_filament_gcode", coStrings);
-    def->label = "End G-code";
-    def->tooltip = "This end procedure is inserted at the end of the output file, before the printer end gcode. Note that you can use placeholder variables for all Slic3r settings. If you have multiple extruders, the gcode is processed in extruder order.";
+    def->label = __TRANS("End G-code");
+    def->tooltip = __TRANS("This end procedure is inserted at the end of the output file, before the printer end gcode. Note that you can use placeholder variables for all Slic3r settings. If you have multiple extruders, the gcode is processed in extruder order.");
     def->cli = "end-filament-gcode=s@";
     def->multiline = true;
     def->full_width = true;
@@ -212,20 +212,20 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("external_fill_pattern", external_fill_pattern);
-    def->label = "Top/bottom fill pattern";
-    def->category = "Infill";
-    def->tooltip = "Fill pattern for top/bottom infill. This only affects the external visible layer, and not its adjacent solid shells.";
+    def->label = __TRANS("Top/bottom fill pattern");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("Fill pattern for top/bottom infill. This only affects the external visible layer, and not its adjacent solid shells.");
     def->cli = "external-fill-pattern|external-infill-pattern|solid-fill-pattern=s";
     def->aliases.push_back("solid_fill_pattern");
     def->shortcut.push_back("top_infill_pattern");
     def->shortcut.push_back("bottom_infill_pattern");
     
     def = this->add("external_perimeter_extrusion_width", coFloatOrPercent);
-    def->label = "↳ external";
-    def->full_label = "External perimeters extrusion width";
+    def->label = __TRANS("↳ external");
+    def->full_label = __TRANS("External perimeters extrusion width");
     def->gui_type = "f_enum_open";
-    def->category = "Extrusion Width";
-    def->tooltip = "Set this to a non-zero value to set a manual extrusion width for external perimeters. If auto is chosen, a value will be used that maximizes accuracy of the external visible surfaces. If expressed as percentage (for example 200%) it will be computed over layer height.";
+    def->category = __TRANS("Extrusion Width");
+    def->tooltip = __TRANS("Set this to a non-zero value to set a manual extrusion width for external perimeters. If auto is chosen, a value will be used that maximizes accuracy of the external visible surfaces. If expressed as percentage (for example 200%) it will be computed over layer height.");
     def->sidetext = "mm or %";
     def->cli = "external-perimeter-extrusion-width=s";
     def->min = 0;
@@ -234,11 +234,11 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(0, false);
 
     def = this->add("external_perimeter_speed", coFloatOrPercent);
-    def->label = "↳ external";
-    def->full_label = "External perimeters speed";
+    def->label = __TRANS("↳ external");
+    def->full_label = __TRANS("External perimeters speed");
     def->gui_type = "f_enum_open";
-    def->category = "Speed";
-    def->tooltip = "This separate setting will affect the speed of external perimeters (the visible ones). If expressed as percentage (for example: 80%) it will be calculated on the perimeters speed setting above.";
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("This separate setting will affect the speed of external perimeters (the visible ones). If expressed as percentage (for example: 80%) it will be calculated on the perimeters speed setting above.");
     def->sidetext = "mm/s or %";
     def->cli = "external-perimeter-speed=s";
     def->ratio_over = "perimeter_speed";
@@ -248,24 +248,24 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(50, true);
 
     def = this->add("external_perimeters_first", coBool);
-    def->label = "External perimeters first";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Print contour perimeters from the outermost one to the innermost one instead of the default inverse order.";
+    def->label = __TRANS("External perimeters first");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Print contour perimeters from the outermost one to the innermost one instead of the default inverse order.");
     def->cli = "external-perimeters-first!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("extra_perimeters", coBool);
-    def->label = "Extra perimeters if needed";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Add more perimeters when needed for avoiding gaps in sloping walls.";
+    def->label = __TRANS("Extra perimeters if needed");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Add more perimeters when needed for avoiding gaps in sloping walls.");
     def->cli = "extra-perimeters!";
     def->default_value = new ConfigOptionBool(true);
 
     def = this->add("extruder", coInt);
     def->gui_type = "i_enum_open";
-    def->label = "Extruder";
-    def->category = "Extruders";
-    def->tooltip = "The extruder to use (unless more specific extruder settings are specified).";
+    def->label = __TRANS("Extruder");
+    def->category = __TRANS("Extruders");
+    def->tooltip = __TRANS("The extruder to use (unless more specific extruder settings are specified).");
     def->cli = "extruder=i";
     def->min = 0;  // 0 = inherit defaults
     def->enum_labels.push_back("default");  // override label for item 0
@@ -275,24 +275,24 @@ PrintConfigDef::PrintConfigDef()
     def->enum_labels.push_back("4");
 
     def = this->add("extruder_clearance_height", coFloat);
-    def->label = "Height";
-    def->tooltip = "Set this to the vertical distance between your nozzle tip and (usually) the X carriage rods. In other words, this is the height of the clearance cylinder around your extruder, and it represents the maximum depth the extruder can peek before colliding with other printed objects.";
+    def->label = __TRANS("Height");
+    def->tooltip = __TRANS("Set this to the vertical distance between your nozzle tip and (usually) the X carriage rods. In other words, this is the height of the clearance cylinder around your extruder, and it represents the maximum depth the extruder can peek before colliding with other printed objects.");
     def->sidetext = "mm";
     def->cli = "extruder-clearance-height=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(20);
 
     def = this->add("extruder_clearance_radius", coFloat);
-    def->label = "Radius";
-    def->tooltip = "Set this to the clearance radius around your extruder. If the extruder is not centered, choose the largest value for safety. This setting is used to check for collisions and to display the graphical preview in the plater.";
+    def->label = __TRANS("Radius");
+    def->tooltip = __TRANS("Set this to the clearance radius around your extruder. If the extruder is not centered, choose the largest value for safety. This setting is used to check for collisions and to display the graphical preview in the plater.");
     def->sidetext = "mm";
     def->cli = "extruder-clearance-radius=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(20);
 
     def = this->add("extruder_offset", coPoints);
-    def->label = "Extruder offset";
-    def->tooltip = "If your firmware doesn't handle the extruder displacement you need the G-code to take it into account. This option lets you specify the displacement of each extruder with respect to the first one. It expects positive coordinates (they will be subtracted from the XY coordinate).";
+    def->label = __TRANS("Extruder offset");
+    def->tooltip = __TRANS("If your firmware doesn't handle the extruder displacement you need the G-code to take it into account. This option lets you specify the displacement of each extruder with respect to the first one. It expects positive coordinates (they will be subtracted from the XY coordinate).");
     def->sidetext = "mm";
     def->cli = "extruder-offset=s@";
     {
@@ -302,14 +302,14 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("extrusion_axis", coString);
-    def->label = "Extrusion axis";
-    def->tooltip = "Use this option to set the axis letter associated to your printer's extruder (usually E but some printers use A).";
+    def->label = __TRANS("Extrusion axis");
+    def->tooltip = __TRANS("Use this option to set the axis letter associated to your printer's extruder (usually E but some printers use A).");
     def->cli = "extrusion-axis=s";
     def->default_value = new ConfigOptionString("E");
 
     def = this->add("extrusion_multiplier", coFloats);
-    def->label = "Extrusion multiplier";
-    def->tooltip = "This factor changes the amount of flow proportionally. You may need to tweak this setting to get nice surface finish and correct single wall widths. Usual values are between 0.9 and 1.1. If you think you need to change this more, check filament diameter and your firmware E steps.";
+    def->label = __TRANS("Extrusion multiplier");
+    def->tooltip = __TRANS("This factor changes the amount of flow proportionally. You may need to tweak this setting to get nice surface finish and correct single wall widths. Usual values are between 0.9 and 1.1. If you think you need to change this more, check filament diameter and your firmware E steps.");
     def->cli = "extrusion-multiplier=f@";
     {
         ConfigOptionFloats* opt = new ConfigOptionFloats();
@@ -318,10 +318,10 @@ PrintConfigDef::PrintConfigDef()
     }
     
     def = this->add("extrusion_width", coFloatOrPercent);
-    def->label = "Default extrusion width";
+    def->label = __TRANS("Default extrusion width");
     def->gui_type = "f_enum_open";
-    def->category = "Extrusion Width";
-    def->tooltip = "Set this to a non-zero value to set a manual extrusion width. If expressed as percentage (for example: 230%) it will be computed over layer height.";
+    def->category = __TRANS("Extrusion Width");
+    def->tooltip = __TRANS("Set this to a non-zero value to set a manual extrusion width. If expressed as percentage (for example: 230%) it will be computed over layer height.");
     def->sidetext = "mm or %";
     def->cli = "extrusion-width=s";
     def->min = 0;
@@ -330,14 +330,14 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(0, false);
 
     def = this->add("fan_always_on", coBool);
-    def->label = "Keep fan always on";
-    def->tooltip = "If this is enabled, fan will never be disabled and will be kept running at least at its minimum speed. Useful for PLA, harmful for ABS.";
+    def->label = __TRANS("Keep fan always on");
+    def->tooltip = __TRANS("If this is enabled, fan will never be disabled and will be kept running at least at its minimum speed. Useful for PLA, harmful for ABS.");
     def->cli = "fan-always-on!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("fan_below_layer_time", coInt);
-    def->label = "Enable fan if layer print time is below";
-    def->tooltip = "If layer print time is estimated below this number of seconds, fan will be enabled and its speed will be calculated by interpolating the minimum and maximum speeds.";
+    def->label = __TRANS("Enable fan if layer print time is below");
+    def->tooltip = __TRANS("If layer print time is estimated below this number of seconds, fan will be enabled and its speed will be calculated by interpolating the minimum and maximum speeds.");
     def->sidetext = "approximate seconds";
     def->cli = "fan-below-layer-time=i";
     def->width = 60;
@@ -346,8 +346,8 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(60);
 
     def = this->add("filament_colour", coStrings);
-    def->label = "Color";
-    def->tooltip = "This is only used in the Slic3r interface as a visual help.";
+    def->label = __TRANS("Color");
+    def->tooltip = __TRANS("This is only used in the Slic3r interface as a visual help.");
     def->cli = "filament-color=s@";
     def->gui_type = "color";
     {
@@ -357,8 +357,8 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("filament_notes", coStrings);
-    def->label = "Filament notes";
-    def->tooltip = "You can put your notes regarding the filament here.";
+    def->label = __TRANS("Filament notes");
+    def->tooltip = __TRANS("You can put your notes regarding the filament here.");
     def->cli = "filament-notes=s@";
     def->multiline = true;
     def->full_width = true;
@@ -370,8 +370,8 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("filament_max_volumetric_speed", coFloats);
-    def->label = "Max volumetric speed";
-    def->tooltip = "Maximum volumetric speed allowed for this filament. Limits the maximum volumetric speed of a print to the minimum of print and filament volumetric speed. Set to zero for no limit.";
+    def->label = __TRANS("Max volumetric speed");
+    def->tooltip = __TRANS("Maximum volumetric speed allowed for this filament. Limits the maximum volumetric speed of a print to the minimum of print and filament volumetric speed. Set to zero for no limit.");
     def->sidetext = "mm³/s";
     def->cli = "filament-max-volumetric-speed=f@";
     def->min = 0;
@@ -382,8 +382,8 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("filament_diameter", coFloats);
-    def->label = "Diameter";
-    def->tooltip = "Enter your filament diameter here. Good precision is required, so use a caliper and do multiple measurements along the filament, then compute the average.";
+    def->label = __TRANS("Diameter");
+    def->tooltip = __TRANS("Enter your filament diameter here. Good precision is required, so use a caliper and do multiple measurements along the filament, then compute the average.");
     def->sidetext = "mm";
     def->cli = "filament-diameter=f@";
     def->min = 0;
@@ -394,8 +394,8 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("filament_density", coFloats);
-    def->label = "Density";
-    def->tooltip = "Enter your filament density here. This is only for statistical information. A decent way is to weigh a known length of filament and compute the ratio of the length to volume. Better is to calculate the volume directly through displacement.";
+    def->label = __TRANS("Density");
+    def->tooltip = __TRANS("Enter your filament density here. This is only for statistical information. A decent way is to weigh a known length of filament and compute the ratio of the length to volume. Better is to calculate the volume directly through displacement.");
     def->sidetext = "g/cm³";
     def->cli = "filament-density=f@";
     def->min = 0;
@@ -406,9 +406,9 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("filament_cost", coFloats);
-    def->label = "Cost";
-    def->tooltip = "Enter your filament cost per kg here. This is only for statistical information.";
-    def->sidetext = "money/kg";
+    def->label = __TRANS("Cost");
+    def->tooltip = __TRANS("Enter your filament cost per kg here. This is only for statistical information.");
+    def->sidetext = __TRANS("money/kg");
     def->cli = "filament-cost=f@";
     def->min = 0;
     {
@@ -421,9 +421,9 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionString("");
     
     def = this->add("fill_angle", coFloat);
-    def->label = "Fill angle";
-    def->category = "Infill";
-    def->tooltip = "Default base angle for infill orientation. Cross-hatching will be applied to this. Bridges will be infilled using the best direction Slic3r can detect, so this setting does not affect them.";
+    def->label = __TRANS("Fill angle");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("Default base angle for infill orientation. Cross-hatching will be applied to this. Bridges will be infilled using the best direction Slic3r can detect, so this setting does not affect them.");
     def->sidetext = "°";
     def->cli = "fill-angle=i";
     def->min = 0;
@@ -433,9 +433,9 @@ PrintConfigDef::PrintConfigDef()
     def = this->add("fill_density", coPercent);
     def->gui_type = "f_enum_open";
     def->gui_flags = "show_value";
-    def->label = "Fill density";
-    def->category = "Infill";
-    def->tooltip = "Density of internal infill, expressed in the range 0% - 100%.";
+    def->label = __TRANS("Fill density");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("Density of internal infill, expressed in the range 0% - 100%.");
     def->sidetext = "%";
     def->cli = "fill-density=s";
     def->min = 0;
@@ -471,16 +471,16 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionPercent(20);
 
     def = this->add("fill_gaps", coBool);
-    def->label = "Fill gaps";
-    def->category = "Infill";
-    def->tooltip = "If this is enabled, gaps will be filled with single passes. Enable this for better quality, disable it for shorter printing times.";
+    def->label = __TRANS("Fill gaps");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("If this is enabled, gaps will be filled with single passes. Enable this for better quality, disable it for shorter printing times.");
     def->cli = "fill-gaps!";
     def->default_value = new ConfigOptionBool(true);
 
     def = this->add("fill_pattern", coEnum);
-    def->label = "Fill pattern";
-    def->category = "Infill";
-    def->tooltip = "Fill pattern for general low-density infill.";
+    def->label = __TRANS("Fill pattern");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("Fill pattern for general low-density infill.");
     def->cli = "fill-pattern=s";
     def->enum_keys_map = ConfigOptionEnum<InfillPattern>::get_enum_values();
     def->enum_values.push_back("rectilinear");
@@ -510,27 +510,27 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionEnum<InfillPattern>(ipStars);
 
     def = this->add("first_layer_acceleration", coFloat);
-    def->label = "First layer";
-    def->category = "Speed > Acceleration";
-    def->tooltip = "This is the acceleration your printer will use for first layer. Set zero to disable acceleration control for first layer.";
+    def->label = __TRANS("First layer");
+    def->category = __TRANS("Speed > Acceleration");
+    def->tooltip = __TRANS("This is the acceleration your printer will use for first layer. Set zero to disable acceleration control for first layer.");
     def->sidetext = "mm/s²";
     def->cli = "first-layer-acceleration=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("first_layer_bed_temperature", coInt);
-    def->label = "First layer";
-    def->tooltip = "Heated build plate temperature for the first layer. Set this to zero to disable bed temperature control commands in the output.";
+    def->label = __TRANS("First layer");
+    def->tooltip = __TRANS("Heated build plate temperature for the first layer. Set this to zero to disable bed temperature control commands in the output.");
     def->cli = "first-layer-bed-temperature=i";
     def->max = 0;
     def->max = 300;
     def->default_value = new ConfigOptionInt(0);
 
     def = this->add("first_layer_extrusion_width", coFloatOrPercent);
-    def->label = "First layer";
+    def->label = __TRANS("First layer");
     def->gui_type = "f_enum_open";
-    def->category = "Extrusion Width";
-    def->tooltip = "Set this to a non-zero value to set a manual extrusion width for first layer. You can use this to force fatter extrudates for better adhesion. If expressed as percentage (for example 120%) it will be computed over first layer height.";
+    def->category = __TRANS("Extrusion Width");
+    def->tooltip = __TRANS("Set this to a non-zero value to set a manual extrusion width for first layer. You can use this to force fatter extrudates for better adhesion. If expressed as percentage (for example 120%) it will be computed over first layer height.");
     def->sidetext = "mm or %";
     def->cli = "first-layer-extrusion-width=s";
     def->ratio_over = "first_layer_height";
@@ -540,26 +540,26 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(200, true);
 
     def = this->add("first_layer_height", coFloatOrPercent);
-    def->label = "First layer height";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "When printing with very low layer heights, you might still want to print a thicker bottom layer to improve adhesion and tolerance for non perfect build plates. This can be expressed as an absolute value or as a percentage (for example: 150%) over the default layer height.";
+    def->label = __TRANS("First layer height");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("When printing with very low layer heights, you might still want to print a thicker bottom layer to improve adhesion and tolerance for non perfect build plates. This can be expressed as an absolute value or as a percentage (for example: 150%) over the default layer height.");
     def->sidetext = "mm or %";
     def->cli = "first-layer-height=s";
     def->ratio_over = "layer_height";
     def->default_value = new ConfigOptionFloatOrPercent(0.35, false);
 
     def = this->add("first_layer_speed", coFloatOrPercent);
-    def->label = "First layer speed";
-    def->category = "Speed";
-    def->tooltip = "If expressed as absolute value in mm/s, this speed will be applied to all the print moves of the first layer, regardless of their type. If expressed as a percentage (for example: 40%) it will scale the default speeds.";
+    def->label = __TRANS("First layer speed");
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("If expressed as absolute value in mm/s, this speed will be applied to all the print moves of the first layer, regardless of their type. If expressed as a percentage (for example: 40%) it will scale the default speeds.");
     def->sidetext = "mm/s or %";
     def->cli = "first-layer-speed=s";
     def->min = 0;
     def->default_value = new ConfigOptionFloatOrPercent(30, false);
 
     def = this->add("first_layer_temperature", coInts);
-    def->label = "First layer";
-    def->tooltip = "Extruder temperature for first layer. If you want to control temperature manually during print, set this to zero to disable temperature control commands in the output file.";
+    def->label = __TRANS("First layer");
+    def->tooltip = __TRANS("Extruder temperature for first layer. If you want to control temperature manually during print, set this to zero to disable temperature control commands in the output file.");
     def->cli = "first-layer-temperature=i@";
     def->min = 0;
     def->max = 500;
@@ -570,11 +570,11 @@ PrintConfigDef::PrintConfigDef()
     }
     
     def = this->add("gap_fill_speed", coFloat);
-    def->label = "↳ gaps";
+    def->label = __TRANS("↳ gaps");
     def->full_label = "Gap fill speed";
     def->gui_type = "f_enum_open";
-    def->category = "Speed";
-    def->tooltip = "Speed for filling gaps. Since these are usually single lines you might want to use a low speed for better sticking. If expressed as percentage (for example: 80%) it will be calculated on the infill speed setting above.";
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("Speed for filling gaps. Since these are usually single lines you might want to use a low speed for better sticking. If expressed as percentage (for example: 80%) it will be calculated on the infill speed setting above.");
     def->sidetext = "mm/s or %";
     def->cli = "gap-fill-speed=s";
     def->ratio_over = "infill_speed";
@@ -584,20 +584,20 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloat(20);
 
     def = this->add("gcode_arcs", coBool);
-    def->label = "Use native G-code arcs";
-    def->tooltip = "This experimental feature tries to detect arcs from segments and generates G2/G3 arc commands instead of multiple straight G1 commands.";
+    def->label = __TRANS("Use native G-code arcs");
+    def->tooltip = __TRANS("This experimental feature tries to detect arcs from segments and generates G2/G3 arc commands instead of multiple straight G1 commands.");
     def->cli = "gcode-arcs!";
     def->default_value = new ConfigOptionBool(0);
 
     def = this->add("gcode_comments", coBool);
-    def->label = "Verbose G-code";
-    def->tooltip = "Enable this to get a commented G-code file, with each line explained by a descriptive text. If you print from SD card, the additional weight of the file could make your firmware slow down.";
+    def->label = __TRANS("Verbose G-code");
+    def->tooltip = __TRANS("Enable this to get a commented G-code file, with each line explained by a descriptive text. If you print from SD card, the additional weight of the file could make your firmware slow down.");
     def->cli = "gcode-comments!";
     def->default_value = new ConfigOptionBool(0);
 
     def = this->add("gcode_flavor", coEnum);
-    def->label = "G-code flavor";
-    def->tooltip = "Some G/M-code commands, including temperature control and others, are not universal. Set this option to your printer's firmware to get a compatible output. The \"No extrusion\" flavor prevents Slic3r from exporting any extrusion value at all.";
+    def->label = __TRANS("G-code flavor");
+    def->tooltip = __TRANS("Some G/M-code commands, including temperature control and others, are not universal. Set this option to your printer's firmware to get a compatible output. The \"No extrusion\" flavor prevents Slic3r from exporting any extrusion value at all.");
     def->cli = "gcode-flavor=s";
     def->enum_keys_map = ConfigOptionEnum<GCodeFlavor>::get_enum_values();
     def->enum_values.push_back("reprap");
@@ -621,18 +621,18 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionEnum<GCodeFlavor>(gcfRepRap);
 
     def = this->add("infill_acceleration", coFloat);
-    def->label = "Infill";
-    def->category = "Speed > Acceleration";
-    def->tooltip = "This is the acceleration your printer will use for infill. Set zero to disable acceleration control for infill.";
+    def->label = __TRANS("Infill");
+    def->category = __TRANS("Speed > Acceleration");
+    def->tooltip = __TRANS("This is the acceleration your printer will use for infill. Set zero to disable acceleration control for infill.");
     def->sidetext = "mm/s²";
     def->cli = "infill-acceleration=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("infill_every_layers", coInt);
-    def->label = "Combine infill every";
-    def->category = "Infill";
-    def->tooltip = "This feature allows to combine infill and speed up your print by extruding thicker infill layers while preserving thin perimeters, thus accuracy.";
+    def->label = __TRANS("Combine infill every");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("This feature allows to combine infill and speed up your print by extruding thicker infill layers while preserving thin perimeters, thus accuracy.");
     def->sidetext = "layers";
     def->cli = "infill-every-layers=i";
     def->full_label = "Combine infill every n layers";
@@ -640,18 +640,18 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(1);
 
     def = this->add("infill_extruder", coInt);
-    def->label = "Infill extruder";
-    def->category = "Extruders";
-    def->tooltip = "The extruder to use when printing infill.";
+    def->label = __TRANS("Infill extruder");
+    def->category = __TRANS("Extruders");
+    def->tooltip = __TRANS("The extruder to use when printing infill.");
     def->cli = "infill-extruder=i";
     def->min = 1;
     def->default_value = new ConfigOptionInt(1);
 
     def = this->add("infill_extrusion_width", coFloatOrPercent);
-    def->label = "Infill";
+    def->label = __TRANS("Infill");
     def->gui_type = "f_enum_open";
-    def->category = "Extrusion Width";
-    def->tooltip = "Set this to a non-zero value to set a manual extrusion width for infill. You may want to use fatter extrudates to speed up the infill and make your parts stronger. If expressed as percentage (for example 90%) it will be computed over layer height.";
+    def->category = __TRANS("Extrusion Width");
+    def->tooltip = __TRANS("Set this to a non-zero value to set a manual extrusion width for infill. You may want to use fatter extrudates to speed up the infill and make your parts stronger. If expressed as percentage (for example 90%) it will be computed over layer height.");
     def->sidetext = "mm or %";
     def->cli = "infill-extrusion-width=s";
     def->min = 0;
@@ -660,33 +660,33 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(0, false);
 
     def = this->add("infill_first", coBool);
-    def->label = "Infill before perimeters";
-    def->category = "Infill";
-    def->tooltip = "This option will switch the print order of perimeters and infill, making the latter first.";
+    def->label = __TRANS("Infill before perimeters");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("This option will switch the print order of perimeters and infill, making the latter first.");
     def->cli = "infill-first!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("infill_only_where_needed", coBool);
-    def->label = "Only infill where needed";
-    def->category = "Infill";
-    def->tooltip = "This option will limit infill to the areas actually needed for supporting ceilings (it will act as internal support material). If enabled, slows down the G-code generation due to the multiple checks involved.";
+    def->label = __TRANS("Only infill where needed");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("This option will limit infill to the areas actually needed for supporting ceilings (it will act as internal support material). If enabled, slows down the G-code generation due to the multiple checks involved.");
     def->cli = "infill-only-where-needed!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("infill_overlap", coFloatOrPercent);
-    def->label = "Infill/perimeters overlap";
-    def->category = "Advanced";
-    def->tooltip = "This setting applies an additional overlap between infill and perimeters for better bonding. Theoretically this shouldn't be needed, but backlash might cause gaps. If expressed as percentage (example: 15%) it is calculated over perimeter extrusion width.";
+    def->label = __TRANS("Infill/perimeters overlap");
+    def->category = __TRANS("Advanced");
+    def->tooltip = __TRANS("This setting applies an additional overlap between infill and perimeters for better bonding. Theoretically this shouldn't be needed, but backlash might cause gaps. If expressed as percentage (example: 15%) it is calculated over perimeter extrusion width.");
     def->sidetext = "mm or %";
     def->cli = "infill-overlap=s";
     def->ratio_over = "perimeter_extrusion_width";
     def->default_value = new ConfigOptionFloatOrPercent(55, true);
 
     def = this->add("infill_speed", coFloat);
-    def->label = "Infill";
+    def->label = __TRANS("Infill");
     def->gui_type = "f_enum_open";
-    def->category = "Speed";
-    def->tooltip = "Speed for printing the internal fill.";
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("Speed for printing the internal fill.");
     def->sidetext = "mm/s";
     def->cli = "infill-speed=f";
     def->aliases.push_back("print_feed_rate");
@@ -697,24 +697,24 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloat(80);
 
     def = this->add("interior_brim_width", coFloat);
-    def->label = "Interior brim width";
-    def->category = "Skirt and brim";
-    def->tooltip = "Horizontal width of the brim that will be printed inside object holes on the first layer.";
+    def->label = __TRANS("Interior brim width");
+    def->category = __TRANS("Skirt and brim");
+    def->tooltip = __TRANS("Horizontal width of the brim that will be printed inside object holes on the first layer.");
     def->sidetext = "mm";
     def->cli = "interior-brim-width=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("interface_shells", coBool);
-    def->label = "Interface shells";
-    def->tooltip = "Force the generation of solid shells between adjacent materials/volumes. Useful for multi-extruder prints with translucent materials or manual soluble support material.";
+    def->label = __TRANS("Interface shells");
+    def->tooltip = __TRANS("Force the generation of solid shells between adjacent materials/volumes. Useful for multi-extruder prints with translucent materials or manual soluble support material.");
     def->cli = "interface-shells!";
-    def->category = "Layers and Perimeters";
+    def->category = __TRANS("Layers and Perimeters");
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("layer_gcode", coString);
-    def->label = "After layer change G-code";
-    def->tooltip = "This custom code is inserted at every layer change, right after the Z move and before the extruder moves to the first layer point. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num] and [layer_z].";
+    def->label = __TRANS("After layer change G-code");
+    def->tooltip = __TRANS("This custom code is inserted at every layer change, right after the Z move and before the extruder moves to the first layer point. Note that you can use placeholder variables for all Slic3r settings as well as [layer_num] and [layer_z].");
     def->cli = "after-layer-gcode|layer-gcode=s";
     def->multiline = true;
     def->full_width = true;
@@ -722,17 +722,17 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionString("");
 
     def = this->add("layer_height", coFloat);
-    def->label = "Layer height";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "This setting controls the height (and thus the total number) of the slices/layers. Thinner layers give better accuracy but take more time to print.";
+    def->label = __TRANS("Layer height");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("This setting controls the height (and thus the total number) of the slices/layers. Thinner layers give better accuracy but take more time to print.");
     def->sidetext = "mm";
     def->cli = "layer-height=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0.3);
 
     def = this->add("max_fan_speed", coInt);
-    def->label = "Max";
-    def->tooltip = "This setting represents the maximum speed of your fan.";
+    def->label = __TRANS("Max");
+    def->tooltip = __TRANS("This setting represents the maximum speed of your fan.");
     def->sidetext = "%";
     def->cli = "max-fan-speed=i";
     def->min = 0;
@@ -740,26 +740,26 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(100);
 
     def = this->add("max_print_speed", coFloat);
-    def->label = "Max print speed";
-    def->category = "Speed";
-    def->tooltip = "When setting other speed settings to 0 Slic3r will autocalculate the optimal speed in order to keep constant extruder pressure. This experimental setting is used to set the highest print speed you want to allow.";
+    def->label = __TRANS("Max print speed");
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("When setting other speed settings to 0 Slic3r will autocalculate the optimal speed in order to keep constant extruder pressure. This experimental setting is used to set the highest print speed you want to allow.");
     def->sidetext = "mm/s";
     def->cli = "max-print-speed=f";
     def->min = 1;
     def->default_value = new ConfigOptionFloat(80);
 
     def = this->add("max_volumetric_speed", coFloat);
-    def->label = "Max volumetric speed";
-    def->category = "Speed";
-    def->tooltip = "This experimental setting is used to set the maximum volumetric speed your extruder supports.";
+    def->label = __TRANS("Max volumetric speed");
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("This experimental setting is used to set the maximum volumetric speed your extruder supports.");
     def->sidetext = "mm³/s";
     def->cli = "max-volumetric-speed=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("min_fan_speed", coInt);
-    def->label = "Min";
-    def->tooltip = "This setting represents the minimum PWM your fan needs to work.";
+    def->label = __TRANS("Min");
+    def->tooltip = __TRANS("This setting represents the minimum PWM your fan needs to work.");
     def->sidetext = "%";
     def->cli = "min-fan-speed=i";
     def->min = 0;
@@ -767,25 +767,25 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(35);
 
     def = this->add("min_print_speed", coFloat);
-    def->label = "Min print speed";
-    def->tooltip = "Slic3r will not scale speed down below this speed.";
+    def->label = __TRANS("Min print speed");
+    def->tooltip = __TRANS("Slic3r will not scale speed down below this speed.");
     def->sidetext = "mm/s";
     def->cli = "min-print-speed=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(10);
 
     def = this->add("min_skirt_length", coFloat);
-    def->label = "Minimum extrusion length";
-    def->category = "Skirt and brim";
-    def->tooltip = "Generate no less than the number of skirt loops required to consume the specified amount of filament on the bottom layer. For multi-extruder machines, this minimum applies to each extruder.";
+    def->label = __TRANS("Minimum extrusion length");
+    def->category = __TRANS("Skirt and brim");
+    def->tooltip = __TRANS("Generate no less than the number of skirt loops required to consume the specified amount of filament on the bottom layer. For multi-extruder machines, this minimum applies to each extruder.");
     def->sidetext = "mm";
     def->cli = "min-skirt-length=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("notes", coString);
-    def->label = "Configuration notes";
-    def->tooltip = "You can put here your personal notes. This text will be added to the G-code header comments.";
+    def->label = __TRANS("Configuration notes");
+    def->tooltip = __TRANS("You can put here your personal notes. This text will be added to the G-code header comments.");
     def->cli = "notes=s";
     def->multiline = true;
     def->full_width = true;
@@ -793,8 +793,8 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionString("");
 
     def = this->add("nozzle_diameter", coFloats);
-    def->label = "Nozzle diameter";
-    def->tooltip = "This is the diameter of your extruder nozzle (for example: 0.5, 0.35 etc.)";
+    def->label = __TRANS("Nozzle diameter");
+    def->tooltip = __TRANS("This is the diameter of your extruder nozzle (for example: 0.5, 0.35 etc.)");
     def->sidetext = "mm";
     def->cli = "nozzle-diameter=f@";
     {
@@ -804,48 +804,48 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("octoprint_apikey", coString);
-    def->label = "API Key";
-    def->tooltip = "Slic3r can upload G-code files to OctoPrint. This field should contain the API Key required for authentication.";
+    def->label = __TRANS("API Key");
+    def->tooltip = __TRANS("Slic3r can upload G-code files to OctoPrint. This field should contain the API Key required for authentication.");
     def->cli = "octoprint-apikey=s";
     def->default_value = new ConfigOptionString("");
 
     def = this->add("octoprint_host", coString);
-    def->label = "Host or IP";
-    def->tooltip = "Slic3r can upload G-code files to OctoPrint. This field should contain the hostname or IP address of the OctoPrint instance.";
+    def->label = __TRANS("Host or IP");
+    def->tooltip = __TRANS("Slic3r can upload G-code files to OctoPrint. This field should contain the hostname or IP address of the OctoPrint instance.");
     def->cli = "octoprint-host=s";
     def->default_value = new ConfigOptionString("");
 
     def = this->add("only_retract_when_crossing_perimeters", coBool);
-    def->label = "Only retract when crossing perimeters";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Disables retraction when the travel path does not exceed the upper layer's perimeters (and thus any ooze will be probably invisible).";
+    def->label = __TRANS("Only retract when crossing perimeters");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Disables retraction when the travel path does not exceed the upper layer's perimeters (and thus any ooze will be probably invisible).");
     def->cli = "only-retract-when-crossing-perimeters!";
     def->default_value = new ConfigOptionBool(true);
 
     def = this->add("ooze_prevention", coBool);
-    def->label = "Enable";
+    def->label = __TRANS("Enable");
     def->full_label = "Ooze Prevention";
-    def->category = "Extruders";
-    def->tooltip = "During multi-extruder prints, this option will drop the temperature of the inactive extruders to prevent oozing. It will enable a tall skirt automatically and move extruders outside such skirt when changing temperatures.";
+    def->category = __TRANS("Extruders");
+    def->tooltip = __TRANS("During multi-extruder prints, this option will drop the temperature of the inactive extruders to prevent oozing. It will enable a tall skirt automatically and move extruders outside such skirt when changing temperatures.");
     def->cli = "ooze-prevention!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("output_filename_format", coString);
-    def->label = "Output filename format";
-    def->tooltip = "You can use all configuration options as variables inside this template. For example: [layer_height], [fill_density] etc. You can also use [timestamp], [year], [month], [day], [hour], [minute], [second], [version], [input_filename], [input_filename_base].";
+    def->label = __TRANS("Output filename format");
+    def->tooltip = __TRANS("You can use all configuration options as variables inside this template. For example: [layer_height], [fill_density] etc. You can also use [timestamp], [year], [month], [day], [hour], [minute], [second], [version], [input_filename], [input_filename_base].");
     def->cli = "output-filename-format=s";
     def->full_width = true;
     def->default_value = new ConfigOptionString("[input_filename_base].gcode");
 
     def = this->add("overhangs", coBool);
-    def->label = "Detect bridging perimeters";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Experimental option to adjust flow for overhangs (bridge flow will be used), to apply bridge speed to them and enable fan.";
+    def->label = __TRANS("Detect bridging perimeters");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Experimental option to adjust flow for overhangs (bridge flow will be used), to apply bridge speed to them and enable fan.");
     def->cli = "overhangs|detect-bridging-perimeters!";
     def->default_value = new ConfigOptionBool(true);
     
     def = this->add("overridable", coStrings);
-    def->label = "Overridable options";
+    def->label = __TRANS("Overridable options");
     {
         ConfigOptionStrings* opt = new ConfigOptionStrings();
         opt->values.push_back("support_material");
@@ -853,27 +853,27 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("perimeter_acceleration", coFloat);
-    def->label = "Perimeters";
-    def->category = "Speed > Acceleration";
-    def->tooltip = "This is the acceleration your printer will use for perimeters. A high value like 9000 usually gives good results if your hardware is up to the job. Set zero to disable acceleration control for perimeters.";
+    def->label = __TRANS("Perimeters");
+    def->category = __TRANS("Speed > Acceleration");
+    def->tooltip = __TRANS("This is the acceleration your printer will use for perimeters. A high value like 9000 usually gives good results if your hardware is up to the job. Set zero to disable acceleration control for perimeters.");
     def->sidetext = "mm/s²";
     def->cli = "perimeter-acceleration=f";
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("perimeter_extruder", coInt);
-    def->label = "Perimeter extruder";
-    def->category = "Extruders";
-    def->tooltip = "The extruder to use when printing perimeters and brim. First extruder is 1.";
+    def->label = __TRANS("Perimeter extruder");
+    def->category = __TRANS("Extruders");
+    def->tooltip = __TRANS("The extruder to use when printing perimeters and brim. First extruder is 1.");
     def->cli = "perimeter-extruder=i";
     def->aliases.push_back("perimeters_extruder");
     def->min = 1;
     def->default_value = new ConfigOptionInt(1);
 
     def = this->add("perimeter_extrusion_width", coFloatOrPercent);
-    def->label = "Perimeters";
+    def->label = __TRANS("Perimeters");
     def->gui_type = "f_enum_open";
-    def->category = "Extrusion Width";
-    def->tooltip = "Set this to a non-zero value to set a manual extrusion width for perimeters. You may want to use thinner extrudates to get more accurate surfaces. If expressed as percentage (for example 200%) it will be computed over layer height.";
+    def->category = __TRANS("Extrusion Width");
+    def->tooltip = __TRANS("Set this to a non-zero value to set a manual extrusion width for perimeters. You may want to use thinner extrudates to get more accurate surfaces. If expressed as percentage (for example 200%) it will be computed over layer height.");
     def->sidetext = "mm or %";
     def->cli = "perimeter-extrusion-width=s";
     def->aliases.push_back("perimeters_extrusion_width");
@@ -883,10 +883,10 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(0, false);
 
     def = this->add("perimeter_speed", coFloat);
-    def->label = "Perimeters";
+    def->label = __TRANS("Perimeters");
     def->gui_type = "f_enum_open";
-    def->category = "Speed";
-    def->tooltip = "Speed for perimeters (contours, aka vertical shells).";
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("Speed for perimeters (contours, aka vertical shells).");
     def->sidetext = "mm/s";
     def->cli = "perimeter-speed=f";
     def->aliases.push_back("perimeter_feed_rate");
@@ -896,9 +896,9 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloat(60);
 
     def = this->add("perimeters", coInt);
-    def->label = "Perimeters";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "This option sets the number of perimeters to generate for each layer. Note that Slic3r may increase this number automatically when it detects sloping surfaces which benefit from a higher number of perimeters if the Extra Perimeters option is enabled.";
+    def->label = __TRANS("Perimeters");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("This option sets the number of perimeters to generate for each layer. Note that Slic3r may increase this number automatically when it detects sloping surfaces which benefit from a higher number of perimeters if the Extra Perimeters option is enabled.");
     def->sidetext = "(minimum)";
     def->cli = "perimeters=i";
     def->aliases.push_back("perimeter_offsets");
@@ -906,8 +906,8 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(3);
 
     def = this->add("post_process", coStrings);
-    def->label = "Post-processing scripts";
-    def->tooltip = "If you want to process the output G-code through custom scripts, just list their absolute paths here. Separate multiple scripts on individual lines. Scripts will be passed the absolute path to the G-code file as the first argument, and they can access the Slic3r config settings by reading environment variables.";
+    def->label = __TRANS("Post-processing scripts");
+    def->tooltip = __TRANS("If you want to process the output G-code through custom scripts, just list their absolute paths here. Separate multiple scripts on individual lines. Scripts will be passed the absolute path to the G-code file as the first argument, and they can access the Slic3r config settings by reading environment variables.");
     def->cli = "post-process=s@";
     def->multiline = true;
     def->full_width = true;
@@ -921,43 +921,43 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionString("");
 
     def = this->add("pressure_advance", coFloat);
-    def->label = "Pressure advance";
-    def->category = "Extruder";
-    def->tooltip = "When set to a non-zero value, this experimental option enables pressure regulation. It's the K constant for the advance algorithm that pushes more or less filament upon speed changes. It's useful for Bowden-tube extruders. Reasonable values are in range 0-10.";
+    def->label = __TRANS("Pressure advance");
+    def->category = __TRANS("Extruder");
+    def->tooltip = __TRANS("When set to a non-zero value, this experimental option enables pressure regulation. It's the K constant for the advance algorithm that pushes more or less filament upon speed changes. It's useful for Bowden-tube extruders. Reasonable values are in range 0-10.");
     def->cli = "pressure-advance=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("raft_layers", coInt);
-    def->label = "Raft layers";
-    def->category = "Support material";
-    def->tooltip = "The object will be raised by this number of layers, and support material will be generated under it.";
+    def->label = __TRANS("Raft layers");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("The object will be raised by this number of layers, and support material will be generated under it.");
     def->sidetext = "layers";
     def->cli = "raft-layers=i";
     def->min = 0;
     def->default_value = new ConfigOptionInt(0);
 
     def = this->add("raft_offset", coFloat);
-    def->label = "Raft offset";
-    def->category = "Support material";
-    def->tooltip = "Horizontal margin between object base layer and raft contour.";
+    def->label = __TRANS("Raft offset");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Horizontal margin between object base layer and raft contour.");
     def->sidetext = "mm";
     def->cli = "raft-offset=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(4);
 
     def = this->add("resolution", coFloat);
-    def->label = "Resolution (deprecated)";
-    def->tooltip = "Minimum detail resolution, used to simplify the input file for speeding up the slicing job and reducing memory usage. High-resolution models often carry more detail than printers can render. Set to zero to disable any simplification and use full resolution from input.";
+    def->label = __TRANS("Resolution (deprecated)");
+    def->tooltip = __TRANS("Minimum detail resolution, used to simplify the input file for speeding up the slicing job and reducing memory usage. High-resolution models often carry more detail than printers can render. Set to zero to disable any simplification and use full resolution from input.");
     def->sidetext = "mm";
     def->cli = "resolution=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("retract_before_travel", coFloats);
-    def->label = "Minimum travel after retraction";
-    def->category = "Retraction";
-    def->tooltip = "Retraction is not triggered when travel moves are shorter than this length.";
+    def->label = __TRANS("Minimum travel after retraction");
+    def->category = __TRANS("Retraction");
+    def->tooltip = __TRANS("Retraction is not triggered when travel moves are shorter than this length.");
     def->sidetext = "mm";
     def->cli = "retract-before-travel=f@";
     {
@@ -967,9 +967,9 @@ PrintConfigDef::PrintConfigDef()
     }
     
     def = this->add("retract_layer_change", coBools);
-    def->label = "Retract on layer change";
-    def->category = "Retraction";
-    def->tooltip = "This flag enforces a retraction whenever a Z move is done.";
+    def->label = __TRANS("Retract on layer change");
+    def->category = __TRANS("Retraction");
+    def->tooltip = __TRANS("This flag enforces a retraction whenever a Z move is done.");
     def->cli = "retract-layer-change!";
     {
         ConfigOptionBools* opt = new ConfigOptionBools();
@@ -978,10 +978,10 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("retract_length", coFloats);
-    def->label = "Length";
-    def->category = "Retraction";
+    def->label = __TRANS("Length");
+    def->category = __TRANS("Retraction");
     def->full_label = "Retraction Length";
-    def->tooltip = "When retraction is triggered, filament is pulled back by the specified amount (the length is measured on raw filament, before it enters the extruder).";
+    def->tooltip = __TRANS("When retraction is triggered, filament is pulled back by the specified amount (the length is measured on raw filament, before it enters the extruder).");
     def->sidetext = "mm (zero to disable)";
     def->cli = "retract-length=f@";
     {
@@ -991,9 +991,9 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("retract_length_toolchange", coFloats);
-    def->label = "Length";
+    def->label = __TRANS("Length");
     def->full_label = "Retraction Length (Toolchange)";
-    def->tooltip = "When retraction is triggered before changing tool, filament is pulled back by the specified amount (the length is measured on raw filament, before it enters the extruder).";
+    def->tooltip = __TRANS("When retraction is triggered before changing tool, filament is pulled back by the specified amount (the length is measured on raw filament, before it enters the extruder).");
     def->sidetext = "mm (zero to disable)";
     def->cli = "retract-length-toolchange=f@";
     {
@@ -1003,9 +1003,9 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("retract_lift", coFloats);
-    def->label = "Lift Z";
-    def->category = "Retraction";
-    def->tooltip = "If you set this to a positive value, Z is quickly raised every time a retraction is triggered. When using multiple extruders, only the setting for the first extruder will be considered.";
+    def->label = __TRANS("Lift Z");
+    def->category = __TRANS("Retraction");
+    def->tooltip = __TRANS("If you set this to a positive value, Z is quickly raised every time a retraction is triggered. When using multiple extruders, only the setting for the first extruder will be considered.");
     def->sidetext = "mm";
     def->cli = "retract-lift=f@";
     {
@@ -1015,10 +1015,10 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("retract_lift_above", coFloats);
-    def->label = "Above Z";
+    def->label = __TRANS("Above Z");
     def->full_label = "Only lift Z above";
-    def->category = "Retraction";
-    def->tooltip = "If you set this to a positive value, Z lift will only take place above the specified absolute Z. You can tune this setting for skipping lift on the first layers.";
+    def->category = __TRANS("Retraction");
+    def->tooltip = __TRANS("If you set this to a positive value, Z lift will only take place above the specified absolute Z. You can tune this setting for skipping lift on the first layers.");
     def->sidetext = "mm";
     def->cli = "retract-lift-above=f@";
     {
@@ -1028,10 +1028,10 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("retract_lift_below", coFloats);
-    def->label = "Below Z";
+    def->label = __TRANS("Below Z");
     def->full_label = "Only lift Z below";
-    def->category = "Retraction";
-    def->tooltip = "If you set this to a positive value, Z lift will only take place below the specified absolute Z. You can tune this setting for limiting lift to the first layers.";
+    def->category = __TRANS("Retraction");
+    def->tooltip = __TRANS("If you set this to a positive value, Z lift will only take place below the specified absolute Z. You can tune this setting for limiting lift to the first layers.");
     def->sidetext = "mm";
     def->cli = "retract-lift-below=f@";
     {
@@ -1041,9 +1041,9 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("retract_restart_extra", coFloats);
-    def->label = "Extra length on restart";
-    def->category = "Retraction";
-    def->tooltip = "When the retraction is compensated after the travel move, the extruder will push this additional amount of filament. This setting is rarely needed.";
+    def->label = __TRANS("Extra length on restart");
+    def->category = __TRANS("Retraction");
+    def->tooltip = __TRANS("When the retraction is compensated after the travel move, the extruder will push this additional amount of filament. This setting is rarely needed.");
     def->sidetext = "mm";
     def->cli = "retract-restart-extra=f@";
     {
@@ -1053,8 +1053,8 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("retract_restart_extra_toolchange", coFloats);
-    def->label = "Extra length on restart";
-    def->tooltip = "When the retraction is compensated after changing tool, the extruder will push this additional amount of filament.";
+    def->label = __TRANS("Extra length on restart");
+    def->tooltip = __TRANS("When the retraction is compensated after changing tool, the extruder will push this additional amount of filament.");
     def->sidetext = "mm";
     def->cli = "retract-restart-extra-toolchange=f@";
     {
@@ -1064,9 +1064,9 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("retract_speed", coFloats);
-    def->label = "Speed";
-    def->category = "Retraction";
-    def->tooltip = "The speed for retractions (it only applies to the extruder motor). If you use the Firmware Retraction option, please note this value still affects the auto-speed pressure regulator.";
+    def->label = __TRANS("Speed");
+    def->category = __TRANS("Retraction");
+    def->tooltip = __TRANS("The speed for retractions (it only applies to the extruder motor). If you use the Firmware Retraction option, please note this value still affects the auto-speed pressure regulator.");
     def->sidetext = "mm/s";
     def->cli = "retract-speed=f@";
     {
@@ -1076,9 +1076,9 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("seam_position", coEnum);
-    def->label = "Seam position";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Position of perimeters starting points.";
+    def->label = __TRANS("Seam position");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Position of perimeters starting points.");
     def->cli = "seam-position=s";
     def->enum_keys_map = ConfigOptionEnum<SeamPosition>::get_enum_values();
     def->enum_values.push_back("random");
@@ -1095,16 +1095,16 @@ PrintConfigDef::PrintConfigDef()
     def->gui_type = "select_open";
     def->label = "";
     def->full_label = "Serial port";
-    def->tooltip = "USB/serial port for printer connection.";
+    def->tooltip = __TRANS("USB/serial port for printer connection.");
     def->cli = "serial-port=s";
     def->width = 200;
     def->default_value = new ConfigOptionString("");
 
     def = this->add("serial_speed", coInt);
     def->gui_type = "i_enum_open";
-    def->label = "Speed";
+    def->label = __TRANS("Speed");
     def->full_label = "Serial port speed";
-    def->tooltip = "Speed (baud) of USB/serial port for printer connection.";
+    def->tooltip = __TRANS("Speed (baud) of USB/serial port for printer connection.");
     def->cli = "serial-speed=i";
     def->min = 1;
     def->max = 300000;
@@ -1114,34 +1114,34 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(250000);
 
     def = this->add("skirt_distance", coFloat);
-    def->label = "Distance from object";
-    def->category = "Skirt and brim";
-    def->tooltip = "Distance between skirt and object(s). Set this to zero to attach the skirt to the object(s) and get a brim for better adhesion.";
+    def->label = __TRANS("Distance from object");
+    def->category = __TRANS("Skirt and brim");
+    def->tooltip = __TRANS("Distance between skirt and object(s). Set this to zero to attach the skirt to the object(s) and get a brim for better adhesion.");
     def->sidetext = "mm";
     def->cli = "skirt-distance=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(6);
 
     def = this->add("skirt_height", coInt);
-    def->label = "Skirt height";
-    def->category = "Skirt and brim";
-    def->tooltip = "Height of skirt expressed in layers. Set this to a tall value to use skirt as a shield against drafts.";
+    def->label = __TRANS("Skirt height");
+    def->category = __TRANS("Skirt and brim");
+    def->tooltip = __TRANS("Height of skirt expressed in layers. Set this to a tall value to use skirt as a shield against drafts.");
     def->sidetext = "layers";
     def->cli = "skirt-height=i";
     def->default_value = new ConfigOptionInt(1);
 
     def = this->add("skirts", coInt);
-    def->label = "Loops (minimum)";
-    def->category = "Skirt and brim";
+    def->label = __TRANS("Loops (minimum)");
+    def->category = __TRANS("Skirt and brim");
     def->full_label = "Skirt Loops";
-    def->tooltip = "Number of loops for the skirt. If the Minimum Extrusion Length option is set, the number of loops might be greater than the one configured here. Set this to zero to disable skirt completely.";
+    def->tooltip = __TRANS("Number of loops for the skirt. If the Minimum Extrusion Length option is set, the number of loops might be greater than the one configured here. Set this to zero to disable skirt completely.");
     def->cli = "skirts=i";
     def->min = 0;
     def->default_value = new ConfigOptionInt(1);
     
     def = this->add("slowdown_below_layer_time", coInt);
-    def->label = "Slow down if layer print time is below";
-    def->tooltip = "If layer print time is estimated below this number of seconds, print moves speed will be scaled down to extend duration to this value.";
+    def->label = __TRANS("Slow down if layer print time is below");
+    def->tooltip = __TRANS("If layer print time is estimated below this number of seconds, print moves speed will be scaled down to extend duration to this value.");
     def->sidetext = "approximate seconds";
     def->cli = "slowdown-below-layer-time=i";
     def->width = 60;
@@ -1150,11 +1150,11 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(5);
 
     def = this->add("small_perimeter_speed", coFloatOrPercent);
-    def->label = "↳ small";
+    def->label = __TRANS("↳ small");
     def->full_label = "Small perimeters speed";
     def->gui_type = "f_enum_open";
-    def->category = "Speed";
-    def->tooltip = "This separate setting will affect the speed of perimeters having radius <= 6.5mm (usually holes). If expressed as percentage (for example: 80%) it will be calculated on the perimeters speed setting above.";
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("This separate setting will affect the speed of perimeters having radius <= 6.5mm (usually holes). If expressed as percentage (for example: 80%) it will be calculated on the perimeters speed setting above.");
     def->sidetext = "mm/s or %";
     def->cli = "small-perimeter-speed=s";
     def->ratio_over = "perimeter_speed";
@@ -1164,37 +1164,37 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(15, false);
 
     def = this->add("solid_infill_below_area", coFloat);
-    def->label = "Solid infill threshold area";
-    def->category = "Infill";
-    def->tooltip = "Force solid infill for regions having a smaller area than the specified threshold.";
+    def->label = __TRANS("Solid infill threshold area");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("Force solid infill for regions having a smaller area than the specified threshold.");
     def->sidetext = "mm²";
     def->cli = "solid-infill-below-area=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(70);
 
     def = this->add("solid_infill_extruder", coInt);
-    def->label = "Solid infill extruder";
-    def->category = "Extruders";
-    def->tooltip = "The extruder to use when printing solid infill.";
+    def->label = __TRANS("Solid infill extruder");
+    def->category = __TRANS("Extruders");
+    def->tooltip = __TRANS("The extruder to use when printing solid infill.");
     def->cli = "solid-infill-extruder=i";
     def->min = 1;
     def->default_value = new ConfigOptionInt(1);
 
     def = this->add("solid_infill_every_layers", coInt);
-    def->label = "Solid infill every";
-    def->category = "Infill";
-    def->tooltip = "This feature allows to force a solid layer every given number of layers. Zero to disable. You can set this to any value (for example 9999); Slic3r will automatically choose the maximum possible number of layers to combine according to nozzle diameter and layer height.";
+    def->label = __TRANS("Solid infill every");
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("This feature allows to force a solid layer every given number of layers. Zero to disable. You can set this to any value (for example 9999); Slic3r will automatically choose the maximum possible number of layers to combine according to nozzle diameter and layer height.");
     def->sidetext = "layers";
     def->cli = "solid-infill-every-layers=i";
     def->min = 0;
     def->default_value = new ConfigOptionInt(0);
 
     def = this->add("solid_infill_extrusion_width", coFloatOrPercent);
-    def->label = "↳ solid";
+    def->label = __TRANS("↳ solid");
     def->full_label = "Solid infill extrusion width";
     def->gui_type = "f_enum_open";
-    def->category = "Extrusion Width";
-    def->tooltip = "Set this to a non-zero value to set a manual extrusion width for infill for solid surfaces. If expressed as percentage (for example 90%) it will be computed over layer height.";
+    def->category = __TRANS("Extrusion Width");
+    def->tooltip = __TRANS("Set this to a non-zero value to set a manual extrusion width for infill for solid surfaces. If expressed as percentage (for example 90%) it will be computed over layer height.");
     def->sidetext = "mm or %";
     def->cli = "solid-infill-extrusion-width=s";
     def->min = 0;
@@ -1203,11 +1203,11 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(0, false);
 
     def = this->add("solid_infill_speed", coFloatOrPercent);
-    def->label = "↳ solid";
+    def->label = __TRANS("↳ solid");
     def->full_label = "Solid infill speed";
     def->gui_type = "f_enum_open";
-    def->category = "Speed";
-    def->tooltip = "Speed for printing solid regions (top/bottom/internal horizontal shells). This can be expressed as a percentage (for example: 80%) over the default infill speed above.";
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("Speed for printing solid regions (top/bottom/internal horizontal shells). This can be expressed as a percentage (for example: 80%) over the default infill speed above.");
     def->sidetext = "mm/s or %";
     def->cli = "solid-infill-speed=s";
     def->ratio_over = "infill_speed";
@@ -1218,25 +1218,25 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(20, false);
 
     def = this->add("solid_layers", coInt);
-    def->label = "Solid layers";
-    def->tooltip = "Number of solid layers to generate on top and bottom surfaces.";
+    def->label = __TRANS("Solid layers");
+    def->tooltip = __TRANS("Number of solid layers to generate on top and bottom surfaces.");
     def->cli = "solid-layers=i";
     def->shortcut.push_back("top_solid_layers");
     def->shortcut.push_back("bottom_solid_layers");
     def->min = 0;
 
     def = this->add("spiral_vase", coBool);
-    def->label = "Spiral vase";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "This feature will raise Z gradually while printing a single-walled object in order to remove any visible seam. This option requires a single perimeter, no infill, no top solid layers and no support material. You can still set any number of bottom solid layers as well as skirt/brim loops. It won't work when printing more than an object.";
+    def->label = __TRANS("Spiral vase");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("This feature will raise Z gradually while printing a single-walled object in order to remove any visible seam. This option requires a single perimeter, no infill, no top solid layers and no support material. You can still set any number of bottom solid layers as well as skirt/brim loops. It won't work when printing more than an object.");
     def->cli = "spiral-vase!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("standby_temperature_delta", coInt);
-    def->label = "Temperature variation";
+    def->label = __TRANS("Temperature variation");
     def->full_label = "Standby temperature delta";
-    def->category = "Extruders";
-    def->tooltip = "Temperature difference to be applied when an extruder is not active.  Enables a full-height \"sacrificial\" skirt on which the nozzles are periodically wiped.";
+    def->category = __TRANS("Extruders");
+    def->tooltip = __TRANS("Temperature difference to be applied when an extruder is not active.  Enables a full-height \"sacrificial\" skirt on which the nozzles are periodically wiped.");
     def->sidetext = "∆°C";
     def->cli = "standby-temperature-delta=i";
     def->min = -500;
@@ -1244,8 +1244,8 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(-5);
 
     def = this->add("start_gcode", coString);
-    def->label = "Start G-code";
-    def->tooltip = "This start procedure is inserted at the beginning, after bed has reached the target temperature and extruder just started heating, and before extruder has finished heating. If Slic3r detects M104, M109, M140 or M190 in your custom codes, such commands will not be prepended automatically so you're free to customize the order of heating commands and other custom actions. Note that you can use placeholder variables for all Slic3r settings, so you can put a \"M109 S[first_layer_temperature]\" command wherever you want.";
+    def->label = __TRANS("Start G-code");
+    def->tooltip = __TRANS("This start procedure is inserted at the beginning, after bed has reached the target temperature and extruder just started heating, and before extruder has finished heating. If Slic3r detects M104, M109, M140 or M190 in your custom codes, such commands will not be prepended automatically so you're free to customize the order of heating commands and other custom actions. Note that you can use placeholder variables for all Slic3r settings, so you can put a \"M109 S[first_layer_temperature]\" command wherever you want.");
     def->cli = "start-gcode=s";
     def->multiline = true;
     def->full_width = true;
@@ -1253,8 +1253,8 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionString("G28 ; home all axes\nG1 Z5 F5000 ; lift nozzle\n");
 
     def = this->add("start_filament_gcode", coStrings);
-    def->label = "Start G-code";
-    def->tooltip = "This start procedure is inserted at the beginning, after any printer start gcode. This is used to override settings for a specific filament. If Slic3r detects M104, M109, M140 or M190 in your custom codes, such commands will not be prepended automatically so you're free to customize the order of heating commands and other custom actions. Note that you can use placeholder variables for all Slic3r settings, so you can put a \"M109 S[first_layer_temperature]\" command wherever you want. If you have multiple extruders, the gcode is processed in extruder order.";
+    def->label = __TRANS("Start G-code");
+    def->tooltip = __TRANS("This start procedure is inserted at the beginning, after any printer start gcode. This is used to override settings for a specific filament. If Slic3r detects M104, M109, M140 or M190 in your custom codes, such commands will not be prepended automatically so you're free to customize the order of heating commands and other custom actions. Note that you can use placeholder variables for all Slic3r settings, so you can put a \"M109 S[first_layer_temperature]\" command wherever you want. If you have multiple extruders, the gcode is processed in extruder order.");
     def->cli = "start-filament-gcode=s@";
     def->multiline = true;
     def->full_width = true;
@@ -1266,16 +1266,16 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("support_material", coBool);
-    def->label = "Generate support material";
-    def->category = "Support material";
-    def->tooltip = "Enable support material generation.";
+    def->label = __TRANS("Generate support material");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Enable support material generation.");
     def->cli = "support-material!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("support_material_angle", coInt);
-    def->label = "Pattern angle";
-    def->category = "Support material";
-    def->tooltip = "Use this setting to rotate the support material pattern on the horizontal plane.";
+    def->label = __TRANS("Pattern angle");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Use this setting to rotate the support material pattern on the horizontal plane.");
     def->sidetext = "°";
     def->cli = "support-material-angle=i";
     def->min = 0;
@@ -1283,17 +1283,17 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(0);
 
     def = this->add("support_material_buildplate_only", coBool);
-    def->label = "Support on build plate only";
-    def->category = "Support material";
-    def->tooltip = "Only create support if it lies on a build plate. Don't create support on a print.";
+    def->label = __TRANS("Support on build plate only");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Only create support if it lies on a build plate. Don't create support on a print.");
     def->cli = "support-material-buildplate-only!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("support_material_contact_distance", coFloat);
     def->gui_type = "f_enum_open";
-    def->label = "Contact Z distance";
-    def->category = "Support material";
-    def->tooltip = "The vertical distance between object and support material interface. Setting this to 0 will also prevent Slic3r from using bridge flow and speed for the first object layer.";
+    def->label = __TRANS("Contact Z distance");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("The vertical distance between object and support material interface. Setting this to 0 will also prevent Slic3r from using bridge flow and speed for the first object layer.");
     def->sidetext = "mm";
     def->cli = "support-material-contact-distance=f";
     def->min = 0;
@@ -1304,9 +1304,9 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloat(0.2);
 
     def = this->add("support_material_enforce_layers", coInt);
-    def->label = "Enforce support for the first";
-    def->category = "Support material";
-    def->tooltip = "Generate support material for the specified number of layers counting from bottom, regardless of whether normal support material is enabled or not and regardless of any angle threshold. This is useful for getting more adhesion of objects having a very thin or poor footprint on the build plate.";
+    def->label = __TRANS("Enforce support for the first");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Generate support material for the specified number of layers counting from bottom, regardless of whether normal support material is enabled or not and regardless of any angle threshold. This is useful for getting more adhesion of objects having a very thin or poor footprint on the build plate.");
     def->sidetext = "layers";
     def->cli = "support-material-enforce-layers=f";
     def->full_label = "Enforce support for the first n layers";
@@ -1314,18 +1314,18 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionInt(0);
 
     def = this->add("support_material_extruder", coInt);
-    def->label = "Support material/raft/skirt extruder";
-    def->category = "Extruders";
-    def->tooltip = "The extruder to use when printing support material, raft and skirt.";
+    def->label = __TRANS("Support material/raft/skirt extruder");
+    def->category = __TRANS("Extruders");
+    def->tooltip = __TRANS("The extruder to use when printing support material, raft and skirt.");
     def->cli = "support-material-extruder=i";
     def->min = 1;
     def->default_value = new ConfigOptionInt(1);
 
     def = this->add("support_material_extrusion_width", coFloatOrPercent);
-    def->label = "Support material";
+    def->label = __TRANS("Support material");
     def->gui_type = "f_enum_open";
-    def->category = "Extrusion Width";
-    def->tooltip = "Set this to a non-zero value to set a manual extrusion width for support material. If expressed as percentage (for example 90%) it will be computed over layer height.";
+    def->category = __TRANS("Extrusion Width");
+    def->tooltip = __TRANS("Set this to a non-zero value to set a manual extrusion width for support material. If expressed as percentage (for example 90%) it will be computed over layer height.");
     def->sidetext = "mm or %";
     def->cli = "support-material-extrusion-width=s";
     def->min = 0;
@@ -1334,38 +1334,38 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(0, false);
 
     def = this->add("support_material_interface_extruder", coInt);
-    def->label = "Support material/raft interface extruder";
-    def->category = "Extruders";
-    def->tooltip = "The extruder to use when printing support material interface. This affects raft too.";
+    def->label = __TRANS("Support material/raft interface extruder");
+    def->category = __TRANS("Extruders");
+    def->tooltip = __TRANS("The extruder to use when printing support material interface. This affects raft too.");
     def->cli = "support-material-interface-extruder=i";
     def->min = 1;
     def->default_value = new ConfigOptionInt(1);
 
     def = this->add("support_material_interface_layers", coInt);
-    def->label = "Interface layers";
-    def->category = "Support material";
-    def->tooltip = "Number of interface layers to insert between the object(s) and support material.";
+    def->label = __TRANS("Interface layers");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Number of interface layers to insert between the object(s) and support material.");
     def->sidetext = "layers";
     def->cli = "support-material-interface-layers=i";
     def->min = 0;
     def->default_value = new ConfigOptionInt(3);
 
     def = this->add("support_material_interface_spacing", coFloat);
-    def->label = "Interface pattern spacing";
-    def->category = "Support material";
-    def->tooltip = "Spacing between interface lines. Set zero to get a solid interface.";
+    def->label = __TRANS("Interface pattern spacing");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Spacing between interface lines. Set zero to get a solid interface.");
     def->sidetext = "mm";
     def->cli = "support-material-interface-spacing=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("support_material_interface_speed", coFloatOrPercent);
-    def->label = "↳ interface";
-    def->label = "Interface Speed";
-    def->category = "Support material interface speed";
+    def->label = __TRANS("↳ interface");
+    def->label = __TRANS("Interface Speed");
+    def->category = __TRANS("Support material interface speed");
     def->gui_type = "f_enum_open";
-    def->category = "Support material";
-    def->tooltip = "Speed for printing support material interface layers. If expressed as percentage (for example 50%) it will be calculated over support material speed.";
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Speed for printing support material interface layers. If expressed as percentage (for example 50%) it will be calculated over support material speed.");
     def->sidetext = "mm/s or %";
     def->cli = "support-material-interface-speed=s";
     def->ratio_over = "support_material_speed";
@@ -1375,9 +1375,9 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(100, true);
 
     def = this->add("support_material_pattern", coEnum);
-    def->label = "Pattern";
-    def->category = "Support material";
-    def->tooltip = "Pattern used to generate support material.";
+    def->label = __TRANS("Pattern");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Pattern used to generate support material.");
     def->cli = "support-material-pattern=s";
     def->enum_keys_map = ConfigOptionEnum<SupportMaterialPattern>::get_enum_values();
     def->enum_values.push_back("rectilinear");
@@ -1391,9 +1391,9 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionEnum<SupportMaterialPattern>(smpPillars);
 
     def = this->add("support_material_spacing", coFloat);
-    def->label = "Pattern spacing";
-    def->category = "Support material";
-    def->tooltip = "Spacing between support material lines.";
+    def->label = __TRANS("Pattern spacing");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Spacing between support material lines.");
     def->sidetext = "mm";
     def->cli = "support-material-spacing=f";
     def->min = 0;
@@ -1403,10 +1403,10 @@ PrintConfigDef::PrintConfigDef()
 
 
     def = this->add("support_material_speed", coFloat);
-    def->label = "Support material";
+    def->label = __TRANS("Support material");
     def->gui_type = "f_enum_open";
-    def->category = "Support material";
-    def->tooltip = "Speed for printing support material.";
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Speed for printing support material.");
     def->sidetext = "mm/s";
     def->cli = "support-material-speed=f";
     def->min = 0;
@@ -1415,9 +1415,9 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloat(60);
 
     def = this->add("support_material_threshold", coFloatOrPercent);
-    def->label = "Overhang threshold";
-    def->category = "Support material";
-    def->tooltip = "Support material will not be generated for overhangs whose slope angle (90° = vertical) is above the given threshold. In other words, this value represent the most horizontal slope (measured from the horizontal plane) that you can print without support material. Set to a percentage to automatically detect based on some % of overhanging perimeter width instead (recommended).";
+    def->label = __TRANS("Overhang threshold");
+    def->category = __TRANS("Support material");
+    def->tooltip = __TRANS("Support material will not be generated for overhangs whose slope angle (90° = vertical) is above the given threshold. In other words, this value represent the most horizontal slope (measured from the horizontal plane) that you can print without support material. Set to a percentage to automatically detect based on some % of overhanging perimeter width instead (recommended).");
     def->sidetext = "° (or %)";
     def->cli = "support-material-threshold=s";
     def->min = 0;
@@ -1425,8 +1425,8 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(60, true);
 
     def = this->add("temperature", coInts);
-    def->label = "Other layers";
-    def->tooltip = "Extruder temperature for layers after the first one. Set this to zero to disable temperature control commands in the output.";
+    def->label = __TRANS("Other layers");
+    def->tooltip = __TRANS("Extruder temperature for layers after the first one. Set this to zero to disable temperature control commands in the output.");
     def->cli = "temperature=i@";
     def->full_label = "Temperature";
     def->max = 0;
@@ -1438,15 +1438,15 @@ PrintConfigDef::PrintConfigDef()
     }
     
     def = this->add("thin_walls", coBool);
-    def->label = "Detect thin walls";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Detect single-width walls (parts where two extrusions don't fit and we need to collapse them into a single trace).";
+    def->label = __TRANS("Detect thin walls");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Detect single-width walls (parts where two extrusions don't fit and we need to collapse them into a single trace).");
     def->cli = "thin-walls!";
     def->default_value = new ConfigOptionBool(true);
 
     def = this->add("threads", coInt);
-    def->label = "Threads";
-    def->tooltip = "Threads are used to parallelize long-running tasks. Optimal threads number is slightly above the number of available cores/processors.";
+    def->label = __TRANS("Threads");
+    def->tooltip = __TRANS("Threads are used to parallelize long-running tasks. Optimal threads number is slightly above the number of available cores/processors.");
     def->readonly = true;
     def->min = 1;
     {
@@ -1455,8 +1455,8 @@ PrintConfigDef::PrintConfigDef()
     }
     
     def = this->add("toolchange_gcode", coString);
-    def->label = "Tool change G-code";
-    def->tooltip = "This custom code is inserted right before every extruder change. Note that you can use placeholder variables for all Slic3r settings as well as [previous_extruder] and [next_extruder].";
+    def->label = __TRANS("Tool change G-code");
+    def->tooltip = __TRANS("This custom code is inserted right before every extruder change. Note that you can use placeholder variables for all Slic3r settings as well as [previous_extruder] and [next_extruder].");
     def->cli = "toolchange-gcode=s";
     def->multiline = true;
     def->full_width = true;
@@ -1464,11 +1464,11 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionString("");
 
     def = this->add("top_infill_extrusion_width", coFloatOrPercent);
-    def->label = "↳ top solid";
+    def->label = __TRANS("↳ top solid");
     def->full_label = "Top solid infill extrusion width";
     def->gui_type = "f_enum_open";
-    def->category = "Extrusion Width";
-    def->tooltip = "Set this to a non-zero value to set a manual extrusion width for infill for top surfaces. You may want to use thinner extrudates to fill all narrow regions and get a smoother finish. If expressed as percentage (for example 90%) it will be computed over layer height.";
+    def->category = __TRANS("Extrusion Width");
+    def->tooltip = __TRANS("Set this to a non-zero value to set a manual extrusion width for infill for top surfaces. You may want to use thinner extrudates to fill all narrow regions and get a smoother finish. If expressed as percentage (for example 90%) it will be computed over layer height.");
     def->sidetext = "mm or %";
     def->cli = "top-infill-extrusion-width=s";
     def->min = 0;
@@ -1477,19 +1477,19 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(0, false);
 
     def = this->add("top_infill_pattern", external_fill_pattern);
-    def->label = "Top";
+    def->label = __TRANS("Top");
     def->full_label = "Top infill pattern";
-    def->category = "Infill";
-    def->tooltip = "Infill pattern for top layers. This only affects the external visible layer, and not its adjacent solid shells.";
+    def->category = __TRANS("Infill");
+    def->tooltip = __TRANS("Infill pattern for top layers. This only affects the external visible layer, and not its adjacent solid shells.");
     def->cli = "top-infill-pattern=s";
     def->default_value = new ConfigOptionEnum<InfillPattern>(ipRectilinear);
 
     def = this->add("top_solid_infill_speed", coFloatOrPercent);
-    def->label = "↳ top solid";
+    def->label = __TRANS("↳ top solid");
     def->full_label = "Top solid infill speed";
     def->gui_type = "f_enum_open";
-    def->category = "Speed";
-    def->tooltip = "Speed for printing top solid layers (it only applies to the uppermost external layers and not to their internal solid layers). You may want to slow down this to get a nicer surface finish. This can be expressed as a percentage (for example: 80%) over the solid infill speed above.";
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("Speed for printing top solid layers (it only applies to the uppermost external layers and not to their internal solid layers). You may want to slow down this to get a nicer surface finish. This can be expressed as a percentage (for example: 80%) over the solid infill speed above.");
     def->sidetext = "mm/s or %";
     def->cli = "top-solid-infill-speed=s";
     def->ratio_over = "solid_infill_speed";
@@ -1499,18 +1499,18 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloatOrPercent(15, false);
 
     def = this->add("top_solid_layers", coInt);
-    def->label = "Top";
-    def->category = "Layers and Perimeters";
-    def->tooltip = "Number of solid layers to generate on top surfaces.";
+    def->label = __TRANS("Top");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Number of solid layers to generate on top surfaces.");
     def->cli = "top-solid-layers=i";
     def->full_label = "Top solid layers";
     def->min = 0;
     def->default_value = new ConfigOptionInt(3);
 
     def = this->add("travel_speed", coFloat);
-    def->label = "Travel";
-    def->category = "Speed";
-    def->tooltip = "Speed for travel moves (jumps between distant extrusion points).";
+    def->label = __TRANS("Travel");
+    def->category = __TRANS("Speed");
+    def->tooltip = __TRANS("Speed for travel moves (jumps between distant extrusion points).");
     def->sidetext = "mm/s";
     def->cli = "travel-speed=f";
     def->aliases.push_back("travel_feed_rate");
@@ -1518,35 +1518,35 @@ PrintConfigDef::PrintConfigDef()
     def->default_value = new ConfigOptionFloat(130);
 
     def = this->add("use_firmware_retraction", coBool);
-    def->label = "Use firmware retraction";
-    def->tooltip = "This experimental setting uses G10 and G11 commands to have the firmware handle the retraction. This is only supported in recent Marlin.";
+    def->label = __TRANS("Use firmware retraction");
+    def->tooltip = __TRANS("This experimental setting uses G10 and G11 commands to have the firmware handle the retraction. This is only supported in recent Marlin.");
     def->cli = "use-firmware-retraction!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("use_relative_e_distances", coBool);
-    def->label = "Use relative E distances";
-    def->tooltip = "If your firmware requires relative E values, check this, otherwise leave it unchecked. Most firmwares use absolute values.";
+    def->label = __TRANS("Use relative E distances");
+    def->tooltip = __TRANS("If your firmware requires relative E values, check this, otherwise leave it unchecked. Most firmwares use absolute values.");
     def->cli = "use-relative-e-distances!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("use_volumetric_e", coBool);
-    def->label = "Use volumetric E";
-    def->tooltip = "This experimental setting uses outputs the E values in cubic millimeters instead of linear millimeters. If your firmware doesn't already know filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] T0' in your start G-code in order to turn volumetric mode on and use the filament diameter associated to the filament selected in Slic3r. This is only supported in recent Marlin.";
+    def->label = __TRANS("Use volumetric E");
+    def->tooltip = __TRANS("This experimental setting uses outputs the E values in cubic millimeters instead of linear millimeters. If your firmware doesn't already know filament diameter(s), you can put commands like 'M200 D[filament_diameter_0] T0' in your start G-code in order to turn volumetric mode on and use the filament diameter associated to the filament selected in Slic3r. This is only supported in recent Marlin.");
     def->cli = "use-volumetric-e!";
     def->default_value = new ConfigOptionBool(false);
 
     def = this->add("vibration_limit", coFloat);
-    def->label = "Vibration limit (deprecated)";
-    def->tooltip = "This experimental option will slow down those moves hitting the configured frequency limit. The purpose of limiting vibrations is to avoid mechanical resonance. Set zero to disable.";
+    def->label = __TRANS("Vibration limit (deprecated)");
+    def->tooltip = __TRANS("This experimental option will slow down those moves hitting the configured frequency limit. The purpose of limiting vibrations is to avoid mechanical resonance. Set zero to disable.");
     def->sidetext = "Hz";
     def->cli = "vibration-limit=f";
     def->min = 0;
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("wipe", coBools);
-    def->label = "Wipe while retracting";
-    def->category = "Retraction";
-    def->tooltip = "This flag will move the nozzle while retracting to minimize the possible blob on leaky extruders.";
+    def->label = __TRANS("Wipe while retracting");
+    def->category = __TRANS("Retraction");
+    def->tooltip = __TRANS("This flag will move the nozzle while retracting to minimize the possible blob on leaky extruders.");
     def->cli = "wipe!";
     {
         ConfigOptionBools* opt = new ConfigOptionBools();
@@ -1555,23 +1555,23 @@ PrintConfigDef::PrintConfigDef()
     }
 
     def = this->add("xy_size_compensation", coFloat);
-    def->label = "XY Size Compensation";
-    def->category = "Advanced";
-    def->tooltip = "The object will be grown/shrunk in the XY plane by the configured value (negative = inwards, positive = outwards). This might be useful for fine-tuning hole sizes.";
+    def->label = __TRANS("XY Size Compensation");
+    def->category = __TRANS("Advanced");
+    def->tooltip = __TRANS("The object will be grown/shrunk in the XY plane by the configured value (negative = inwards, positive = outwards). This might be useful for fine-tuning hole sizes.");
     def->sidetext = "mm";
     def->cli = "xy-size-compensation=f";
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("z_offset", coFloat);
-    def->label = "Z offset";
-    def->tooltip = "This value will be added (or subtracted) from all the Z coordinates in the output G-code. It is used to compensate for bad Z endstop position: for example, if your endstop zero actually leaves the nozzle 0.3mm far from the print bed, set this to -0.3 (or fix your endstop).";
+    def->label = __TRANS("Z offset");
+    def->tooltip = __TRANS("This value will be added (or subtracted) from all the Z coordinates in the output G-code. It is used to compensate for bad Z endstop position: for example, if your endstop zero actually leaves the nozzle 0.3mm far from the print bed, set this to -0.3 (or fix your endstop).");
     def->sidetext = "mm";
     def->cli = "z-offset=f";
     def->default_value = new ConfigOptionFloat(0);
 
     def = this->add("z_steps_per_mm", coFloat);
-    def->label = "Z full steps/mm";
-    def->tooltip = "Set this to the number of *full* steps (not microsteps) needed for moving the Z axis by 1mm; you can calculate this by dividing the number of microsteps configured in your firmware by the microstepping amount (8, 16, 32). Slic3r will round your configured layer height to the nearest multiple of that value in order to ensure the best accuracy. This is most useful for machines with imperial leadscrews or belt-driven Z or for unusual layer heights with metric leadscrews. Set to zero to disable this experimental feature.";
+    def->label = __TRANS("Z full steps/mm");
+    def->tooltip = __TRANS("Set this to the number of *full* steps (not microsteps) needed for moving the Z axis by 1mm; you can calculate this by dividing the number of microsteps configured in your firmware by the microstepping amount (8, 16, 32). Slic3r will round your configured layer height to the nearest multiple of that value in order to ensure the best accuracy. This is most useful for machines with imperial leadscrews or belt-driven Z or for unusual layer heights with metric leadscrews. Set to zero to disable this experimental feature.");
     def->cli = "z-steps-per-mm=f";
     def->default_value = new ConfigOptionFloat(0);
 }
@@ -1713,98 +1713,98 @@ CLIConfigDef::CLIConfigDef()
     ConfigOptionDef* def;
     
     def = this->add("cut", coFloat);
-    def->label = "Cut";
-    def->tooltip = "Cut model at the given Z.";
+    def->label = __TRANS("Cut");
+    def->tooltip = __TRANS("Cut model at the given Z.");
     def->cli = "cut";
     def->default_value = new ConfigOptionFloat(0);
     
     def = this->add("cut_grid", coFloat);
-    def->label = "Cut";
-    def->tooltip = "Cut model in the XY plane into tiles of the specified max size.";
+    def->label = __TRANS("Cut");
+    def->tooltip = __TRANS("Cut model in the XY plane into tiles of the specified max size.");
     def->cli = "cut-grid";
     def->default_value = new ConfigOptionPoint();
     
     def = this->add("cut_x", coFloat);
-    def->label = "Cut";
-    def->tooltip = "Cut model at the given X.";
+    def->label = __TRANS("Cut");
+    def->tooltip = __TRANS("Cut model at the given X.");
     def->cli = "cut-x";
     def->default_value = new ConfigOptionFloat(0);
     
     def = this->add("cut_y", coFloat);
-    def->label = "Cut";
-    def->tooltip = "Cut model at the given Y.";
+    def->label = __TRANS("Cut");
+    def->tooltip = __TRANS("Cut model at the given Y.");
     def->cli = "cut-y";
     def->default_value = new ConfigOptionFloat(0);
     
     def = this->add("export_obj", coBool);
-    def->label = "Export SVG";
-    def->tooltip = "Export the model as OBJ.";
+    def->label = __TRANS("Export SVG");
+    def->tooltip = __TRANS("Export the model as OBJ.");
     def->cli = "export-obj";
     def->default_value = new ConfigOptionBool(false);
     
     def = this->add("export_pov", coBool);
-    def->label = "Export POV";
-    def->tooltip = "Export the model as POV-Ray definition.";
+    def->label = __TRANS("Export POV");
+    def->tooltip = __TRANS("Export the model as POV-Ray definition.");
     def->cli = "export-pov";
     def->default_value = new ConfigOptionBool(false);
     
     def = this->add("export_svg", coBool);
-    def->label = "Export SVG";
-    def->tooltip = "Slice the model and export slices as SVG.";
+    def->label = __TRANS("Export SVG");
+    def->tooltip = __TRANS("Slice the model and export slices as SVG.");
     def->cli = "export-svg";
     def->default_value = new ConfigOptionBool(false);
     
     def = this->add("info", coBool);
-    def->label = "Output Model Info";
-    def->tooltip = "Write information about the model to the console.";
+    def->label = __TRANS("Output Model Info");
+    def->tooltip = __TRANS("Write information about the model to the console.");
     def->cli = "info";
     def->default_value = new ConfigOptionBool(false);
     
     def = this->add("load", coStrings);
-    def->label = "Load config file";
-    def->tooltip = "Load configuration from the specified file. It can be used more than once to load options from multiple files.";
+    def->label = __TRANS("Load config file");
+    def->tooltip = __TRANS("Load configuration from the specified file. It can be used more than once to load options from multiple files.");
     def->cli = "load";
     def->default_value = new ConfigOptionStrings();
     
     def = this->add("output", coString);
-    def->label = "Output File";
-    def->tooltip = "The file where the output will be written (if not specified, it will be based on the input file).";
+    def->label = __TRANS("Output File");
+    def->tooltip = __TRANS("The file where the output will be written (if not specified, it will be based on the input file).");
     def->cli = "output";
     def->default_value = new ConfigOptionString("");
     
     def = this->add("rotate", coFloat);
-    def->label = "Rotate";
-    def->tooltip = "Rotation angle around the Z axis in degrees (0-360, default: 0).";
+    def->label = __TRANS("Rotate");
+    def->tooltip = __TRANS("Rotation angle around the Z axis in degrees (0-360, default: 0).");
     def->cli = "rotate";
     def->default_value = new ConfigOptionFloat(0);
     
     def = this->add("rotate_x", coFloat);
-    def->label = "Rotate around X";
-    def->tooltip = "Rotation angle around the X axis in degrees (0-360, default: 0).";
+    def->label = __TRANS("Rotate around X");
+    def->tooltip = __TRANS("Rotation angle around the X axis in degrees (0-360, default: 0).");
     def->cli = "rotate-x";
     def->default_value = new ConfigOptionFloat(0);
     
     def = this->add("rotate_y", coFloat);
-    def->label = "Rotate around Y";
-    def->tooltip = "Rotation angle around the Y axis in degrees (0-360, default: 0).";
+    def->label = __TRANS("Rotate around Y");
+    def->tooltip = __TRANS("Rotation angle around the Y axis in degrees (0-360, default: 0).");
     def->cli = "rotate-y";
     def->default_value = new ConfigOptionFloat(0);
     
     def = this->add("save", coString);
-    def->label = "Save config file";
-    def->tooltip = "Save configuration to the specified file.";
+    def->label = __TRANS("Save config file");
+    def->tooltip = __TRANS("Save configuration to the specified file.");
     def->cli = "save";
     def->default_value = new ConfigOptionString();
     
     def = this->add("scale", coFloat);
-    def->label = "Scale";
-    def->tooltip = "Scaling factor (default: 1).";
+    def->label = __TRANS("Scale");
+    def->tooltip = __TRANS("Scaling factor (default: 1).");
     def->cli = "scale";
     def->default_value = new ConfigOptionFloat(1);
     
     def = this->add("scale_to_fit", coPoint3);
-    def->label = "Scale to Fit";
-    def->tooltip = "Scale to fit the given volume.";
+    def->label = __TRANS("Scale to Fit");
+    def->tooltip = __TRANS("Scale to fit the given volume.");
     def->cli = "scale-to-fit";
     def->default_value = new ConfigOptionPoint3(Pointf3(0,0,0));
 }

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -166,7 +166,7 @@ PrintConfigDef::PrintConfigDef()
 
     def = this->add("disable_fan_first_layers", coInt);
     def->label = __TRANS("Disable fan for the first");
-    def->tooltip = __TRANS("You can set this to a positive value to disable fan at all during the first layers, so that it does not make adhesion worse.");
+    def->tooltip = __TRANS("This disables the fan completely for the first N layers to aid in the adhesion of media to the bed. (default 3)");
     def->sidetext = __TRANS("layers");
     def->cli = "disable-fan-first-layers=i";
     def->min = 0;


### PR DESCRIPTION
Recommend merging if only to avoid headaches later (and give a heads-up to people adding options that they need to wrap strings in libslic3r with the macro for things to work). 

I think that the branch should stay up to collect translations (provide another PR when they are known to work). 

I am unsure if we should include the compiled files here in the repository or run a script over them to generate them during the build process.