### PR TITLE
fix transparent desktop icon

### DIFF
--- a/package/linux/appimage.sh
+++ b/package/linux/appimage.sh
@@ -68,7 +68,7 @@ cp ${WD}/appimage-apprun.sh ${WD}/${APP}.AppDir/AppRun
 
 chmod +x AppRun
 
-cp ${WD}/${APP}.AppDir/usr/bin/var/Slic3r_192px_transparent.png $WD/${APP}.AppDir/${APP}.png
+cp ${WD}/${APP}.AppDir/usr/bin/var/Slic3r_192px.png $WD/${APP}.AppDir/${APP}.png
 
 cat > $WD/${APP}.AppDir/${APP}.desktop <<EOF
 [Desktop Entry]


### PR DESCRIPTION
fixes #4721 

Changes the icon used for Linux `.appimage` builds to `/var/Slic3r_192px.png` instead of `/var/Slic3r_192px_transparent.png`