### PR TITLE
Simplify collinear points

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -306,6 +306,7 @@ set(SLIC3R_TEST_SOURCES
     ${TESTDIR}/libslic3r/test_geometry.cpp
     ${TESTDIR}/libslic3r/test_log.cpp
     ${TESTDIR}/libslic3r/test_model.cpp
+    ${TESTDIR}/libslic3r/test_polygon.cpp
     ${TESTDIR}/libslic3r/test_print.cpp
     ${TESTDIR}/libslic3r/test_printgcode.cpp
     ${TESTDIR}/libslic3r/test_skirt_brim.cpp

--- a/src/test/libslic3r/test_polygon.cpp
+++ b/src/test/libslic3r/test_polygon.cpp
@@ -1,0 +1,48 @@
+
+#include <catch.hpp>
+
+#include "Point.hpp"
+#include "Polygon.hpp"
+
+
+using namespace Slic3r;
+
+
+// This test currently only covers remove_collinear_points.
+// All remaining tests are to be ported from xs/t/06_polygon.t
+
+Points collinear_circle({
+    Point::new_scale(0, 0), // 3 collinear points at beginning
+    Point::new_scale(10, 0),
+    Point::new_scale(20, 0),
+    Point::new_scale(30, 10),
+    Point::new_scale(40, 20), // 2 collinear points
+    Point::new_scale(40, 30),
+    Point::new_scale(30, 40), // 3 collinear points
+    Point::new_scale(20, 40),
+    Point::new_scale(10, 40),
+    Point::new_scale(-10, 20),
+    Point::new_scale(-20, 10),
+    Point::new_scale(-20, 0), // 3 collinear points at end
+    Point::new_scale(-10, 0),
+    Point::new_scale(-5, 0)
+});
+
+
+SCENARIO("Remove collinear points from Polygon") {
+    GIVEN("Polygon with collinear points"){
+        Polygon p(collinear_circle);
+        WHEN("collinear points are removed") {
+            p.remove_collinear_points();
+            THEN("Leading collinear points are removed") {
+                REQUIRE(p.points.front() == Point::new_scale(20, 0));
+            }
+            THEN("Trailing collinear points are removed") {
+                REQUIRE(p.points.back() == Point::new_scale(-20, 0));
+            }
+            THEN("Number of remaining points is correct") {
+                REQUIRE(p.points.size() == 7);
+            }
+        }
+    }
+}

--- a/xs/src/libslic3r/ExPolygon.cpp
+++ b/xs/src/libslic3r/ExPolygon.cpp
@@ -130,6 +130,14 @@ ExPolygon::has_boundary_point(const Point &point) const
 }
 
 void
+ExPolygon::remove_colinear_points()
+{
+    this->contour.remove_collinear_points();
+    for (Polygon &p : this->holes)
+        p.remove_collinear_points();
+}
+
+void
 ExPolygon::remove_vertical_collinear_points(coord_t tolerance)
 {
     this->contour.remove_vertical_collinear_points(tolerance);

--- a/xs/src/libslic3r/ExPolygon.hpp
+++ b/xs/src/libslic3r/ExPolygon.hpp
@@ -37,6 +37,8 @@ class ExPolygon
     bool contains_b(const Point &point) const;
     bool has_boundary_point(const Point &point) const;
     BoundingBox bounding_box() const { return this->contour.bounding_box(); };
+    /// removes collinear points within SCALED_EPSILON tolerance
+    void remove_colinear_points();
     void remove_vertical_collinear_points(coord_t tolerance);
     void simplify_p(double tolerance, Polygons* polygons) const;
     Polygons simplify_p(double tolerance) const;

--- a/xs/src/libslic3r/Point.cpp
+++ b/xs/src/libslic3r/Point.cpp
@@ -23,6 +23,12 @@ Point::new_scale(Pointf p) {
     return Point(scale_(p.x), scale_(p.y));
 }
 
+std::ostream&
+operator<<(std::ostream &stm, const Point &point)
+{
+    return stm << "POINT(" << point.x << " " << point.y << ")";
+}
+
 std::string
 Point::wkt() const
 {

--- a/xs/src/libslic3r/Point.hpp
+++ b/xs/src/libslic3r/Point.hpp
@@ -85,6 +85,7 @@ class Point
     void align_to_grid(const Point &spacing, const Point &base = Point(0,0));
 };
 
+std::ostream& operator<<(std::ostream &stm, const Point &point);
 Point operator+(const Point& point1, const Point& point2);
 Point operator-(const Point& point1, const Point& point2);
 Point operator*(double scalar, const Point& point2);

--- a/xs/src/libslic3r/Polygon.cpp
+++ b/xs/src/libslic3r/Polygon.cpp
@@ -157,6 +157,42 @@ Polygon::douglas_peucker(double tolerance)
 }
 
 void
+Polygon::remove_collinear_points()
+{
+    if(this->points.size() > 2) {
+        // copy points and append both 1 and last point in place to cover the boundaries
+        Points pp;
+        pp.reserve(this->points.size()+2);
+        pp.push_back(this->points.back());
+        pp.insert(pp.begin()+1, this->points.begin(), this->points.end());
+        pp.push_back(this->points.front());
+        // delete old points vector. Will be re-filled in the loop
+        this->points.clear();
+
+        size_t i = 0;
+        size_t k = 0;
+        while (i < pp.size()-2) {
+            k = i+1;
+            const Point &p1 = pp[i];
+            while (k < pp.size()-1) {
+                const Point &p2 = pp[k];
+                const Point &p3 = pp[k+1];
+                Line l(p1, p3);
+                if(l.distance_to(p2) < SCALED_EPSILON) {
+                    k++;
+                } else {
+                    if(i > 0) this->points.push_back(p1); // implicitly removes the first point we appended above
+                    i = k;
+                    break;
+                }
+            }
+            if(k > pp.size()-2) break; // all remaining points are collinear and can be skipped
+        }
+        this->points.push_back(pp[i]);
+    }
+}
+
+void
 Polygon::remove_vertical_collinear_points(coord_t tolerance)
 {
     Points &pp = this->points;

--- a/xs/src/libslic3r/Polygon.hpp
+++ b/xs/src/libslic3r/Polygon.hpp
@@ -41,6 +41,8 @@ class Polygon : public MultiPoint {
     // Tested by counting intersections along a horizontal line.
     bool contains(const Point &point) const;
     void douglas_peucker(double tolerance);
+    /// removes collinear points within SCALED_EPSILON tolerance
+    void remove_collinear_points();
     void remove_vertical_collinear_points(coord_t tolerance);
     Polygons simplify(double tolerance) const;
     void simplify(double tolerance, Polygons &polygons) const;

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -842,19 +842,6 @@ void PrintObject::_slice()
         }
     }
 
-    // remove collinear points from slice polygons (artifacts from stl-triangulation)
-    std::queue<SurfaceCollection*> queue;
-    for (Layer* layer : this->layers) {
-        for (LayerRegion* layerm : layer->regions) {
-            queue.push(&layerm->slices);
-        }
-    }
-    parallelize<SurfaceCollection*>(
-        queue,
-        boost::bind(&Slic3r::SurfaceCollection::remove_collinear_points, _1),
-        this->_print->config.threads.value
-    );
-
     // remove last layer(s) if empty
     bool done = false;
     while (! this->layers.empty()) {
@@ -869,7 +856,20 @@ void PrintObject::_slice()
         }
         this->delete_layer(int(this->layers.size()) - 1);
     }
-    
+
+    // remove collinear points from slice polygons (artifacts from stl-triangulation)
+    std::queue<SurfaceCollection*> queue;
+    for (Layer* layer : this->layers) {
+        for (LayerRegion* layerm : layer->regions) {
+            queue.push(&layerm->slices);
+        }
+    }
+    parallelize<SurfaceCollection*>(
+        queue,
+        boost::bind(&Slic3r::SurfaceCollection::remove_collinear_points, _1),
+        this->_print->config.threads.value
+    );
+
     // Apply size compensation and perform clipping of multi-part objects.
     const coord_t xy_size_compensation = scale_(this->config.xy_size_compensation.value);
     for (Layer* layer : this->layers) {

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -842,6 +842,19 @@ void PrintObject::_slice()
         }
     }
 
+    // remove collinear points from slice polygons (artifacts from stl-triangulation)
+    std::queue<SurfaceCollection*> queue;
+    for (Layer* layer : this->layers) {
+        for (LayerRegion* layerm : layer->regions) {
+            queue.push(&layerm->slices);
+        }
+    }
+    parallelize<SurfaceCollection*>(
+        queue,
+        boost::bind(&Slic3r::SurfaceCollection::remove_collinear_points, _1),
+        this->_print->config.threads.value
+    );
+
     // remove last layer(s) if empty
     bool done = false;
     while (! this->layers.empty()) {

--- a/xs/src/libslic3r/SurfaceCollection.cpp
+++ b/xs/src/libslic3r/SurfaceCollection.cpp
@@ -39,6 +39,14 @@ SurfaceCollection::simplify(double tolerance)
     this->surfaces = ss;
 }
 
+void
+SurfaceCollection::remove_collinear_points()
+{
+    for(Surface &surface : this->surfaces) {
+        surface.expolygon.remove_colinear_points();
+    }
+}
+
 /* group surfaces by common properties */
 void
 SurfaceCollection::group(std::vector<SurfacesConstPtr> *retval) const

--- a/xs/src/libslic3r/SurfaceCollection.hpp
+++ b/xs/src/libslic3r/SurfaceCollection.hpp
@@ -18,6 +18,8 @@ class SurfaceCollection
     operator Polygons() const;
     operator ExPolygons() const;
     void simplify(double tolerance);
+    /// Unifies straight multi-segment lines to a single line (artifacts from stl-triangulation)
+    void remove_collinear_points();
     void group(std::vector<SurfacesConstPtr> *retval) const;
     template <class T> bool any_internal_contains(const T &item) const;
     template <class T> bool any_bottom_contains(const T &item) const;


### PR DESCRIPTION
Fixes #4726.

collinear lines are removed from the `slices` polygons of each layer (parallelized).

This could potentially also be implemented in the [make_loops](https://github.com/slic3r/Slic3r/blob/master/xs/src/libslic3r/TriangleMesh.cpp#L1135) method where the polygons from slicing are assembled, not sure if that would gain any performance.

Includes a simple CATCH testcase, but only for the remove_collinear_points part of Polygon.