### PR TITLE
Catch and rethrow parse errors, showing a log entry and a GUI error.

### DIFF
--- a/lib/Slic3r/GUI/Preset.pm
+++ b/lib/Slic3r/GUI/Preset.pm
@@ -195,7 +195,14 @@ sub load_config {
             Slic3r::GUI::show_error(undef, "The selected preset does not exist anymore (" . $self->file . ").");
             return undef;
         }
-        my $external_config = Slic3r::Config->load($self->file);
+        my $external_config = "";
+        eval {
+            $external_config = Slic3r::Config->load($self->file);
+        } or do {
+            # Catch exception from the XS load
+            Slic3r::GUI::show_error(undef, "The selected preset failed to load.");
+            return undef;
+        };
         if (!@keys) {
             $self->_config($external_config);
         } else {

--- a/xs/src/libslic3r/ConfigBase.cpp
+++ b/xs/src/libslic3r/ConfigBase.cpp
@@ -1,4 +1,5 @@
 #include "ConfigBase.hpp"
+#include "Log.hpp"
 #include <assert.h>
 #include <ctime>
 #include <fstream>
@@ -618,7 +619,13 @@ ConfigBase::load(const std::string &file)
     namespace pt = boost::property_tree;
     pt::ptree tree;
 	boost::nowide::ifstream ifs(file);
-	pt::read_ini(ifs, tree);
+    try {
+        pt::read_ini(ifs, tree);
+    } catch(std::exception& ex) {
+        // Log or error string stating that the data read is corrupt
+        Log::error("Config") << "Error reading ini " << file << ":" << ex.what() << "\n";
+        throw ex;
+    }
     BOOST_FOREACH(const pt::ptree::value_type &v, tree) {
         try {
             t_config_option_key opt_key = v.first;

--- a/xs/src/libslic3r/Log.hpp
+++ b/xs/src/libslic3r/Log.hpp
@@ -26,10 +26,18 @@ class _Log {
 public:
     static std::unique_ptr<_Log> make_log() {
         std::unique_ptr<_Log> tmp {new _Log()};
+        tmp->_inclusive_levels = true;
+        tmp->set_level(log_t::ERR);
+        tmp->set_level(log_t::FERR);
+        tmp->set_level(log_t::WARN);
         return tmp;
     }
     static std::unique_ptr<_Log> make_log(std::ostream& out) {
         std::unique_ptr<_Log> tmp {new _Log(out)};
+        tmp->_inclusive_levels = true;
+        tmp->set_level(log_t::ERR);
+        tmp->set_level(log_t::FERR);
+        tmp->set_level(log_t::WARN);
         return tmp;
     }
     void fatal_error(const std::string& topic, const std::string& message);


### PR DESCRIPTION
If a loaded config.ini has a parse error from boost::property_tree::read_ini, handle things a little more gracefully.

Fixes #4724 
