### PR TITLE
Simplify the Preferences UI for the default reload behavior and clarify labels

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -95,8 +95,7 @@ our $Settings = {
         show_host => 1,
         nudge_val => 1,
         extended_gui => 0,
-        reload_hide_dialog => 0,
-        reload_behavior => 0
+        reload_behavior => 'prompt',
     },
 };
 

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -2493,10 +2493,10 @@ sub reload_from_disk {
         }
     }
 
-    my $reload_behavior = $Slic3r::GUI::Settings->{_}{reload_behavior};
+    my $reload_behavior = $Slic3r::GUI::Settings->{_}{reload_behavior} || 'prompt';
 
     # ask the user how to proceed, if option is selected in preferences
-    if ($org_obj_has_modifiers && !$Slic3r::GUI::Settings->{_}{reload_hide_dialog}) {
+    if ($org_obj_has_modifiers && $reload_behavior eq 'prompt') {
         my $dlg = Slic3r::GUI::ReloadDialog->new(undef,$reload_behavior);
         my $res = $dlg->ShowModal;
         if ($res==wxID_CANCEL) {
@@ -2510,8 +2510,8 @@ sub reload_from_disk {
             $Slic3r::GUI::Settings->{_}{reload_behavior} = $reload_behavior;
             $save = 1;
         }
-        if ($dlg->GetHideOnNext) {
-            $Slic3r::GUI::Settings->{_}{reload_hide_dialog} = 1;
+        if (!$dlg->GetHideOnNext) {
+            $Slic3r::GUI::Settings->{_}{reload_behavior} = 'prompt';
             $save = 1;
         }
         Slic3r::GUI->save_settings if $save;

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -92,20 +92,13 @@ sub new {
         tooltip     => 'In 2D plater, Move objects using keyboard by nudge value of',
         default     => $Slic3r::GUI::Settings->{_}{nudge_val},
     ));
-    $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # reload hide dialog
-        opt_id      => 'reload_hide_dialog',
-        type        => 'bool',
-        label       => 'Hide Dialog on Reload',
-        tooltip     => 'When checked, the dialog on reloading files with added parts & modifiers is suppressed. The reload is performed according to the option given in \'Default Reload Behavior\'',
-        default     => $Slic3r::GUI::Settings->{_}{reload_hide_dialog},
-    ));
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # default reload behavior
         opt_id      => 'reload_behavior',
         type        => 'select',
-        label       => 'Default Reload Behavior',
-        tooltip     => 'Choose the default behavior of the \'Reload from disk\' function regarding additional parts and modifiers.',
-        labels      => ['Reload all','Reload main, copy added','Reload main, discard added'],
-        values      => [0, 1, 2],
+        label       => 'Reloading multipart files',
+        tooltip     => 'Choose the behavior of the \'Reload from disk\' function when reloading models having additional parts and modifiers loaded via the interface.',
+        labels      => ['Prompt user','Reload parts/modifiers','Keep parts/modifiers (don\'t reload)','Discard parts/modifiers'],
+        values      => ['prompt', 0, 1, 2],
         default     => $Slic3r::GUI::Settings->{_}{reload_behavior},
         width       => 180,
     ));

--- a/lib/Slic3r/GUI/ReloadDialog.pm
+++ b/lib/Slic3r/GUI/ReloadDialog.pm
@@ -12,16 +12,16 @@ use base 'Wx::Dialog';
 sub new {
     my $class = shift;
     my ($parent,$default_selection) = @_;
-    my $self = $class->SUPER::new($parent, -1, "Additional parts and modifiers detected", wxDefaultPosition, [350,100], wxDEFAULT_DIALOG_STYLE);
+    my $self = $class->SUPER::new($parent, -1, "Additional parts/modifiers detected", wxDefaultPosition, [350,100], wxDEFAULT_DIALOG_STYLE);
     
     # label
-    my $text = Wx::StaticText->new($self, -1, "Additional parts and modifiers are loaded in the current model. \n\nHow do you want to proceed?", wxDefaultPosition, wxDefaultSize);
+    my $text = Wx::StaticText->new($self, -1, "Additional parts or modifiers were added in Slic3r to the model you're reloading. \n\nHow do you want to proceed?", wxDefaultPosition, wxDefaultSize);
 
     # selector
     $self->{choice} = my $choice = Wx::Choice->new($self, -1, wxDefaultPosition, wxDefaultSize, []);
-    $choice->Append("Reload all linked files");
-    $choice->Append("Reload main file, copy added parts & modifiers");
-    $choice->Append("Reload main file, discard added parts & modifiers");
+    $choice->Append("Reload parts/modifiers");
+    $choice->Append("Keep parts/modifiers (don't reload)");
+    $choice->Append("Discard parts/modifiers");
     $choice->SetSelection($default_selection);
     
     # checkbox


### PR DESCRIPTION
As of now, the "Don't remind me again" checkbox upon selection of the reload behavior for models with added parts/modifiers is tied to a dedicated checkbox in the Preferences.
This can be simplified by adding "Prompt user" as one more possible value to the behavior setting itself. A "prompt" item is a common UI pattern.

I also tried to clarify the labels of the options because there were not clear at all to me and I had to look at the code to understand it better. :)

@Oekn5w @gege2b 