### PR TITLE
Fix edge case in spacing calculation for solid spacing.

### DIFF
--- a/src/test/libslic3r/test_flow.cpp
+++ b/src/test/libslic3r/test_flow.cpp
@@ -136,6 +136,22 @@ SCENARIO("Flow: Flow math for non-bridges", "[!mayfail]") {
             }
         }
     }
+
+
+    /// Check for an edge case in the maths where the spacing could be 0; original
+    /// math is 0.99. Slic3r issue #4654
+    GIVEN("Input spacing of 0.414159 and a total width of 2") {
+        double in_spacing = 0.414159;
+        double total_width = 2.0;
+        auto flow {Flow::new_from_spacing(1.0, 0.4, 0.3, false)};
+        WHEN("solid_spacing() is called") {
+            double result = flow.solid_spacing(total_width, in_spacing);
+            THEN("Yielded spacing is greater than 0") {
+                REQUIRE(result > 0);
+            }
+        }
+    }
+
 }
 
 /// Spacing, width calculation for bridge extrusions

--- a/xs/src/libslic3r/Flow.cpp
+++ b/xs/src/libslic3r/Flow.cpp
@@ -145,6 +145,10 @@ Flow::solid_spacing(const T total_width, const T spacing)
     const double factor_max = 1.2;
     if (factor > factor_max)
         spacing_new = floor((double)spacing * factor_max + 0.5);
+    // There is an edge case where spacing with the max factor still ends up to be 0
+    // In this case, use the full factor and don't round it
+    if (spacing_new == 0)
+        spacing_new = (static_cast<double>(spacing) * factor);
     
     assert((spacing_new * number_of_intervals) <= total_width);
     


### PR DESCRIPTION
In some situations the calculated solid spacing can be 0 with first-layer  widths of ~0.41mm and a requested brim connection width of 1mm, even though the actual spacing is nonzero.

Add a test case to flow test suite to cover this situation.

Fixes #4654 