### PR TITLE
Use GCC8 instead of 4.9 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ addons:
     packages:
     - g++-7
     - gcc-7
-    - g++-4.9
-    - gcc-4.9
+    - g++-8
+    - gcc-8
     - libgtk2.0-0 
     - libgtk2.0-dev
     - freeglut3

--- a/package/linux/appimage-apprun.sh
+++ b/package/linux/appimage-apprun.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Cribbed from https://github.com/darealshinji/AppImageKit-checkrt/blob/master/AppRun.sh
+
 # some magic to find out the real location of this script dealing with symlinks
 DIR=`readlink "$0"` || DIR="$0";
 DIR=`dirname "$DIR"`;

--- a/package/linux/appimage-apprun.sh
+++ b/package/linux/appimage-apprun.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# some magic to find out the real location of this script dealing with symlinks
+DIR=`readlink "$0"` || DIR="$0";
+DIR=`dirname "$DIR"`;
+cd "$DIR"
+DIR=`pwd`
+cd - > /dev/null
+
+cxxpre=""
+gccpre=""
+execpre=""
+libc6arch="libc6,x86-64"
+if [ -n "$APPIMAGE" ] && [ "$(file -b "$APPIMAGE" | cut -d, -f2)" != " x86-64" ]; then
+  libc6arch="libc6"
+fi
+
+cd "${DIR}/usr"
+
+if [ -e "./optional/libstdc++/libstdc++.so.6" ]; then
+  lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libstdc++\.so\.6 ($libc6arch)" | awk 'NR==1{print $NF}')"
+  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GLIBCXX_3\.4' | tail -n1)
+  sym_app=$(tr '\0' '\n' < "./optional/libstdc++/libstdc++.so.6" | grep -e '^GLIBCXX_3\.4' | tail -n1)
+  if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
+    cxxpath="./optional/libstdc++:"
+  fi
+fi
+
+if [ -e "./optional/libgcc/libgcc_s.so.1" ]; then
+  lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libgcc_s\.so\.1 ($libc6arch)" | awk 'NR==1{print $NF}')"
+  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GCC_[0-9]\\.[0-9]' | tail -n1)
+  sym_app=$(tr '\0' '\n' < "./optional/libgcc/libgcc_s.so.1" | grep -e '^GCC_[0-9]\\.[0-9]' | tail -n1)
+  if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
+    gccpath="./optional/libgcc:"
+  fi
+fi
+
+if [ -n "$cxxpath" ] || [ -n "$gccpath" ]; then
+  if [ -e "./optional/exec.so" ]; then
+    execpre=""
+    export LD_PRELOAD="./optional/exec.so:${LD_PRELOAD}"
+  fi
+  export LD_LIBRARY_PATH="${cxxpath}${gccpath}${LD_LIBRARY_PATH}"
+fi
+
+# disable parameter expansion to forward all arguments unprocessed to the VM
+set -f
+# run the VM and pass along all arguments as is
+LD_LIBRARY_PATH="$DIR/usr/lib:${LD_LIBRARY_PATH}" "${DIR}/usr/bin/perl-local" -I"${DIR}/usr/lib/local-lib/lib/perl5" "${DIR}/usr/bin/slic3r.pl" --gui "$@"
+exit $?

--- a/package/linux/appimage-apprun.sh
+++ b/package/linux/appimage-apprun.sh
@@ -34,12 +34,21 @@ if [ -e "./optional/libgcc/libgcc_s.so.1" ]; then
   fi
 fi
 
-if [ -n "$cxxpath" ] || [ -n "$gccpath" ]; then
+if [ -e "./optional/swrast_dri/swrast_dri.so" ]; then
+  lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "swrast_dri\.so\ ($libc6arch)" | awk 'NR==1{print $NF}')"
+  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GCC_[0-9]\\.[0-9]' | tail -n1)
+  sym_app=$(tr '\0' '\n' < "./optional/swrast_dri/swrast_dri.so" | grep -e '^GCC_[0-9]\\.[0-9]' | tail -n1)
+  if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
+    swrastpath="./optional/swrast_dri:"
+  fi
+fi
+
+if [ -n "$cxxpath" ] || [ -n "$gccpath" ] || [ -n "$swrastpath" ]; then
   if [ -e "./optional/exec.so" ]; then
     execpre=""
     export LD_PRELOAD="./optional/exec.so:${LD_PRELOAD}"
   fi
-  export LD_LIBRARY_PATH="${cxxpath}${gccpath}${LD_LIBRARY_PATH}"
+  export LD_LIBRARY_PATH="${cxxpath}${gccpath}${swrastpath}${LD_LIBRARY_PATH}"
 fi
 
 # disable parameter expansion to forward all arguments unprocessed to the VM

--- a/package/linux/appimage.sh
+++ b/package/linux/appimage.sh
@@ -17,6 +17,8 @@ set_branch
 set_app_name
 set_pr_id
 
+SCRIPTDIR=$(dirname $0)
+
 WD=${PWD}/$(dirname $0)
 srcfolder="$WD/${appname}"
 export ARCH=$(arch)
@@ -48,22 +50,18 @@ for i in $(cat $WD/libpaths.appimage.txt | grep -v "^#" | awk -F# '{print $1}');
     install -v $i ${WD}/${APP}.AppDir/usr/lib
 done
 
+# Workaround to increase compatibility with older systems; see https://github.com/darealshinji/AppImageKit-checkrt for details
+mkdir -p ${WD}/${APP}.AppDir/usr/optional/
+wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./Slic3r.AppDir/usr/optional/exec.so
+
+mkdir -p ${WD}/${APP}.AppDir/usr/optional/libstdc++/
+cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./Slic3r.AppDir/usr/optional/libstdc++/
+mkdir -p ${WD}/${APP}.AppDir/usr/optional/libgcc/
+cp /lib/x86_64-linux-gnu/libgcc_s.so.1 ./Slic3r.AppDir/usr/optional/libgcc/
 
 cp -R $srcfolder/local-lib ${WD}/${APP}.AppDir/usr/lib/local-lib
 
-cat > $WD/${APP}.AppDir/AppRun << 'EOF'
-#!/usr/bin/env bash
-# some magic to find out the real location of this script dealing with symlinks
-DIR=`readlink "$0"` || DIR="$0";
-DIR=`dirname "$DIR"`;
-cd "$DIR"
-DIR=`pwd`
-cd - > /dev/null
-# disable parameter expansion to forward all arguments unprocessed to the VM
-set -f
-# run the VM and pass along all arguments as is
-LD_LIBRARY_PATH="$DIR/usr/lib" "${DIR}/usr/bin/perl-local" -I"${DIR}/usr/lib/local-lib/lib/perl5" "${DIR}/usr/bin/slic3r.pl" --gui "$@"
-EOF
+cp ${WD}/appimage-apprun.sh ${WD}/${APP}.AppDir/AppRun
 
 chmod +x AppRun
 

--- a/package/linux/appimage.sh
+++ b/package/linux/appimage.sh
@@ -55,9 +55,12 @@ mkdir -p ${WD}/${APP}.AppDir/usr/optional/
 wget -c https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./Slic3r.AppDir/usr/optional/exec.so
 
 mkdir -p ${WD}/${APP}.AppDir/usr/optional/libstdc++/
-cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./Slic3r.AppDir/usr/optional/libstdc++/
+cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ${WD}/${APP}.AppDir/usr/optional/libstdc++/
 mkdir -p ${WD}/${APP}.AppDir/usr/optional/libgcc/
-cp /lib/x86_64-linux-gnu/libgcc_s.so.1 ./Slic3r.AppDir/usr/optional/libgcc/
+cp /lib/x86_64-linux-gnu/libgcc_s.so.1 ${WD}/${APP}.AppDir/usr/optional/libgcc/
+
+mkdir -p ${WD}/${APP}.AppDir/usr/optional/swrast_dri/
+cp /usr/lib/x86_64-linux-gnu/dri/swrast_dri.so	${WD}/${APP}.AppDir/usr/optional/swrast_dri/
 
 cp -R $srcfolder/local-lib ${WD}/${APP}.AppDir/usr/lib/local-lib
 

--- a/package/linux/build_shell.mk
+++ b/package/linux/build_shell.mk
@@ -4,10 +4,10 @@ src=../common/shell.cpp
 CXX ?= g++
 
 # Path to perl header files
-INCLUDEDIR ?= ${HOME}/perl5/perlbrew/perls/slic3r-perl/lib/5.24.0/x86_64-linux-thread-multi/CORE
+INCLUDEDIR ?= ${HOME}/perl5/perlbrew/perls/slic3r-perl/lib/5.28.1/x86_64-linux-thread-multi/CORE
 
 # path to library files for perl
-LIBDIR ?= ${HOME}/perl5/perlbrew/perls/slic3r-perl/lib/5.24.0/x86_64-linux-thread-multi/CORE
+LIBDIR ?= ${HOME}/perl5/perlbrew/perls/slic3r-perl/lib/5.28.1/x86_64-linux-thread-multi/CORE
 
 LIBS += -lperl -lpthread -lcrypt
 

--- a/package/linux/libpaths.appimage.txt
+++ b/package/linux/libpaths.appimage.txt
@@ -1,2 +1,2 @@
 #/usr/lib/x86_64-linux-gnu/libstdc++.so.6 # needed because of ancient distros and slic3r (and perl for perl reasons) needs modern c++.
-/usr/lib/x86_64-linux-gnu/dri/swrast_dri.so	# Missing? 
+#/usr/lib/x86_64-linux-gnu/dri/swrast_dri.so	# Missing? 

--- a/package/linux/travis-build-main.sh
+++ b/package/linux/travis-build-main.sh
@@ -5,31 +5,27 @@
 set -eo pipefail
 
 if [ ! -d $HOME/perl5/perlbrew/perls/slic3r-perl ]; then
-    echo "Downloading slic3r-perlbrew-5.24.tar.bz2"
-    curl -L "http://www.siusgs.com/slic3r/buildserver/slic3r-perl.524.gcc49.travis.tar.bz2" -o /tmp/slic3r-perlbrew-5.24.tar.bz2; 
-    tar -C$HOME/perl5/perlbrew/perls -xjf /tmp/slic3r-perlbrew-5.24.tar.bz2
+    echo "Downloading slic3r-perlbrew-5.28.tar.bz2"
+    curl -L "http://www.siusgs.com/slic3r/buildserver/slic3r-perl.528.gcc81.travis.tar.bz2" -o /tmp/slic3r-perlbrew-5.28.tar.bz2; 
+    tar -C$HOME/perl5/perlbrew/perls -xjf /tmp/slic3r-perlbrew-5.28.tar.bz2
 fi
 
 source $HOME/perl5/perlbrew/etc/bashrc
 perlbrew switch slic3r-perl
 
 if [ ! -e $HOME/boost_1_63_0/boost/version.hpp ]; then
-    echo "Downloading boost_1_63_0.built.gcc-4.9.4-buildserver.tar.bz2"
-    curl -L "http://www.siusgs.com/slic3r/buildserver/boost_1_63_0.built.gcc-4.9.4-buildserver.tar.bz2" -o /tmp/boost-compiled.tar.bz2
+    echo "Downloading boost_1_69_0.built.gcc-8.1.0-buildserver.tar.bz2"
+    curl -L "http://www.siusgs.com/slic3r/buildserver/boost_1_69_0.built.gcc-8.1.0-buildserver.tar.bz2" -o /tmp/boost-compiled.tar.bz2
     tar -C$HOME -xjf /tmp/boost-compiled.tar.bz2
 fi
 
 if [ ! -e ./local-lib/lib/perl5/x86_64-linux-thread-multi/Wx.pm ]; then
-    echo "Downloading slic3r-dependencies.gcc49.travis-wx302.tar.bz2"
-    curl -L "http://www.siusgs.com/slic3r/buildserver/slic3r-dependencies.travis-wx302.tar.bz2" -o /tmp/local-lib-wx302.tar.bz2
+    echo "Downloading slic3r-dependencies.gcc81.travis-wx302.tar.bz2"
+    curl -L "http://www.siusgs.com/slic3r/buildserver/slic3r-dependencies.gcc81.travis-wx302.tar.bz2" -o /tmp/local-lib-wx302.tar.bz2
     tar -C$TRAVIS_BUILD_DIR -xjf /tmp/local-lib-wx302.tar.bz2
-    
-    echo "Downloading buildserver/wx302-libs.tar.bz2"
-    curl -L "http://www.siusgs.com/slic3r/buildserver/wx302-libs.tar.bz2" -o /tmp/wx302.tar.bz2
-    tar -C$HOME -xjf /tmp/wx302.tar.bz2
 fi
 
-SLIC3R_STATIC=1 CC=g++-4.9 CXX=g++-4.9 BOOST_DIR=$HOME/boost_1_63_0 perl ./Build.PL
+CC=g++-8 CXX=g++-8 BOOST_DIR=$HOME/boost_1_69_0 perl ./Build.PL
 excode=$?
 if [ $excode -ne 0 ]; then exit $excode; fi
 perl ./Build.PL --gui

--- a/xs/src/libslic3r/ConfigBase.hpp
+++ b/xs/src/libslic3r/ConfigBase.hpp
@@ -29,8 +29,8 @@ extern bool unescape_strings_cstyle(const std::string &str, std::vector<std::str
 /// Specialization of std::exception to indicate that an unknown config option has been encountered.
 class ConfigOptionException : public std::exception {
     public:
-    t_config_option_key opt_key;
-    ConfigOptionException(t_config_option_key _opt_key)
+    const t_config_option_key opt_key;
+    ConfigOptionException(const t_config_option_key _opt_key)
         : opt_key(_opt_key) {};
 };
 class UnknownOptionException : public ConfigOptionException {

--- a/xs/src/libslic3r/GCodeSender.hpp
+++ b/xs/src/libslic3r/GCodeSender.hpp
@@ -9,6 +9,7 @@
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>
+#include <boost/core/noncopyable.hpp>
 
 namespace Slic3r {
 


### PR DESCRIPTION
Update travis build items to use gcc8 instead of gcc4.9

Fixes #4664