### PR TITLE
Restrict speed setting to fixed-point output with 3 decimal places.

### DIFF
--- a/package/linux/travis-build-main.sh
+++ b/package/linux/travis-build-main.sh
@@ -25,6 +25,9 @@ if [ ! -e ./local-lib/lib/perl5/x86_64-linux-thread-multi/Wx.pm ]; then
     tar -C$TRAVIS_BUILD_DIR -xjf /tmp/local-lib-wx302.tar.bz2
 fi
 
+cpanm local::lib
+eval $(perl -Mlocal::lib=${TRAVIS_BUILD_DIR}/local-lib)
+CC=g++-8 CXX=g++-8 cpanm ExtUtils::CppGuess --force
 CC=g++-8 CXX=g++-8 BOOST_DIR=$HOME/boost_1_69_0 perl ./Build.PL
 excode=$?
 if [ $excode -ne 0 ]; then exit $excode; fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -303,6 +303,7 @@ set(SLIC3R_TEST_SOURCES
     ${TESTDIR}/libslic3r/test_fill.cpp
     ${TESTDIR}/libslic3r/test_flow.cpp
     ${TESTDIR}/libslic3r/test_gcodewriter.cpp
+    ${TESTDIR}/libslic3r/test_gcode.cpp
     ${TESTDIR}/libslic3r/test_geometry.cpp
     ${TESTDIR}/libslic3r/test_log.cpp
     ${TESTDIR}/libslic3r/test_model.cpp
@@ -544,6 +545,7 @@ if (SLIC3R_BUILD_TESTS)
     endif()
     configure_file("${TESTDIR}/test_options.hpp.in" "${TESTDIR}/test_options.hpp")
     add_executable(slic3r_test ${SLIC3R_TEST_SOURCES}) 
+    target_compile_options(slic3r_test PUBLIC -DSLIC3R_TEST)
     add_test(NAME TestSlic3r COMMAND slic3r_test)
     target_compile_features(slic3r_test PUBLIC cxx_std_14)
     target_include_directories(slic3r_test PUBLIC cxx_std_14 ${SLIC3R_INCLUDES})

--- a/src/test/libslic3r/test_gcode.cpp
+++ b/src/test/libslic3r/test_gcode.cpp
@@ -1,0 +1,15 @@
+#include <catch.hpp>
+
+
+#include "GCode/CoolingBuffer.hpp"
+#include "GCode.hpp"
+
+SCENARIO("Cooling buffer speed factor rewrite enforces precision") {
+    GIVEN("GCode line of set speed") {
+        std::string gcode_string = "G1 F1000000.000";
+        WHEN("40% speed factor is applied to a speed of 1000000 with 3-digit precision") {
+            Slic3r::apply_speed_factor(gcode_string, (1.0f/3.0f), 30.0);
+            REQUIRE_THAT(gcode_string, Catch::Equals("G1 F333333.344"));
+        }
+    }
+}

--- a/src/test/libslic3r/test_gcodewriter.cpp
+++ b/src/test/libslic3r/test_gcodewriter.cpp
@@ -98,3 +98,30 @@ SCENARIO("lift() is not ignored after unlift() at normal values of Z") {
         }
     }
 }
+
+SCENARIO("set_speed emits values with fixed-point output.") {
+
+    GIVEN("GCodeWriter instance") {
+        GCodeWriter writer;
+        WHEN("set_speed is called to set speed to 1.09321e+06") {
+            THEN("Output string is G1 F1093210.000") {
+                REQUIRE_THAT(writer.set_speed(1.09321e+06), Catch::Equals("G1 F1093210.000\n"));
+            }
+        }
+        WHEN("set_speed is called to set speed to 1") {
+            THEN("Output string is G1 F1.000") {
+                REQUIRE_THAT(writer.set_speed(1.0), Catch::Equals("G1 F1.000\n"));
+            }
+        }
+        WHEN("set_speed is called to set speed to 203.200022") {
+            THEN("Output string is G1 F203.200") {
+                REQUIRE_THAT(writer.set_speed(203.200022), Catch::Equals("G1 F203.200\n"));
+            }
+        }
+        WHEN("set_speed is called to set speed to 203.200522") {
+            THEN("Output string is G1 F203.200") {
+                REQUIRE_THAT(writer.set_speed(203.200522), Catch::Equals("G1 F203.201\n"));
+            }
+        }
+    }
+}

--- a/xs/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/xs/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -50,7 +50,8 @@ apply_speed_factor(std::string &line, float speed_factor, float min_print_speed)
     // replace speed in string
     {
         std::ostringstream oss;
-        oss << speed;
+        oss.precision(3);
+        oss << std::fixed << speed;
         line.replace(pos+1, (last_pos-pos), oss.str());
     }
 }

--- a/xs/src/libslic3r/GCode/CoolingBuffer.hpp
+++ b/xs/src/libslic3r/GCode/CoolingBuffer.hpp
@@ -37,6 +37,10 @@ class CoolingBuffer {
     float                       _min_print_speed;
 };
 
+#ifdef SLIC3R_TEST
+void apply_speed_factor(std::string &line, float speed_factor, float min_print_speed);
+#endif
+
 }
 
 #endif

--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -309,7 +309,8 @@ GCodeWriter::set_speed(double F, const std::string &comment,
                        const std::string &cooling_marker) const
 {
     std::ostringstream gcode;
-    gcode << "G1 F" << F;
+    gcode.precision(3);
+    gcode << "G1 F" << std::fixed << F;
     COMMENT(comment);
     gcode << cooling_marker;
     gcode << "\n";


### PR DESCRIPTION
Includes test.

Fixes #4769

Duplicates #4770 because could not check branch out of just number names.