### PR TITLE
Raft pattern angles (#3001)

### DIFF
--- a/lib/Slic3r/Print/SupportMaterial.pm
+++ b/lib/Slic3r/Print/SupportMaterial.pm
@@ -753,7 +753,9 @@ sub generate_toolpaths {
         
         # interface and contact infill
         if (@$interface || @$contact_infill) {
-            $fillers{interface}->set_angle(deg2rad($interface_angle));
+            # make interface layers alternate angles by 90 degrees
+            my $alternate_angle = $interface_angle + (90 * (($layer_id + 1) % 2));
+            $fillers{interface}->set_angle(deg2rad($alternate_angle));
             $fillers{interface}->set_min_spacing($_interface_flow->spacing);
             
             # find centerline of the external loop


### PR DESCRIPTION
Added changes suggested by @GregoryNoel that alternates interface layers by 90 degrees (each layer) which improves layer support.

Changes can be seen when viewing interface layers in the layer preview for a given object (set interface layers >1).