### PR TITLE
Perimeter loop : continuous mode for perimeters

### DIFF
--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -437,7 +437,7 @@ sub options {
     return qw(
         layer_height first_layer_height
         adaptive_slicing adaptive_slicing_quality match_horizontal_surfaces
-        perimeters spiral_vase
+        perimeters perimeter_loop perimeter_loop_seam spiral_vase
         top_solid_layers min_shell_thickness min_top_bottom_shell_thickness bottom_solid_layers
         extra_perimeters avoid_crossing_perimeters thin_walls overhangs
         seam_position external_perimeters_first
@@ -547,6 +547,8 @@ sub build {
             my $optgroup = $page->new_optgroup('Advanced');
             $optgroup->append_single_option_line('seam_position');
             $optgroup->append_single_option_line('external_perimeters_first');
+            $optgroup->append_single_option_line('perimeter_loop');
+            $optgroup->append_single_option_line('perimeter_loop_seam');
         }
     }
     
@@ -888,8 +890,13 @@ sub _update {
         $self->get_field($_)->toggle($have_perimeters)
             for qw(extra_perimeters thin_walls overhangs seam_position external_perimeters_first
                     external_perimeter_extrusion_width
-                    perimeter_speed small_perimeter_speed external_perimeter_speed);
+                    perimeter_speed small_perimeter_speed external_perimeter_speed
+					perimeter_loop perimeter_loop_seam);
     }
+
+    # Disable features that need perimeter_loop to be enabled.    
+    $self->get_field($_)->toggle($config->perimeter_loop)
+        for qw(perimeter_loop_seam);
 
     my $have_adaptive_slicing = $config->adaptive_slicing;
     if (any { /$opt_key/ } qw(all_keys adaptive_slicing)) {

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -460,6 +460,8 @@ $j
     --toolchange-gcode  Load tool-change G-code from the supplied file (default: nothing).
     --seam-position     Position of loop starting points (random/nearest/aligned, default: $config->{seam_position}).
     --external-perimeters-first Reverse perimeter order. (default: no)
+    --perimeter-loop    Join the perimeters in a unique loop (default: no)
+    --perimeter-loop-seam       Position of the perimeter loop switching points (nearest/rear), default: $config->{perimeter_loop_seam}).
     --spiral-vase       Experimental option to raise Z gradually when printing single-walled vases
                         (default: no)
     --only-retract-when-crossing-perimeters

--- a/src/GUI/Dialogs/PresetEditor.hpp
+++ b/src/GUI/Dialogs/PresetEditor.hpp
@@ -141,7 +141,7 @@ public:
         {
             "layer_height"s, "first_layer_height"s,
             "adaptive_slicing"s, "adaptive_slicing_quality"s, "match_horizontal_surfaces"s,
-            "perimeters"s, "spiral_vase"s,
+            "perimeters"s, "perimeter_loop"s, "perimeter_loop_seam"s, "spiral_vase"s,
             "top_solid_layers"s, "bottom_solid_layers"s,
             "extra_perimeters"s, "avoid_crossing_perimeters"s, "thin_walls"s, "overhangs"s,
             "seam_position"s, "external_perimeters_first"s,

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -543,6 +543,8 @@ GCode::_extrude(ExtrusionPath path, std::string description, double speed)
             speed = this->config.get_abs_value("top_solid_infill_speed");
         } else if (path.role == erGapFill) {
             speed = this->config.get_abs_value("gap_fill_speed");
+        } else if (path.role == erNone) {
+            speed = this->config.get_abs_value("travel_speed");
         } else {
             CONFESS("Invalid speed");
         }

--- a/xs/src/libslic3r/Layer.cpp
+++ b/xs/src/libslic3r/Layer.cpp
@@ -189,7 +189,8 @@ Layer::make_perimeters()
                 && config.overhangs         == other_config.overhangs
                 && config.serialize("perimeter_extrusion_width").compare(other_config.serialize("perimeter_extrusion_width")) == 0
                 && config.thin_walls        == other_config.thin_walls
-                && config.external_perimeters_first == other_config.external_perimeters_first) {
+                && config.external_perimeters_first == other_config.external_perimeters_first
+                && config.perimeter_loop    == other_config.perimeter_loop) {
                 layerms.push_back(other_layerm);
                 done.insert(it - this->regions.begin());
             }

--- a/xs/src/libslic3r/Line.cpp
+++ b/xs/src/libslic3r/Line.cpp
@@ -218,6 +218,14 @@ Line::ccw(const Point& point) const
     return point.ccw(*this);
 }
 
+coord_t
+Line::dot(const Line &l2) const
+{
+    Vector v_1 = vector();
+    Vector v_2 = l2.vector();
+    return v_1.x*v_2.x + v_1.y*v_2.y;
+}
+
 Pointf3
 Linef3::intersect_plane(double z) const
 {

--- a/xs/src/libslic3r/Line.hpp
+++ b/xs/src/libslic3r/Line.hpp
@@ -45,6 +45,7 @@ class Line
     void extend_start(double distance);
     bool intersection(const Line& line, Point* intersection) const;
     double ccw(const Point& point) const;
+    coord_t dot(const Line &l2) const;
 };
 
 class ThickLine : public Line

--- a/xs/src/libslic3r/MultiPoint.hpp
+++ b/xs/src/libslic3r/MultiPoint.hpp
@@ -31,6 +31,21 @@ class MultiPoint
 
     int find_point(const Point &point) const;
     bool has_boundary_point(const Point &point) const;
+    int  closest_point_index(const Point &point) const {
+        int idx = -1;
+        if (! this->points.empty()) {
+            idx = 0;
+            double dist_min = this->points.front().distance_to(point);
+            for (int i = 1; i < int(this->points.size()); ++ i) {
+                double d = this->points[i].distance_to(point);
+                if (d < dist_min) {
+                    dist_min = d;
+                    idx = i;
+                }
+            }
+        }
+        return idx;
+    }
     BoundingBox bounding_box() const;
     
     // Return true if there are exact duplicates.
@@ -44,6 +59,7 @@ class MultiPoint
     void append(const Points::const_iterator &begin, const Points::const_iterator &end);
     bool intersection(const Line& line, Point* intersection) const;
     std::string dump_perl() const;
+    virtual Point point_projection(const Point &point) const;
     
     static Points _douglas_peucker(const Points &points, const double tolerance);
     

--- a/xs/src/libslic3r/PerimeterGenerator.hpp
+++ b/xs/src/libslic3r/PerimeterGenerator.hpp
@@ -8,8 +8,18 @@
 #include "Polygon.hpp"
 #include "PrintConfig.hpp"
 #include "SurfaceCollection.hpp"
+#include "ExtrusionEntityCollection.hpp"
 
 namespace Slic3r {
+	
+	
+struct PerimeterIntersectionPoint {
+    size_t idx_children;
+    Point child_best;
+    Point outter_best;
+    size_t idx_polyline_outter;
+    coord_t distance;
+};
 
 // Hierarchy of perimeters.
 class PerimeterGeneratorLoop {
@@ -86,6 +96,12 @@ public:
     
     ExtrusionEntityCollection _traverse_loops(const PerimeterGeneratorLoops &loops,
         ThickPolylines &thin_walls) const;
+    ExtrusionLoop _traverse_and_join_loops(const PerimeterGeneratorLoop &loop, 
+        const PerimeterGeneratorLoops &childs, const Point entryPoint) const;
+    ExtrusionLoop _extrude_and_cut_loop(const PerimeterGeneratorLoop &loop, 
+        const Point entryPoint, const Line &direction = Line(Point(0,0),Point(0,0))) const;
+    PerimeterIntersectionPoint _get_nearest_point(const PerimeterGeneratorLoops &children, 
+        ExtrusionLoop &myPolylines, const coord_t dist_cut, const coord_t max_dist) const;
     ExtrusionEntityCollection _variable_width
         (const ThickPolylines &polylines, ExtrusionRole role, Flow flow) const;
 };

--- a/xs/src/libslic3r/Point.hpp
+++ b/xs/src/libslic3r/Point.hpp
@@ -47,6 +47,8 @@ class Point
     static Point new_scale(Pointf p);
     bool operator==(const Point& rhs) const;
     bool operator!=(const Point& rhs) const { return !(*this == rhs); }
+    Point& operator+=(const Point& rhs) { this->x += rhs.x; this->y += rhs.y; return *this; }
+    Point& operator-=(const Point& rhs) { this->x -= rhs.x; this->y -= rhs.y; return *this; }
     std::string wkt() const;
     std::string dump_perl() const;
     void scale(double factor);
@@ -142,6 +144,8 @@ class Pointf
 
 Pointf operator+(const Pointf& point1, const Pointf& point2);
 Pointf operator/(const Pointf& point1, const double& scalar);
+inline coordf_t dot(const Pointf &v1, const Pointf &v2) { return v1.x * v2.x + v1.y * v2.y; }
+inline coordf_t dot(const Pointf &v) { return v.x * v.x + v.y * v.y; }
 
 std::ostream& operator<<(std::ostream &stm, const Pointf3 &pointf3);
 

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -983,6 +983,26 @@ PrintConfigDef::PrintConfigDef()
     def->enum_values.push_back("0");
     def->enum_labels.push_back("default");
     def->default_value = new ConfigOptionFloatOrPercent(0, false);
+	
+    def = this->add("perimeter_loop", coBool);
+    def->label = __TRANS("Looping perimeters");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Join the perimeters to create only one continuous extrusion without any z-hop."
+        " Long inside travel (from external to holes) are not extruded to give some place to the infill.");
+    def->cli = "loop-perimeter!";
+    def->default_value = new ConfigOptionBool(false);
+    
+    def = this->add("perimeter_loop_seam", coEnum);
+    def->label = __TRANS("Seam position");
+    def->category = __TRANS("Layers and Perimeters");
+    def->tooltip = __TRANS("Position of perimeters starting points.");
+    def->cli = "perimeter-seam-position=s";
+    def->enum_keys_map = ConfigOptionEnum<SeamPosition>::get_enum_values();
+    def->enum_values.push_back("nearest");
+    def->enum_values.push_back("rear");
+    def->enum_labels.push_back("Nearest");
+    def->enum_labels.push_back("Rear");
+    def->default_value = new ConfigOptionEnum<SeamPosition>(spRear); 
 
     def = this->add("perimeter_speed", coFloat);
     def->label = __TRANS("Perimeters");

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -260,6 +260,8 @@ class PrintRegionConfig : public virtual StaticPrintConfig
     ConfigOptionBool                overhangs;
     ConfigOptionInt                 perimeter_extruder;
     ConfigOptionFloatOrPercent      perimeter_extrusion_width;
+    ConfigOptionBool                perimeter_loop;
+    ConfigOptionEnum<SeamPosition>  perimeter_loop_seam;
     ConfigOptionFloat               perimeter_speed;
     ConfigOptionInt                 perimeters;
     ConfigOptionFloatOrPercent      small_perimeter_speed;
@@ -302,6 +304,8 @@ class PrintRegionConfig : public virtual StaticPrintConfig
         OPT_PTR(overhangs);
         OPT_PTR(perimeter_extruder);
         OPT_PTR(perimeter_extrusion_width);
+        OPT_PTR(perimeter_loop);
+        OPT_PTR(perimeter_loop_seam);
         OPT_PTR(perimeter_speed);
         OPT_PTR(perimeters);
         OPT_PTR(small_perimeter_speed);

--- a/xs/src/libslic3r/PrintRegion.cpp
+++ b/xs/src/libslic3r/PrintRegion.cpp
@@ -81,6 +81,8 @@ PrintRegion::invalidate_state_by_config(const PrintConfigBase &config)
             || opt_key == "overhangs"
             || opt_key == "first_layer_extrusion_width"
             || opt_key == "perimeter_extrusion_width"
+            || opt_key == "perimeter_loop"
+            || opt_key == "perimeter_loop_seam"
             || opt_key == "thin_walls"
             || opt_key == "external_perimeters_first") {
             steps.insert(posPerimeters);


### PR DESCRIPTION
It merges the loops into a big one

 also add perimeter loop seam option : rear => it put the externals ones on -y and the internal ones on +y, if possible.

see https://github.com/slic3r/Slic3r/issues/4552

thanks to @gotthalmseder for sponsoring this feature.