### PR TITLE
fix to make current_extruder available in start GCode issue 4637

### DIFF
--- a/lib/Slic3r/Print/GCode.pm
+++ b/lib/Slic3r/Print/GCode.pm
@@ -159,7 +159,13 @@ sub export {
     }
     $self->_print_first_layer_temperature(0)
         if $include_start_extruder_temp;
+    
+    # initialize current_extruder placeholder now, because start_gcode may be relying on it.
+    $gcodegen->placeholder_parser->set("current_extruder", $self->print->extruders->[0]);
+    
+    # process start gcode
     printf $fh "%s\n", Slic3r::ConditionalGCode::apply_math($gcodegen->placeholder_parser->process($self->config->start_gcode));
+    
     my $filament_extruder = 0;
     foreach my $start_gcode (@{ $self->config->start_filament_gcode }) { # process filament gcode in order
         $gcodegen->placeholder_parser->set("filament_extruder_id", $filament_extruder);

--- a/xs/src/libslic3r/PrintGCode.cpp
+++ b/xs/src/libslic3r/PrintGCode.cpp
@@ -121,6 +121,10 @@ PrintGCode::output()
 
     if (include_start_extruder_temp) this->_print_first_layer_temperature(0);
 
+    // initialize current_extruder placeholder now, because start_gcode may be relying on it
+    const auto extruders = _print.extruders();
+    _gcodegen.placeholder_parser->set("current_extruder", *(extruders.begin()));
+    
     // Apply gcode math to start gcode
     fh << apply_math(_gcodegen.placeholder_parser->process(config.start_gcode.value));
     {
@@ -161,9 +165,7 @@ PrintGCode::output()
 
         _gcodegen.avoid_crossing_perimeters.init_external_mp(union_ex(islands_p));
     }
-
-    const auto extruders = _print.extruders();
-
+    
     // Calculate wiping points if needed.
     if (config.ooze_prevention && extruders.size() > 1) {
         /*


### PR DESCRIPTION
@lordofhyphens 
@supermerill 
#4637 
`current_extruder`  initialization was moved before **Start G-code** is executed.
Both, C++ and Perl sources were modified, Slic3r built and tested in both, single and multi-extruder GCode exports. 
Our tool changer is now capable of picking the right tool (this fix), swapping tools and parking the last used tool at the end.
IMHO the fix it quite safe and has a very limited scope.

During testing, I came to conclusion that `lib/Slic3r/Print/GCode.pm` is exporting the GCode and not `xs/src/libslic3r/PrintGCode.cpp`.

This triggers the question of how to test the C++ side to witness it to be used during the export.