### PR TITLE
Permit coBool options to be set with booleans

### DIFF
--- a/src/test/libslic3r/test_config.cpp
+++ b/src/test/libslic3r/test_config.cpp
@@ -49,14 +49,23 @@ SCENARIO("Config accessor functions perform as expected.") {
     GIVEN("A config generated from default options") {
         auto config {Slic3r::Config::new_from_defaults()};
         WHEN("A boolean option is set to a boolean value") {
-            THEN("A BadOptionTypeException exception is thrown.") {
-                REQUIRE_THROWS_AS(config->set("gcode_comments", true), BadOptionTypeException);
-            }
-        }
-        WHEN("A boolean option is set to a string value") {
-            config->set("gcode_comments", "1");
+            REQUIRE_NOTHROW(config->set("gcode_comments", true));
             THEN("The underlying value is set correctly.") {
                 REQUIRE(config->get<ConfigOptionBool>("gcode_comments").getBool() == true);
+            }
+        }
+        WHEN("A boolean option is set to a string value representing a 0 or 1") {
+            CHECK_NOTHROW(config->set("gcode_comments", "1"));
+            THEN("The underlying value is set correctly.") {
+                REQUIRE(config->get<ConfigOptionBool>("gcode_comments").getBool() == true);
+            }
+        }
+        WHEN("A boolean option is set to a string value representing something other than 0 or 1") {
+            THEN("A BadOptionTypeException exception is thrown.") {
+                REQUIRE_THROWS_AS(config->set("gcode_comments", "Z"), BadOptionTypeException);
+            }
+            AND_THEN("Value is unchanged.") {
+                REQUIRE(config->get<ConfigOptionBool>("gcode_comments").getBool() == false);
             }
         }
         WHEN("A string option is set to an int value") {

--- a/xs/src/libslic3r/ConfigBase.hpp
+++ b/xs/src/libslic3r/ConfigBase.hpp
@@ -480,12 +480,16 @@ class ConfigOptionBool : public ConfigOptionSingle<bool>
     ConfigOptionBool* clone() const { return new ConfigOptionBool(this->value); };
     
     bool getBool() const { return this->value; };
+    void setBool(bool val) { this->value = val; }
     
     std::string serialize() const {
         return std::string(this->value ? "1" : "0");
     };
     
     bool deserialize(std::string str, bool append = false) {
+        // Enforce the type on deserialize.
+        if (str.compare("1") != 0 && str.compare("0") != 0)
+            return false;
         this->value = (str.compare("1") == 0);
         return true;
     };


### PR DESCRIPTION
coBool options weren't permitted to be set with boolean values; the only valid setter was via string "1" and "0", which is very inconvenient (and wasn't intended on the initial PR). 

Additionally, booleans being set with a string are a special kind of enumeration and should be treated as such. Our configs emit "1" and "0" and should not accept "Z" or anything like that (which they were and treating as false). 

Tests have been fixed/expanded.