### PR TITLE
Use GCC7 instead of 4.9 with perl build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - export SLIC3R_GIT_VERSION=$(git rev-parse --short HEAD)
 
 script:
-    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "main" ]]; then ./package/linux/travis-build-main.sh; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "main" ]]; then exit $(./package/linux/travis-build-main.sh); fi
     - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "cpp"  ]]; then ./package/linux/travis-build-cpp.sh; fi
     - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "main" ]]; then ./package/osx/travis-build-main.sh; fi
     - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "cpp"  ]]; then ./package/osx/travis-build-cpp.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - export SLIC3R_GIT_VERSION=$(git rev-parse --short HEAD)
 
 script:
-    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "main" ]]; then exit $(./package/linux/travis-build-main.sh); fi
+    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "main" ]]; then ./package/linux/travis-build-main.sh || travis_terminate 1; fi
     - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "cpp"  ]]; then ./package/linux/travis-build-cpp.sh; fi
     - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "main" ]]; then ./package/osx/travis-build-main.sh; fi
     - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "cpp"  ]]; then ./package/osx/travis-build-cpp.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ addons:
     packages:
     - g++-7
     - gcc-7
-    - g++-4.9
-    - gcc-4.9
     - libgtk2.0-0 
     - libgtk2.0-dev
     - freeglut3

--- a/package/linux/travis-build-main.sh
+++ b/package/linux/travis-build-main.sh
@@ -30,3 +30,5 @@ fi
 
 SLIC3R_STATIC=1 CC=g++-7 CXX=g++-7 BOOST_DIR=$HOME/boost_1_63_0 perl ./Build.PL
 perl ./Build.PL --gui
+
+exit $?

--- a/package/linux/travis-build-main.sh
+++ b/package/linux/travis-build-main.sh
@@ -4,9 +4,9 @@
 ### set -euo pipefail
 
 if [ ! -d $HOME/perl5/perlbrew/perls/slic3r-perl ]; then
-    echo "Downloading slic3r-perlbrew-5.24.tar.bz2"
-    curl -L "http://www.siusgs.com/slic3r/buildserver/slic3r-perl.524.gcc49.travis.tar.bz2" -o /tmp/slic3r-perlbrew-5.24.tar.bz2; 
-    tar -C$HOME/perl5/perlbrew/perls -xjf /tmp/slic3r-perlbrew-5.24.tar.bz2
+    echo "Downloading slic3r-perlbrew-5.28.tar.bz2"
+    curl -L "http://www.siusgs.com/slic3r/buildserver/slic3r-perl.528.gcc7.travis.tar.bz2" -o /tmp/slic3r-perlbrew.tar.bz2;
+    tar -C$HOME/perl5/perlbrew/perls -xjf /tmp/slic3r-perlbrew.tar.bz2
 fi
 
 source $HOME/perl5/perlbrew/etc/bashrc

--- a/package/linux/travis-build-main.sh
+++ b/package/linux/travis-build-main.sh
@@ -29,6 +29,7 @@ if [ ! -e ./local-lib/lib/perl5/x86_64-linux-thread-multi/Wx.pm ]; then
 fi
 
 SLIC3R_STATIC=1 CC=g++-7 CXX=g++-7 BOOST_DIR=$HOME/boost_1_63_0 perl ./Build.PL
+excode=$?
+if [ $excode -ne 0 ]; then return $excode; fi
 perl ./Build.PL --gui
-
 exit $?

--- a/package/linux/travis-build-main.sh
+++ b/package/linux/travis-build-main.sh
@@ -28,5 +28,5 @@ if [ ! -e ./local-lib/lib/perl5/x86_64-linux-thread-multi/Wx.pm ]; then
     tar -C$HOME -xjf /tmp/wx302.tar.bz2
 fi
 
-SLIC3R_STATIC=1 CC=g++-4.9 CXX=g++-4.9 BOOST_DIR=$HOME/boost_1_63_0 perl ./Build.PL
+SLIC3R_STATIC=1 CC=g++-7 CXX=g++-7 BOOST_DIR=$HOME/boost_1_63_0 perl ./Build.PL
 perl ./Build.PL --gui

--- a/package/linux/travis-build-main.sh
+++ b/package/linux/travis-build-main.sh
@@ -30,6 +30,6 @@ fi
 
 SLIC3R_STATIC=1 CC=g++-7 CXX=g++-7 BOOST_DIR=$HOME/boost_1_63_0 perl ./Build.PL
 excode=$?
-if [ $excode -ne 0 ]; then return $excode; fi
+if [ $excode -ne 0 ]; then exit $excode; fi
 perl ./Build.PL --gui
 exit $?


### PR DESCRIPTION
Branch to exercise building with gcc7 instead of gcc-4.9