### PR TITLE
Print CLI options in addition to the print ones

### DIFF
--- a/src/slic3r.cpp
+++ b/src/slic3r.cpp
@@ -20,6 +20,8 @@
     #include "GUI/GUI.hpp"
 #endif
 
+/// utility function for displaying CLI usage
+void printUsage();
 
 using namespace Slic3r;
 
@@ -36,7 +38,12 @@ main(int argc, char **argv)
     config_def.merge(print_config_def);
     DynamicConfig config(&config_def);
     t_config_option_keys input_files;
-    config.read_cli(argc, argv, &input_files);
+    // if any option is unsupported, print usage and abort immediately
+    if ( !config.read_cli(argc, argv, &input_files) )
+    {
+        printUsage();
+        return 0;
+    }
     
     // apply command line options to a more handy CLIConfig
     CLIConfig cli_config;
@@ -121,11 +128,7 @@ main(int argc, char **argv)
         models.push_back(model);
     }
     if (cli_config.help) {
-        std::cout << "Slic3r " << SLIC3R_VERSION << " is a STL-to-GCODE translator for RepRap 3D printers" << "\n"
-                  << "written by Alessandro Ranellucci <aar@cpan.org> - http://slic3r.org/ - https://github.com/slic3r/Slic3r" << "\n"
-                  << "Git Version " << BUILD_COMMIT << "\n\n"
-                  << "Usage: slic3r.pl [ OPTIONS ] [ file.stl ] [ file2.stl ] ..." << "\n";
-        print_cli_options(boost::nowide::cout);
+        printUsage();
         return 0;
     }
     
@@ -238,4 +241,19 @@ main(int argc, char **argv)
     }
     
     return 0;
+}
+void printUsage()
+{
+        std::cout << "Slic3r " << SLIC3R_VERSION << " is a STL-to-GCODE translator for RepRap 3D printers" << "\n"
+                  << "written by Alessandro Ranellucci <aar@cpan.org> - http://slic3r.org/ - https://github.com/slic3r/Slic3r" << "\n"
+                  << "Git Version " << BUILD_COMMIT << "\n\n"
+                  << "Usage (C++ only): ./slic3r [ OPTIONS ] [ file.stl ] [ file2.stl ] ..." << "\n";
+        // CLI Options
+        std::cout << "** CLI OPTIONS **\n";
+        print_cli_options(boost::nowide::cout);
+        std::cout << "****\n";
+            // Print options
+            std::cout << "** PRINT OPTIONS **\n";
+        print_print_options(boost::nowide::cout);
+        std::cout << "****\n";
 }

--- a/xs/src/libslic3r/ConfigBase.cpp
+++ b/xs/src/libslic3r/ConfigBase.cpp
@@ -538,7 +538,7 @@ DynamicConfig::read_cli(const std::vector<std::string> &tokens, t_config_option_
     this->read_cli(_argv.size(), &_argv[0], extra);
 }
 
-void
+bool
 DynamicConfig::read_cli(int argc, char** argv, t_config_option_keys* extra)
 {
     // cache the CLI option => opt_key mapping
@@ -594,7 +594,10 @@ DynamicConfig::read_cli(int argc, char** argv, t_config_option_keys* extra)
         const auto it = opts.find(token);
         if (it == opts.end()) {
             printf("Warning: unknown option --%s\n", token.c_str());
-            continue;
+            // instead of continuing, return false to caller
+            // to stop execution and print usage
+            return false;
+            //continue;
         }
         const t_config_option_key opt_key = it->second;
         const ConfigOptionDef &optdef = this->def->options.at(opt_key);
@@ -629,6 +632,7 @@ DynamicConfig::read_cli(int argc, char** argv, t_config_option_keys* extra)
             this->set_deserialize(opt_key, value, true);
         }
     }
+    return true;
 }
 
 void

--- a/xs/src/libslic3r/ConfigBase.hpp
+++ b/xs/src/libslic3r/ConfigBase.hpp
@@ -736,7 +736,7 @@ class DynamicConfig : public virtual ConfigBase
     void clear();
     bool empty() const;
     void read_cli(const std::vector<std::string> &tokens, t_config_option_keys* extra);
-    void read_cli(int argc, char** argv, t_config_option_keys* extra);
+    bool read_cli(int argc, char** argv, t_config_option_keys* extra);
     
     private:
     typedef std::map<t_config_option_key,ConfigOption*> t_options_map;

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -1921,7 +1921,7 @@ CLIConfigDef::CLIConfigDef()
     def->default_value = new ConfigOptionFloat(0);
     
     def = this->add("export_obj", coBool);
-    def->label = __TRANS("Export OBJ");
+    def->label = __TRANS("Export SVG");
     def->tooltip = __TRANS("Export the model as OBJ.");
     def->cli = "export-obj";
     def->default_value = new ConfigOptionBool(false);
@@ -2027,6 +2027,21 @@ const CLIConfigDef cli_config_def;
 
 std::ostream&
 print_cli_options(std::ostream& out) {
+    for (const auto& opt : cli_config_def.options) {
+        if (opt.second.cli.size() != 0) {
+            out << "\t" << std::left << std::setw(40) << std::string("--") + opt.second.cli; 
+            out << "\t" << opt.second.tooltip << "\n";
+            if (opt.second.default_value != nullptr) 
+                out << "\t" << std::setw(40) << " " << "\t" << " (default: " << opt.second.default_value->serialize() << ")";
+            out << "\n";
+        }
+    }
+    std::cerr << std::endl;
+    return out;
+}
+
+std::ostream&
+print_print_options(std::ostream& out) {
     for (const auto& opt : print_config_def.options) {
         if (opt.second.cli.size() != 0) {
             out << "\t" << std::left << std::setw(40) << std::string("--") + opt.second.cli; 

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -706,8 +706,11 @@ class CLIConfig
     };
 };
 
-/// Iterate through all of the options and write them to a stream.
-std::ostream& print_cli_options(std::ostream& out);
+/// Iterate through all of the print options and write them to a stream.
+std::ostream& print_print_options(std::ostream& out);
+/// Iterate through all of the CLI options and write them to a stream.
+std::ostream&
+print_cli_options(std::ostream& out);
 }
 
 #endif


### PR DESCRIPTION
In response to what was discussed [here](https://github.com/slic3r/Slic3r/issues/4509#issuecomment-414833202) and what was suggested, I've decided to make some modifications to add coherence.

1. Previously, `print_cli_options`only printed the options related to **printing**. I was find it very confusing to use the CLI as the options weren't listed. I've renamed it to `print_print_options`.
2. Now, in addition to that options, I've added the CLI options (which is basically a copy of the previous function calling out CliConfigDef options). I've attached the resulting usage file for convenience.
3. I was finding it strange and confusing (at least as a user) that if an unsupported option is entered as CLI's input, it will only issue a warning and continue processing. As such, I've made `DynamicConfig::readCli` return a bool, which should be true if all options are valid and return immediately to the caller if an unsupported option. The caller (slic3r.cpp) can then invoke `printUsage` and abort execution.

I hope this makes sense. Obviously, I could have added the CLI options inside the already provided function, but I wanted to mess as little as possible with the previous code. If you prefer, I could add directly there :)

[test_print_cli_final.txt](https://github.com/slic3r/Slic3r/files/2316582/test_print_cli_final.txt)
