### PR TITLE
Rename "Extended GUI" to "Rotation controls" and simplify it

### DIFF
--- a/lib/Slic3r/GUI.pm
+++ b/lib/Slic3r/GUI.pm
@@ -94,7 +94,7 @@ our $Settings = {
         tabbed_preset_editors => 1,
         show_host => 1,
         nudge_val => 1,
-        extended_gui => 0,
+        rotation_controls => 'z',
         reload_hide_dialog => 0,
         reload_behavior => 0
     },

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -102,7 +102,7 @@ sub getSolarized { # add this name to Preferences.pm
     $SOLID_BACKGROUNDCOLOR = 1;               # Switch between SOLID or FADED background color
     my $largeicons         = 0;               # Default: 0. 1 for large icons-set.
     
-    if ($Slic3r::GUI::Settings->{_}{extended_gui} >= 4){
+    if ($Slic3r::GUI::Settings->{_}{rotation_controls} eq 'xyz-big'){
         $largeicons = 1;
     }
     

--- a/lib/Slic3r/GUI/Preferences.pm
+++ b/lib/Slic3r/GUI/Preferences.pm
@@ -111,13 +111,13 @@ sub new {
         width       => 180,
     ));
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # Extended GUI - Context and/or Toolbar
-        opt_id      => 'extended_gui',
+        opt_id      => 'rotation_controls',
         type        => 'select',
-        label       => 'Extended GUI: ',
-        tooltip     => 'Choose extended rotate commands in the toolbar and/or in the context menu. If you don\'t use the default color scheme, the themed icons for the toolbar will be used.(Restart of Slic3r required.)',
-        labels      => ['Default', 'Context only', 'Toolbar only', 'Toolbar and Context', 'Toolbar only (big)', 'Toolbar (big) and Context'],
-        values      => [0, 1, 2, 3, 4, 5],
-        default     => $Slic3r::GUI::Settings->{_}{extended_gui},
+        label       => 'Rotation controls in toolbar',
+        tooltip     => 'What rotation controls to show in the toolbar. (Restart of Slic3r required.)',
+        labels      => ['Z only', 'X,Y,Z', 'X,Y,Z (big buttons)'],
+        values      => ['z', 'xyz', 'xyz-big'],
+        default     => $Slic3r::GUI::Settings->{_}{rotation_controls},
         width       => 180,
     ));
     $optgroup->append_single_option_line(Slic3r::GUI::OptionsGroup::Option->new(    # colorscheme
@@ -147,7 +147,7 @@ sub new {
 sub _accept {
     my $self = shift;
     
-    if (any { exists $self->{values}{$_} } qw(show_host extended_gui colorscheme)) {
+    if (any { exists $self->{values}{$_} } qw(show_host rotation_controls colorscheme)) {
         Slic3r::GUI::warning_catcher($self)->("You need to restart Slic3r to make the changes effective.");
     }
     


### PR DESCRIPTION
I think the idea proposed in #4419 is great, as power users need advanced and flexible controls for manipulating models. Slic3r definitely needs to be very customizable in the long term so that every user can adapt it to their preferred workflow. As of now we don't have customizable palettes or other things like this, so the idea proposed by @foreachthing is a great start.

I think we can achieve the same goal by simplifying it a bit. I understand @foreachthing did it fully customizable in order to make sure his Pull Request was merged :-) and now I think we can improve over that.

Here I'm proposing the following changes:
* **always** have the *Rotate by 180°* commands in the contextual menu item (no need to make this configurable)
* No need to show the *Rotate Z 90°* buttons in the toolbar as we already have the *Rotate Z 45°* (two clicks are quicker than looking for the right button in a long row)
* Rename *Extended GUI* to *Rotation controls* as it's more descriptive

In this proposal I kept the big buttons proposed; however I'd like to understand better: @foreachthing, do you think that *all* toolbar buttons should be offered in the big size? Or just some? Only the rotation ones seem arbitrary, so we should probably think about a more consistent pattern.

![schermata 2018-11-10 alle 23 38 39](https://user-images.githubusercontent.com/594957/48306968-549dd700-e543-11e8-8c93-ffd0cbe27fc2.png)

![schermata 2018-11-10 alle 23 41 52](https://user-images.githubusercontent.com/594957/48306971-59628b00-e543-11e8-98a0-c6f5a3051d25.png)
