### PR TITLE
Add raft_offset to the options dialog.

### DIFF
--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -612,6 +612,7 @@ sub build {
         {
             my $optgroup = $page->new_optgroup('Raft');
             $optgroup->append_single_option_line('raft_layers');
+            $optgroup->append_single_option_line('raft_offset');
         }
         {
             my $optgroup = $page->new_optgroup('Options for support material and raft');


### PR DESCRIPTION
I have a large object with big holes and the raft does not work as well as it could with big holes, and I discovered there was already an option that I could use to fix that, but it was not available in the GUI, for some reason.