### PR TITLE
Use intmax_t for coord_t

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ deploy_script:
 on_success:
 - ps: 
 on_failure:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+- ps:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 on_finish:
 - ps:

--- a/xs/src/libslic3r/Point.hpp
+++ b/xs/src/libslic3r/Point.hpp
@@ -31,7 +31,6 @@ class Point
     coord_t y;
     Point(coord_t _x = 0, coord_t _y = 0): x(_x), y(_y) {};
     Point(int _x, int _y): x(_x), y(_y) {};
-    Point(long long _x, long long _y): x(_x), y(_y) {};  // for Clipper
     Point(double x, double y);
     static Point new_scale(coordf_t x, coordf_t y) {
         return Point(scale_(x), scale_(y));

--- a/xs/src/libslic3r/Point.hpp
+++ b/xs/src/libslic3r/Point.hpp
@@ -157,8 +157,10 @@ to_points(const std::vector<T> &items)
 #include <boost/version.hpp>
 #include <boost/polygon/polygon.hpp>
 namespace boost { namespace polygon {
+    /* Boost::Polygon already defines long long as a geometry concept.
     template <>
     struct geometry_concept<coord_t> { typedef coordinate_concept type; };
+    */
     
 /* Boost.Polygon already defines a specialization for coordinate_traits<long> as of 1.60:
    https://github.com/boostorg/polygon/commit/0ac7230dd1f8f34cb12b86c8bb121ae86d3d9b97 */

--- a/xs/src/libslic3r/libslic3r.h
+++ b/xs/src/libslic3r/libslic3r.h
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <vector>
 #include <boost/thread.hpp>
+#include <cstdint>
 
 /* Implementation of CONFESS("foo"): */
 #ifdef _MSC_VER
@@ -38,7 +39,7 @@ namespace Slic3r {
 
 constexpr auto SLIC3R_VERSION = "1.3.1-dev";
 
-typedef long coord_t;
+using coord_t = intmax_t;
 typedef double coordf_t;
 
 // Scaling factor for a conversion from coord_t to coordf_t: 10e-6

--- a/xs/src/libslic3r/libslic3r.h
+++ b/xs/src/libslic3r/libslic3r.h
@@ -39,7 +39,7 @@ namespace Slic3r {
 
 constexpr auto SLIC3R_VERSION = "1.3.1-dev";
 
-using coord_t = intmax_t;
+using coord_t = int64_t;
 typedef double coordf_t;
 
 // Scaling factor for a conversion from coord_t to coordf_t: 10e-6

--- a/xs/xsp/Point.xsp
+++ b/xs/xsp/Point.xsp
@@ -8,7 +8,7 @@
 %}
 
 %name{Slic3r::Point} class Point {
-    Point(long _x = 0, long _y = 0);
+    Point(long long _x = 0, long long _y = 0);
     ~Point();
     Clone<Point> clone()
         %code{% RETVAL=THIS; %}; 
@@ -76,7 +76,7 @@ Point::coincides_with(point_sv)
 };
 
 %name{Slic3r::Point3} class Point3 {
-    Point3(long _x = 0, long _y = 0, long _z = 0);
+    Point3(long long _x = 0, long long _y = 0, long long _z = 0);
     ~Point3();
     Clone<Point3> clone()
         %code{% RETVAL = THIS; %};

--- a/xs/xsp/Point.xsp
+++ b/xs/xsp/Point.xsp
@@ -2,13 +2,14 @@
 
 %{
 #include <xsinit.h>
+#include <stdint.h>
 #include "libslic3r/Point.hpp"
 #include "libslic3r/Polygon.hpp"
 #include "libslic3r/Polyline.hpp"
 %}
 
 %name{Slic3r::Point} class Point {
-    Point(long long _x = 0, long long _y = 0);
+    Point(int64_t _x = 0, int64_t _y = 0);
     ~Point();
     Clone<Point> clone()
         %code{% RETVAL=THIS; %}; 
@@ -22,9 +23,9 @@
         %code{% RETVAL = THIS->x; %};
     long y()
         %code{% RETVAL = THIS->y; %};
-    void set_x(long val)
+    void set_x(int64_t val)
         %code{% THIS->x = val; %};
-    void set_y(long val)
+    void set_y(int64_t val)
         %code{% THIS->y = val; %};
     int nearest_point_index(Points points);
     Clone<Point> nearest_point(Points points)
@@ -76,7 +77,7 @@ Point::coincides_with(point_sv)
 };
 
 %name{Slic3r::Point3} class Point3 {
-    Point3(long long _x = 0, long long _y = 0, long long _z = 0);
+    Point3(int64_t _x = 0, int64_t _y = 0, int64_t _z = 0);
     ~Point3();
     Clone<Point3> clone()
         %code{% RETVAL = THIS; %};

--- a/xs/xsp/typemap.xspt
+++ b/xs/xsp/typemap.xspt
@@ -3,7 +3,7 @@
 %typemap{coord_t}{simple};
 %typemap{coordf_t}{simple};
 %typemap{std::string};
-%typemap{int64_t};
+%typemap{int64_t}{simple};
 %typemap{t_config_option_key};
 %typemap{t_model_material_id};
 %typemap{std::vector<int>};

--- a/xs/xsp/typemap.xspt
+++ b/xs/xsp/typemap.xspt
@@ -3,6 +3,7 @@
 %typemap{coord_t}{simple};
 %typemap{coordf_t}{simple};
 %typemap{std::string};
+%typemap{int64_t};
 %typemap{t_config_option_key};
 %typemap{t_model_material_id};
 %typemap{std::vector<int>};


### PR DESCRIPTION
Use the widest type available to the compiler on the architecture.

Instead of using long (which may be ambiguous) or int64_t (which may not be supported on different architectures). 

Drawback: Different platforms have different maximum sizes. 