### PR TITLE
Ensure that travis reports failure if build/tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
     - export SLIC3R_GIT_VERSION=$(git rev-parse --short HEAD)
 
 script:
-    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "main" ]]; then ./package/linux/travis-build-main.sh || travis_terminate 1;; fi
-    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "cpp"  ]]; then ./package/linux/travis-build-cpp.sh || travis_terminate 1;; fi
-    - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "main" ]]; then ./package/osx/travis-build-main.sh || travis_terminate 1;; fi
-    - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "cpp"  ]]; then ./package/osx/travis-build-cpp.sh || travis_terminate 1;; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "main" ]]; then ./package/linux/travis-build-main.sh || travis_terminate 1; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "cpp"  ]]; then ./package/linux/travis-build-cpp.sh || travis_terminate 1; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "main" ]]; then ./package/osx/travis-build-main.sh || travis_terminate 1; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "cpp"  ]]; then ./package/osx/travis-build-cpp.sh || travis_terminate 1; fi
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
     - export SLIC3R_GIT_VERSION=$(git rev-parse --short HEAD)
 
 script:
-    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "main" ]]; then ./package/linux/travis-build-main.sh; fi
-    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "cpp"  ]]; then ./package/linux/travis-build-cpp.sh; fi
-    - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "main" ]]; then ./package/osx/travis-build-main.sh; fi
-    - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "cpp"  ]]; then ./package/osx/travis-build-cpp.sh; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "main" ]]; then ./package/linux/travis-build-main.sh || travis_terminate 1;; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "linux" && "$TARGET" == "cpp"  ]]; then ./package/linux/travis-build-cpp.sh || travis_terminate 1;; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "main" ]]; then ./package/osx/travis-build-main.sh || travis_terminate 1;; fi
+    - if [[ "${TRAVIS_OS_NAME}" == "osx"   && "$TARGET" == "cpp"  ]]; then ./package/osx/travis-build-cpp.sh || travis_terminate 1;; fi
 
 branches:
   only:

--- a/package/linux/travis-build-main.sh
+++ b/package/linux/travis-build-main.sh
@@ -29,4 +29,7 @@ if [ ! -e ./local-lib/lib/perl5/x86_64-linux-thread-multi/Wx.pm ]; then
 fi
 
 SLIC3R_STATIC=1 CC=g++-4.9 CXX=g++-4.9 BOOST_DIR=$HOME/boost_1_63_0 perl ./Build.PL
+excode=$?
+if [ $excode -ne 0 ]; then exit $excode; fi
 perl ./Build.PL --gui
+exit $?


### PR DESCRIPTION
Looks like if a dependent script fails, Travis will happily report everything is fine because the if statement completed. These changes should ensure that a return code is propagated up and travis is terminated if the return code comes back with an error.

Reference: http://steven.casagrande.io/articles/travis-ci-and-if-statements/