### PR TITLE
Remove support test compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,7 +298,6 @@ set(SLIC3R_TEST_SOURCES
     ${TESTDIR}/libslic3r/test_print.cpp
     ${TESTDIR}/libslic3r/test_printgcode.cpp
     ${TESTDIR}/libslic3r/test_skirt_brim.cpp
-    ${TESTDIR}/libslic3r/test_support_material.cpp
     ${TESTDIR}/libslic3r/test_test_data.cpp
     ${TESTDIR}/libslic3r/test_trianglemesh.cpp
 )


### PR DESCRIPTION
The c++ support tests were never fully completed and should be disabled until that code is looked at again and updated in a PR.