### PR TITLE
Set the initial maximum size for layer heights and nozzle diameter to max

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -310,6 +310,7 @@ set(SLIC3R_TEST_SOURCES
     ${TESTDIR}/libslic3r/test_polygon.cpp
     ${TESTDIR}/libslic3r/test_print.cpp
     ${TESTDIR}/libslic3r/test_printgcode.cpp
+    ${TESTDIR}/libslic3r/test_printobject.cpp
     ${TESTDIR}/libslic3r/test_skirt_brim.cpp
     ${TESTDIR}/libslic3r/test_test_data.cpp
     ${TESTDIR}/libslic3r/test_trianglemesh.cpp

--- a/src/test/libslic3r/test_printobject.cpp
+++ b/src/test/libslic3r/test_printobject.cpp
@@ -11,17 +11,12 @@ SCENARIO("PrintObject: object layer heights") {
         auto config {Slic3r::Config::new_from_defaults()};
         TestMesh m { TestMesh::cube_20x20x20 };
         Slic3r::Model model;
-        auto event_counter {0U};
-        std::string stage;
-        int value {0};
-        config->set("fill_density", 0);
         config->set("nozzle_diameter", "3");
         config->set("layer_height", 2.0);
         config->set("first_layer_height", 2.0);
 
         WHEN("generate_object_layers() is called with a starting layer of 2mm") {
             auto print {Slic3r::Test::init_print({m}, model, config)};
-            const auto& object = *(print->objects.at(0));
             auto result {print->objects[0]->generate_object_layers(2.0)};
             THEN("The output vector has 10 entries") {
                 REQUIRE(result.size() == 10);

--- a/src/test/libslic3r/test_printobject.cpp
+++ b/src/test/libslic3r/test_printobject.cpp
@@ -1,0 +1,38 @@
+#include <catch.hpp>
+#include <string>
+#include "test_data.hpp"
+#include "libslic3r.h"
+
+using namespace Slic3r::Test;
+using namespace std::literals;
+
+SCENARIO("PrintObject: object layer heights") {
+    GIVEN("20mm cube and config that has a 3mm nozzle and a 2mm requested layer height") {
+        auto config {Slic3r::Config::new_from_defaults()};
+        TestMesh m { TestMesh::cube_20x20x20 };
+        Slic3r::Model model;
+        auto event_counter {0U};
+        std::string stage;
+        int value {0};
+        config->set("fill_density", 0);
+        config->set("nozzle_diameter", "3");
+        config->set("layer_height", 2.0);
+        config->set("first_layer_height", 2.0);
+
+        WHEN("generate_object_layers() is called with a starting layer of 2mm") {
+            auto print {Slic3r::Test::init_print({m}, model, config)};
+            const auto& object = *(print->objects.at(0));
+            auto result {print->objects[0]->generate_object_layers(2.0)};
+            THEN("The output vector has 10 entries") {
+                REQUIRE(result.size() == 10);
+            }
+            AND_THEN("Each layer is approximately 2mm above the previous Z") {
+                coordf_t last = 0.0;
+                for (size_t i = 0; i < result.size(); i++) {
+                    REQUIRE((result[i] - last) == Approx(2.0));
+                    last = result[i];
+                }
+            }
+        }
+    }
+}

--- a/src/test/libslic3r/test_printobject.cpp
+++ b/src/test/libslic3r/test_printobject.cpp
@@ -7,15 +7,16 @@ using namespace Slic3r::Test;
 using namespace std::literals;
 
 SCENARIO("PrintObject: object layer heights") {
-    GIVEN("20mm cube and config that has a 3mm nozzle and a 2mm requested layer height") {
+    GIVEN("20mm cube and default initial config, initial layer height of 2mm") {
         auto config {Slic3r::Config::new_from_defaults()};
         TestMesh m { TestMesh::cube_20x20x20 };
         Slic3r::Model model;
-        config->set("nozzle_diameter", "3");
-        config->set("layer_height", 2.0);
+
         config->set("first_layer_height", 2.0);
 
-        WHEN("generate_object_layers() is called with a starting layer of 2mm") {
+        WHEN("generate_object_layers() is called for 2mm layer heights and nozzle diameter of 3mm") {
+            config->set("nozzle_diameter", "3");
+            config->set("layer_height", 2.0);
             auto print {Slic3r::Test::init_print({m}, model, config)};
             auto result {print->objects[0]->generate_object_layers(2.0)};
             THEN("The output vector has 10 entries") {
@@ -29,5 +30,50 @@ SCENARIO("PrintObject: object layer heights") {
                 }
             }
         }
+        WHEN("generate_object_layers() is called for 10mm layer heights and nozzle diameter of 11mm") {
+            config->set("nozzle_diameter", "11");
+            config->set("layer_height", 10.0);
+            auto print {Slic3r::Test::init_print({m}, model, config)};
+            auto result {print->objects[0]->generate_object_layers(2.0)};
+            THEN("The output vector has 2 entries") {
+                REQUIRE(result.size() == 3);
+            }
+            AND_THEN("Layer 0 is at 2mm") {
+                REQUIRE(result[0] == Approx(2.0));
+            }
+            AND_THEN("Layer 1 is at 12mm") {
+                REQUIRE(result[1] == Approx(12.0));
+            }
+        }
+        WHEN("generate_object_layers() is called for 15mm layer heights and nozzle diameter of 16mm") {
+            config->set("nozzle_diameter", "16");
+            config->set("layer_height", 15.0);
+            auto print {Slic3r::Test::init_print({m}, model, config)};
+            auto result {print->objects[0]->generate_object_layers(2.0)};
+            THEN("The output vector has 2 entries") {
+                REQUIRE(result.size() == 3);
+            }
+            AND_THEN("Layer 0 is at 2mm") {
+                REQUIRE(result[0] == Approx(2.0));
+            }
+            AND_THEN("Layer 1 is at 17mm") {
+                REQUIRE(result[1] == Approx(17.0));
+            }
+        }
+        WHEN("generate_object_layers() is called for 15mm layer heights and nozzle diameter of 5mm") {
+            config->set("nozzle_diameter", "5");
+            config->set("layer_height", 15.0);
+            auto print {Slic3r::Test::init_print({m}, model, config)};
+            auto result {print->objects[0]->generate_object_layers(2.0)};
+            THEN("The layer height is limited to 5mm.") {
+                CHECK(result.size() == 5);
+                coordf_t last = 2.0;
+                for (size_t i = 1; i < result.size(); i++) {
+                    REQUIRE((result[i] - last) == Approx(5.0));
+                    last = result[i];
+                }
+            }
+        }
+
     }
 }

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -5,6 +5,7 @@
 #include "Log.hpp"
 #include <algorithm>
 #include <vector>
+#include <limits>
 
 namespace Slic3r {
 
@@ -561,9 +562,9 @@ std::vector<coordf_t> PrintObject::generate_object_layers(coordf_t first_layer_h
     std::vector<coordf_t> result;
 
     // collect values from config
-    coordf_t min_nozzle_diameter = 1.0;
+    coordf_t min_nozzle_diameter = std::numeric_limits<double>::max();
     coordf_t min_layer_height = 0.0;
-    coordf_t max_layer_height = 10.0;
+    coordf_t max_layer_height = std::numeric_limits<double>::max();
     std::set<size_t> object_extruders = this->_print->object_extruders();
     for (std::set<size_t>::const_iterator it_extruder = object_extruders.begin(); it_extruder != object_extruders.end(); ++ it_extruder) {
         min_nozzle_diameter = std::min(min_nozzle_diameter, this->_print->config.nozzle_diameter.get_at(*it_extruder));
@@ -589,7 +590,7 @@ std::vector<coordf_t> PrintObject::generate_object_layers(coordf_t first_layer_h
         // layer heights are already generated, just update layers from spline
         // we don't need to respect first layer here, it's correctly provided by the spline object
         result = this->layer_height_spline.getInterpolatedLayers();
-    }else{ // create new set of layers
+    } else { // create new set of layers
         // create stateful objects and variables for the adaptive slicing process
         SlicingAdaptive as;
         coordf_t adaptive_quality = this->config.adaptive_slicing_quality.value;


### PR DESCRIPTION
The algorithm used to adjust layer heights in PrintObject has as a ceiling some default values that were fine when nozzles were < 1.0mm but not anymore.
To avoid more surprises, set to numeric_limits<double>::max()
Adds regression test as well.
Fixes #4516