### PR TITLE
"Reload from disk" - UI function overhaul

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -52,6 +52,7 @@ use Slic3r::GUI::Preset;
 use Slic3r::GUI::PresetEditor;
 use Slic3r::GUI::PresetEditorDialog;
 use Slic3r::GUI::SLAPrintOptions;
+use Slic3r::GUI::ReloadDialog;
 
 our $have_OpenGL = eval "use Slic3r::GUI::3DScene; 1";
 our $have_LWP    = eval "use LWP::UserAgent; 1";
@@ -91,7 +92,9 @@ our $Settings = {
         color_toolpaths_by => 'role',
         tabbed_preset_editors => 1,
         show_host => 0,
-        nudge_val => 1
+        nudge_val => 1,
+        reload_hide_dialog => 0,
+        reload_behavior => 0
     },
 };
 

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -2319,10 +2319,19 @@ sub reload_from_disk {
         $o->clear_instances;
         $o->add_instance($_) for @{$model_object->instances};
         
-        if ($o->volumes_count == $model_object->volumes_count) {
+        if (($o->volumes_count) <= ($model_object->volumes_count)) {
             for my $i (0..($o->volumes_count-1)) {
                 $o->get_volume($i)->config->apply($model_object->get_volume($i)->config);
             }
+            if ($o->volumes_count != $model_object->volumes_count) {
+                for my $i ($o->volumes_count..($model_object->volumes_count-1)) {
+                    # add_volume merges material and config attributes
+                    my $new_volume = $o->add_volume($model_object->get_volume($i));
+                    $new_volume->set_name($model_object->get_volume($i)->name);
+                    $new_volume->set_input_file($model_object->get_volume($i)->input_file);
+                    $new_volume->set_modifier($model_object->get_volume($i)->modifier);
+				}
+			}
         }
     }
     

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -1213,7 +1213,15 @@ sub load_file {
         my $i = 0;
         foreach my $obj_idx (@obj_idx) {
             $self->{objects}[$obj_idx]->input_file($input_file);
-            $self->{objects}[$obj_idx]->input_file_obj_idx($i++);
+            $self->{objects}[$obj_idx]->input_file_obj_idx($i);
+            
+            # additional information for reloading
+            for my $vol_idx (0..($self->{objects}[$obj_idx]->volumes_count-1)) {
+                $self->{objects}[$obj_idx]->get_volume($vol_idx)->set_input_file($input_file);
+                $self->{objects}[$obj_idx]->get_volume($vol_idx)->set_obj_idx($i);
+                $self->{objects}[$obj_idx]->get_volume($vol_idx)->set_vol_idx($vol_idx);
+            }
+            $i++;
         }
 
         $self->statusbar->SetStatusText("Loaded " . basename($input_file));

--- a/lib/Slic3r/GUI/Plater/ObjectPartsPanel.pm
+++ b/lib/Slic3r/GUI/Plater/ObjectPartsPanel.pm
@@ -353,13 +353,18 @@ sub on_btn_load {
             next;
         }
         
-        foreach my $object (@{$model->objects}) {
-            foreach my $volume (@{$object->volumes}) {
-                my $new_volume = $self->{model_object}->add_volume($volume);
+        for my $obj_idx (0..($model->objects_count-1)) {
+            my $object = $model->objects->[$obj_idx];
+            for my $vol_idx (0..($object->volumes_count-1)) {
+                my $new_volume = $self->{model_object}->add_volume($object->get_volume($vol_idx));
                 $new_volume->set_modifier($is_modifier);
                 $new_volume->set_name(basename($input_file));
+                 
                 # input_file needed to reload / update modifiers' volumes
                 $new_volume->set_input_file($input_file);
+                $new_volume->set_input_file_obj_idx($obj_idx);
+                $new_volume->set_input_file_vol_idx($vol_idx);
+                
                 # apply the same translation we applied to the object
                 $new_volume->mesh->translate(@{$self->{model_object}->origin_translation});
                 

--- a/lib/Slic3r/GUI/Plater/ObjectPartsPanel.pm
+++ b/lib/Slic3r/GUI/Plater/ObjectPartsPanel.pm
@@ -358,7 +358,8 @@ sub on_btn_load {
                 my $new_volume = $self->{model_object}->add_volume($volume);
                 $new_volume->set_modifier($is_modifier);
                 $new_volume->set_name(basename($input_file));
-                
+                # input_file needed to reload / update modifiers' volumes
+                $new_volume->set_input_file($input_file);
                 # apply the same translation we applied to the object
                 $new_volume->mesh->translate(@{$self->{model_object}->origin_translation});
                 

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -92,6 +92,23 @@ sub new {
         tooltip     => 'In 2D plater, Move objects using keyboard by nudge value of',
         default     => $Slic3r::GUI::Settings->{_}{nudge_val},
     ));
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # reload hide dialog
+        opt_id      => 'reload_hide_dialog',
+        type        => 'bool',
+        label       => 'Hide Dialog on Reload',
+        tooltip     => 'When checked, the dialog on reloading files with added parts & modifiers is suppressed. The reload is performed according to the option given in \'Default Reload Behavior\'',
+        default     => $Slic3r::GUI::Settings->{_}{reload_hide_dialog},
+    ));
+    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # default reload behavior
+        opt_id      => 'reload_behavior',
+        type        => 'select',
+        label       => 'Default Reload Behavior',
+        tooltip     => 'Choose the default behavior of the \'Reload from disk\' function regarding additional parts and modifiers.',
+        labels      => ['Reload all','Reload main, copy added','Reload main, discard added'],
+        values      => [0, 1, 2],
+        default     => $Slic3r::GUI::Settings->{_}{reload_behavior},
+        width       => 180,
+    ));
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # colorscheme
         opt_id      => 'colorscheme',
         type        => 'select',
@@ -100,7 +117,7 @@ sub new {
         labels      => ['Default','Solarized'], # add more schemes, if you want in ColorScheme.pm.
         values      => ['getDefault','getSolarized'], # add more schemes, if you want - those are the names of the corresponding function in ColorScheme.pm.
         default     => $Slic3r::GUI::Settings->{_}{colorscheme} // 'getDefault',
-        width       => 130,
+        width       => 180,
     ));
     
     my $sizer = Wx::BoxSizer->new(wxVERTICAL);

--- a/lib/Slic3r/GUI/ReloadDialog.pm
+++ b/lib/Slic3r/GUI/ReloadDialog.pm
@@ -1,0 +1,60 @@
+# A tiny dialog to select how to reload an object that has additional parts or modifiers.
+
+package Slic3r::GUI::ReloadDialog;
+use strict;
+use warnings;
+use utf8;
+
+use Wx qw(:button :dialog :id :misc :sizer :choicebook wxTAB_TRAVERSAL);
+use Wx::Event qw(EVT_CLOSE);
+use base 'Wx::Dialog';
+
+sub new {
+    my $class = shift;
+    my ($parent,$default_selection) = @_;
+    my $self = $class->SUPER::new($parent, -1, "Additional parts and modifiers detected", wxDefaultPosition, [350,100], wxDEFAULT_DIALOG_STYLE);
+    
+    # label
+    my $text = Wx::StaticText->new($self, -1, "Additional parts and modifiers are loaded in the current model. \n\nHow do you want to proceed?", wxDefaultPosition, wxDefaultSize);
+
+    # selector
+    $self->{choice} = my $choice = Wx::Choice->new($self, -1, wxDefaultPosition, wxDefaultSize, []);
+    $choice->Append("Reload all linked files");
+    $choice->Append("Reload main file, copy added parts & modifiers");
+    $choice->Append("Reload main file, discard added parts & modifiers");
+    $choice->SetSelection($default_selection);
+    
+    # checkbox
+    $self->{checkbox} = my $checkbox = Wx::CheckBox->new($self, -1, "Don't ask again");
+
+    my $vsizer = Wx::BoxSizer->new(wxVERTICAL);
+    my $hsizer = Wx::BoxSizer->new(wxHORIZONTAL);
+    $vsizer->Add($text, 0, wxEXPAND | wxALL, 10);
+    $vsizer->Add($choice, 0, wxEXPAND | wxALL, 10);
+    $hsizer->Add($checkbox, 1, wxEXPAND | wxALL, 10);
+    $hsizer->Add($self->CreateButtonSizer(wxOK | wxCANCEL), 0, wxEXPAND | wxALL, 10);
+    $vsizer->Add($hsizer, 0, wxEXPAND | wxALL, 0);
+    
+    $self->SetSizer($vsizer);
+    $self->SetMinSize($self->GetSize);
+    $vsizer->SetSizeHints($self);
+    
+    # needed to actually free memory
+    EVT_CLOSE($self, sub {
+        $self->EndModal(wxID_CANCEL);
+        $self->Destroy;
+    });
+    
+    return $self;
+}
+
+sub GetSelection {
+    my ($self) = @_;
+    return $self->{choice}->GetSelection;
+}
+sub GetHideOnNext {
+    my ($self) = @_;
+    return $self->{checkbox}->GetValue;
+}
+
+1;

--- a/xs/src/libslic3r/Model.cpp
+++ b/xs/src/libslic3r/Model.cpp
@@ -959,6 +959,10 @@ ModelVolume::swap(ModelVolume &other)
     std::swap(this->mesh,       other.mesh);
     std::swap(this->config,     other.config);
     std::swap(this->modifier,   other.modifier);
+	
+	std::swap(this->input_file, other.input_file);
+	std::swap(this->obj_idx,    other.obj_idx);
+	std::swap(this->vol_idx,    other.vol_idx);
 }
 
 t_model_material_id

--- a/xs/src/libslic3r/Model.cpp
+++ b/xs/src/libslic3r/Model.cpp
@@ -936,12 +936,18 @@ ModelObject::print_info() const
 
 
 ModelVolume::ModelVolume(ModelObject* object, const TriangleMesh &mesh)
-:   mesh(mesh), modifier(false), object(object)
+:   mesh(mesh), modifier(false), input_file(""), object(object)
 {}
 
 ModelVolume::ModelVolume(ModelObject* object, const ModelVolume &other)
-:   name(other.name), mesh(other.mesh), config(other.config),
-    modifier(other.modifier), object(object)
+:   name(other.name),
+    mesh(other.mesh),
+    config(other.config),
+    modifier(other.modifier),
+    input_file(other.input_file),
+    input_file_obj_idx(other.input_file_obj_idx),
+    input_file_vol_idx(other.input_file_vol_idx),
+    object(object)
 {
     this->material_id(other.material_id());
 }

--- a/xs/src/libslic3r/Model.cpp
+++ b/xs/src/libslic3r/Model.cpp
@@ -960,9 +960,9 @@ ModelVolume::swap(ModelVolume &other)
     std::swap(this->config,     other.config);
     std::swap(this->modifier,   other.modifier);
 	
-	std::swap(this->input_file, other.input_file);
-	std::swap(this->obj_idx,    other.obj_idx);
-	std::swap(this->vol_idx,    other.vol_idx);
+	std::swap(this->input_file,            other.input_file);
+	std::swap(this->input_file_obj_idx,    other.input_file_obj_idx);
+	std::swap(this->input_file_vol_idx,    other.input_file_vol_idx);
 }
 
 t_model_material_id

--- a/xs/src/libslic3r/Model.hpp
+++ b/xs/src/libslic3r/Model.hpp
@@ -464,7 +464,7 @@ class ModelVolume
     int input_file_vol_idx; ///< Input file volume index
     
     bool modifier;  ///< Is it an object to be printed, or a modifier volume?
-    
+
     /// Get the parent object owning this modifier volume.
     /// \return ModelObject* pointer to the owner ModelObject
     ModelObject* get_object() const { return this->object; };

--- a/xs/src/libslic3r/Model.hpp
+++ b/xs/src/libslic3r/Model.hpp
@@ -457,9 +457,14 @@ class ModelVolume
     DynamicPrintConfig config;
     ///< Configuration parameters specific to an object model geometry or a modifier volume,
     ///< overriding the global Slic3r settings and the ModelObject settings.
-
+    
+    /// Input file path needed for reloading the volume from disk
+    std::string input_file; ///< Input file path
+    int obj_idx;            ///< Input file object index
+    int vol_idx;            ///< Input file volume index	
+    
     bool modifier;  ///< Is it an object to be printed, or a modifier volume?
-
+    
     /// Get the parent object owning this modifier volume.
     /// \return ModelObject* pointer to the owner ModelObject
     ModelObject* get_object() const { return this->object; };

--- a/xs/src/libslic3r/Model.hpp
+++ b/xs/src/libslic3r/Model.hpp
@@ -460,8 +460,8 @@ class ModelVolume
     
     /// Input file path needed for reloading the volume from disk
     std::string input_file; ///< Input file path
-    int obj_idx;            ///< Input file object index
-    int vol_idx;            ///< Input file volume index	
+    int input_file_obj_idx; ///< Input file object index
+    int input_file_vol_idx; ///< Input file volume index
     
     bool modifier;  ///< Is it an object to be printed, or a modifier volume?
     

--- a/xs/xsp/Model.xsp
+++ b/xs/xsp/Model.xsp
@@ -308,6 +308,7 @@ ModelMaterial::attributes()
         %};
 };
 
+
 %name{Slic3r::Model::Instance} class ModelInstance {
     Ref<ModelObject> object()
         %code%{ RETVAL = THIS->get_object(); %};

--- a/xs/xsp/Model.xsp
+++ b/xs/xsp/Model.xsp
@@ -263,14 +263,14 @@ ModelMaterial::attributes()
         %code%{ RETVAL = THIS->input_file; %};
     void set_input_file(std::string value)
         %code%{ THIS->input_file = value; %};
-    int obj_idx()
-        %code%{ RETVAL = THIS->obj_idx; %};
-    void set_obj_idx(int obj_idx)
-        %code%{ THIS->obj_idx = obj_idx; %};
-    int vol_idx()
-        %code%{ RETVAL = THIS->vol_idx; %};
-    void set_vol_idx(int vol_idx)
-        %code%{ THIS->vol_idx = vol_idx; %};
+    int input_file_obj_idx()
+        %code%{ RETVAL = THIS->input_file_obj_idx; %};
+    void set_input_file_obj_idx(int obj_idx)
+        %code%{ THIS->input_file_obj_idx = obj_idx; %};
+    int input_file_vol_idx()
+        %code%{ RETVAL = THIS->input_file_vol_idx; %};
+    void set_input_file_vol_idx(int vol_idx)
+        %code%{ THIS->input_file_vol_idx = vol_idx; %};
 
     t_model_material_id material_id();
     void set_material_id(t_model_material_id material_id)

--- a/xs/xsp/Model.xsp
+++ b/xs/xsp/Model.xsp
@@ -258,6 +258,20 @@ ModelMaterial::attributes()
         %code%{ RETVAL = THIS->name; %};
     void set_name(std::string value)
         %code%{ THIS->name = value; %};
+
+    std::string input_file()
+        %code%{ RETVAL = THIS->input_file; %};
+    void set_input_file(std::string value)
+        %code%{ THIS->input_file = value; %};
+    int obj_idx()
+        %code%{ RETVAL = THIS->obj_idx; %};
+    void set_obj_idx(int obj_idx)
+        %code%{ THIS->obj_idx = obj_idx; %};
+    int vol_idx()
+        %code%{ RETVAL = THIS->vol_idx; %};
+    void set_vol_idx(int vol_idx)
+        %code%{ THIS->vol_idx = vol_idx; %};
+
     t_model_material_id material_id();
     void set_material_id(t_model_material_id material_id)
         %code%{ THIS->material_id(material_id); %};
@@ -293,7 +307,6 @@ ModelMaterial::attributes()
             }
         %};
 };
-
 
 %name{Slic3r::Model::Instance} class ModelInstance {
     Ref<ModelObject> object()


### PR DESCRIPTION
### Related issue: #4374

### Description
The function now tries to reload all referenced files (original object and added parts and modifiers) and asks the user how to proceed.
In the issue some opinions were given, that the function should discard all manual configurations (as 3mf files already contain them), and some that it should keep them (working with multiple exported STLs).

Additionally, warnings are thrown, if the reload doesn't work (original file deleted, object cut/ split) or added parts/ modifiers loose their reference to the path (modifier file deleted, less volumes in file -> the mesh is copied in that case).

### Changes breakdown by file
**Plater.pm**
function load_file: pass the correct object index
                           set variables in the volumes to determine their origin
function reload_from_disk: see description

**ObjectPartsPanel.pm**
set variables in the volumes to determine their origin (parts/ modifiers)

**Model.xsp/.hpp/.cpp**
adding needed variables to ModelVolume

### Testing
Testing turned out to be tedious, as the names had to be changed repeatedly, but I think I covered all relevant cases (major mesh change, different number of volumes, application of configurations)
The attached files were used.
[Multidomain_test_files.zip](https://github.com/slic3r/Slic3r/files/1929979/Multidomain_test_files.zip)