### PR TITLE
Patch for #4620 - ensure posDetectSurfaces is invalidated on slice change

### DIFF
--- a/src/test/libslic3r/test_print.cpp
+++ b/src/test/libslic3r/test_print.cpp
@@ -91,7 +91,7 @@ SCENARIO("Print: Changing number of solid surfaces does not cause all surfaces t
             print->regions[0]->config.top_solid_layers = 3;
             print->objects[0]->invalidate_step(posPrepareInfill);
             print->process();
-            THEN("Print object does not have 0 bottom surfaces.") {
+            THEN("Print object does not have 0 solid bottom layers.") {
                 test_is_solid_infill(print, 0, 0);
             }
             AND_THEN("Print object has 3 top solid layers") {

--- a/src/test/libslic3r/test_print.cpp
+++ b/src/test/libslic3r/test_print.cpp
@@ -86,7 +86,11 @@ SCENARIO("Print: Changing number of solid surfaces does not cause all surfaces t
         std::string stage;
         auto print {Slic3r::Test::init_print({m}, model, config)};
         print->process();
-        test_is_solid_infill(print, 0, 39); // check to make sure it sliced properly
+        // Precondition: Ensure that the model has 2 solid top layers (39, 38)
+        // and one solid bottom layer (0).
+        test_is_solid_infill(print, 0, 0); // should be solid
+        test_is_solid_infill(print, 0, 39); // should be solid
+        test_is_solid_infill(print, 0, 38); // should be solid
         WHEN("Model is re-sliced with top_solid_layers == 3") {
             print->regions[0]->config.top_solid_layers = 3;
             print->objects[0]->invalidate_step(posPrepareInfill);

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -1055,17 +1055,15 @@ void
 PrintObject::make_perimeters()
 {
     if (this->state.is_done(posPerimeters)) return;
-    this->state.set_started(posPerimeters);
     
     // Temporary workaround for detect_surfaces_type() not being idempotent (see #3764).
     // We can remove this when idempotence is restored. This make_perimeters() method
     // will just call merge_slices() to undo the typed slices and invalidate posDetectSurfaces.
     if (this->typed_slices) {
-        this->state.invalidate(posSlice);
-        // also invalidate posDetectSurfaces
-        this->state.invalidate(posDetectSurfaces);
+        this->invalidate_step(posSlice);
     }
-    
+    this->state.set_started(posPerimeters);
+
     // prerequisites
     this->slice();
     


### PR DESCRIPTION
Invalidate posDetectSurfaces during make_perimeters() when posSlice would also get invalidated.
Can't use invalidate_step() as that invalidates the perimeters as well.

Fixes #4620