### PR TITLE
Fix linker error due to absence of FillGyroid.cpp in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(libslic3r STATIC
     ${LIBDIR}/libslic3r/Fill/FillHoneycomb.cpp
     ${LIBDIR}/libslic3r/Fill/FillPlanePath.cpp
     ${LIBDIR}/libslic3r/Fill/FillRectilinear.cpp
+    ${LIBDIR}/libslic3r/Fill/FillGyroid.cpp
     ${LIBDIR}/libslic3r/Flow.cpp
     ${LIBDIR}/libslic3r/GCode.cpp
     ${LIBDIR}/libslic3r/GCode/CoolingBuffer.cpp


### PR DESCRIPTION
When using the libslic3r c++ code only via cmake and make commands the following error is obtained.
```Console
Undefined symbols for architecture x86_64:
  "vtable for Slic3r::FillGyroid", referenced from:
      Slic3r::FillGyroid::FillGyroid() in liblibslic3r.a(Fill.cpp.o)
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [slic3r] Error 1
make[1]: *** [CMakeFiles/slic3r.dir/all] Error 2
make: *** [all] Error 2
```