### PR TITLE
Solve some compilation warnings in libslic3r

### DIFF
--- a/xs/src/libslic3r/ExPolygon.cpp
+++ b/xs/src/libslic3r/ExPolygon.cpp
@@ -322,7 +322,6 @@ ExPolygon::medial_axis(const ExPolygon &bounds, double max_width, double min_wid
     
     // Loop through all returned polylines in order to extend their endpoints to the 
     //   expolygon boundaries
-    bool removed = false;
     for (size_t i = 0; i < pp.size(); ++i) {
         ThickPolyline& polyline = pp[i];
         
@@ -422,7 +421,6 @@ ExPolygon::medial_axis(const ExPolygon &bounds, double max_width, double min_wid
             && polyline.length() < max_w * 2) {
             pp.erase(pp.begin() + i);
             --i;
-            removed = true;
             continue;
         }
 

--- a/xs/src/libslic3r/Fill/FillPlanePath.cpp
+++ b/xs/src/libslic3r/Fill/FillPlanePath.cpp
@@ -139,14 +139,11 @@ static inline Point hilbert_n_to_xy(const size_t n)
         }
     }
     int state    = (ndigits & 1) ? 4 : 0;
-    int dirstate = (ndigits & 1) ? 0 : 4;
     coord_t x = 0;
     coord_t y = 0;
     for (int i = (int)ndigits - 1; i >= 0; -- i) {
         int digit = (n >> (i * 2)) & 3;
         state += digit;
-        if (digit != 3)
-            dirstate = state; // lowest non-3 digit
         x |= digit_to_x[state] << i;
         y |= digit_to_y[state] << i;
         state = next_state[state];

--- a/xs/src/libslic3r/IO/AMF.cpp
+++ b/xs/src/libslic3r/IO/AMF.cpp
@@ -543,7 +543,7 @@ AMF::write(const Model& model, std::string output_file)
             volume->mesh.require_shared_vertices();
             vertices_offsets.push_back(num_vertices);
             const auto &stl = volume->mesh.stl;
-            for (size_t i = 0; i < stl.stats.shared_vertices; ++i)
+            for (size_t i = 0; i < static_cast<size_t>(stl.stats.shared_vertices); ++i)
                 // Subtract origin_translation in order to restore the coordinates of the parts
                 // before they were imported. Otherwise, when this AMF file is reimported parts
                 // will be placed in the plater correctly, but we will have lost origin_translation

--- a/xs/src/libslic3r/SurfaceCollection.cpp
+++ b/xs/src/libslic3r/SurfaceCollection.cpp
@@ -213,7 +213,7 @@ SurfaceCollection::keep_types(const SurfaceType *types, size_t ntypes)
     size_t j = 0;
     for (size_t i = 0; i < surfaces.size(); ++ i) {
         bool keep = false;
-        for (int k = 0; k < ntypes; ++ k) {
+        for (size_t k = 0; k < ntypes; ++ k) {
             if (surfaces[i].surface_type == types[k]) {
                 keep = true;
                 break;


### PR DESCRIPTION
- Removed un-used variables.
- Fixed some comparisons with signed / unsigned variables

There are still warnings but solving them would require to change `PrintConfig` (derives from`GCodeConfig`) and I'm not familiar with the code base so I didn't try anything.