### PR TITLE
CancelObject implementation

### DIFF
--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -547,7 +547,7 @@ sub process_layer {
     my $copy_idx = 0;
     for my $copy (@$object_copies) {
         if ($self->config->gcode_comments) {
-            $gcode .=   "; printing object " . $object->model_object()->name . " " . $obj_idx . " copy "  . $copy_idx . "\n";
+            $gcode .=   "; printing object " . $object->model_object()->name . " id:" . $obj_idx . " copy "  . $copy_idx . "\n";
         }
         # when starting a new object, use the external motion planner for the first travel move
         $self->_gcodegen->avoid_crossing_perimeters->set_use_external_mp_once(1) if ($self->_last_obj_copy // '') ne "$copy";
@@ -676,7 +676,7 @@ sub process_layer {
             }
         }
         if ($self->config->gcode_comments) {
-            $gcode .=   "; stop printing object " . $object->model_object()->name . " " . $obj_idx . " copy "  . $copy_idx . "\n";
+            $gcode .=   "; stop printing object " . $object->model_object()->name . " id:" . $obj_idx . " copy "  . $copy_idx . "\n";
         }
         $copy_idx = $copy_idx + 1;
     }

--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -266,7 +266,7 @@ sub export {
                             if $self->config->between_objects_gcode !~ /M(?:109|104)/i;
                         printf $fh "%s\n", Slic3r::ConditionalGCode::apply_math($gcodegen->placeholder_parser->process($self->config->between_objects_gcode));
                     }
-                    $self->process_layer($layer, [$copy]);
+                    $self->process_layer($obj_idx, $layer, [$copy]);
                 }
                 $self->flush_filters;
                 $finished_objects++;
@@ -291,7 +291,7 @@ sub export {
         foreach my $print_z (sort { $a <=> $b } keys %layers) {
             foreach my $obj_idx (@obj_idx) {
                 foreach my $layer (@{ $layers{$print_z}[$obj_idx] // [] }) {
-                    $self->process_layer($layer, $layer->object->_shifted_copies);
+                    $self->process_layer($obj_idx, $layer, $layer->object->_shifted_copies);
                 }
             }
         }
@@ -383,7 +383,7 @@ sub _print_off_temperature {
 # then filtered and finally written to a file $fh.
 sub process_layer {
     my $self = shift;
-    my ($layer, $object_copies) = @_;
+    my ($obj_idx, $layer, $object_copies) = @_;
     my $gcode = "";
     
     my $object = $layer->object;
@@ -544,7 +544,11 @@ sub process_layer {
         $self->_gcodegen->avoid_crossing_perimeters->set_disable_once(1);
     }
     
+    my $copy_idx = 0;
     for my $copy (@$object_copies) {
+        if ($self->config->gcode_comments) {
+            $gcode .=   "; printing object " . $object->model_object()->name . " " . $obj_idx . " copy "  . $copy_idx . "\n";
+        }
         # when starting a new object, use the external motion planner for the first travel move
         $self->_gcodegen->avoid_crossing_perimeters->set_use_external_mp_once(1) if ($self->_last_obj_copy // '') ne "$copy";
         $self->_last_obj_copy("$copy");
@@ -671,6 +675,10 @@ sub process_layer {
                 }
             }
         }
+        if ($self->config->gcode_comments) {
+            $gcode .=   "; stop printing object " . $object->model_object()->name . " " . $obj_idx . " copy "  . $copy_idx . "\n";
+        }
+        $copy_idx = $copy_idx + 1;
     }
     
     # apply spiral vase post-processing if this layer contains suitable geometry

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -291,12 +291,16 @@ GCodeWriter::set_extruder(unsigned int extruder_id)
 std::string
 GCodeWriter::toolchange(unsigned int extruder_id)
 {
+    std::ostringstream gcode;
+    
     // set the new extruder
     this->_extruder = &this->extruders.find(extruder_id)->second;
     
+    //first thing to do : reset E (because a new item is now printed or with a new extruder)
+    gcode << this->reset_e(true);
+    
     // return the toolchange command
     // if we are running a single-extruder setup, just set the extruder and return nothing
-    std::ostringstream gcode;
     if (this->multiple_extruders) {
         if (FLAVOR_IS(gcfMakerWare)) {
             gcode << "M135 T";
@@ -308,8 +312,6 @@ GCodeWriter::toolchange(unsigned int extruder_id)
         gcode << extruder_id;
         if (this->config.gcode_comments) gcode << " ; change extruder";
         gcode << "\n";
-        
-        gcode << this->reset_e(true);
     }
     return gcode.str();
 }


### PR DESCRIPTION
activated with "verbose gcode" option

note: you didn't need to recompile GCodeWriter.cpp if you set "use relative E distance"