### PR TITLE
Fixed that bridge angle is lost on shell layers

### DIFF
--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -1664,7 +1664,7 @@ PrintObject::_discover_neighbor_horizontal_shells(LayerRegion* layerm, const siz
             append_to(tmp, to_polygons(internal));
             
             const auto solid_surfaces = diff_ex(to_polygons(s), tmp, true);
-            neighbor_layerm->fill_surfaces.append(solid_surfaces, s.front()->surface_type);
+            neighbor_layerm->fill_surfaces.append(solid_surfaces, *s.front());
         }
     }
 }


### PR DESCRIPTION
Previously, if a bridge was on a layer which had solid infill due to a horizontal shell, the bridge angle would be reset to -1. This could occur e.g. if a model has two bridges on on neighbouring layers (even if the bridges aren't near each other).

This may be a fix for issues https://github.com/slic3r/Slic3r/issues/3175 and https://github.com/slic3r/Slic3r/issues/3139.