### PR TITLE
FIX: check bounds for fill->min_spacing causing fill_density<100 to abort

### DIFF
--- a/src/slic3r.cpp
+++ b/src/slic3r.cpp
@@ -154,12 +154,14 @@ main(int argc, char **argv)
             boost::nowide::cout << "File exported to " << outfile << std::endl;
         } else if (cli_config.export_svg) {
             std::string outfile = cli_config.output.value;
-            if (outfile.empty()) outfile = model.objects.front()->input_file + ".svg";
-            
-            SLAPrint print(&model);
-            print.config.apply(print_config, true);
-            print.slice();
-            print.write_svg(outfile);
+            if (outfile.empty()) 
+                outfile = model.objects.front()->input_file + ".svg";
+
+            SLAPrint print(&model); // initialize print with model
+            print.config.apply(print_config, true); // apply configuration
+            if( !print.slice() ) // slice file
+                return -1;
+            print.write_svg(outfile); // write SVG
             boost::nowide::cout << "SVG file exported to " << outfile << std::endl;
         } else if (cli_config.export_3mf) {
             std::string outfile = cli_config.output.value;

--- a/xs/src/libslic3r/SLAPrint.hpp
+++ b/xs/src/libslic3r/SLAPrint.hpp
@@ -39,7 +39,7 @@ class SLAPrint
     std::vector<SupportPillar> sm_pillars;
     
     SLAPrint(Model* _model) : model(_model) {};
-    void slice();
+    bool slice();
     void write_svg(const std::string &outputfile) const;
     
     private:


### PR DESCRIPTION
`Fill->min_spacing` was being initialized to 0, due to the `infill_extrusion_width`being set to 0 in the config file.
- As such, I defined a lower bound value to be positive (>0), in spite thinking that this should be at least the size of `nozzle_diameter`.
- Now, I don't get any exceptions as discussed [here](https://github.com/slic3r/Slic3r/issues/4509#issuecomment-417147752). 

Tests
-- 
For convenience, I had the result of some tests:
- `Infill_extrusion_width = 0.5`:
![imagem](https://user-images.githubusercontent.com/29806215/44872068-80235c00-ac8c-11e8-90b2-95f811f37220.png)
- `Infill_extrusion_width = 0.1`:
![imagem](https://user-images.githubusercontent.com/29806215/44872149-aa751980-ac8c-11e8-9cd4-089ddca9feed.png)
- `Infill_extrusion_width = 2.1`:
![imagem](https://user-images.githubusercontent.com/29806215/44872192-c1b40700-ac8c-11e8-9a77-260d7e74253c.png)
- `Infill_extrusion_width = 0.01`: Was taking too long.

This lasts two values highlight the importance of convenient bounding, but for now, I will leave as it is, as it suits my needs.
