### PR TITLE
Allow for flattening with and without sort.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -315,6 +315,7 @@ set(SLIC3R_TEST_SOURCES
     ${TESTDIR}/libslic3r/test_skirt_brim.cpp
     ${TESTDIR}/libslic3r/test_test_data.cpp
     ${TESTDIR}/libslic3r/test_trianglemesh.cpp
+    ${TESTDIR}/libslic3r/test_extrusion_entity.cpp
     ${TESTDIR}/libslic3r/test_3mf.cpp
 )
 

--- a/src/test/libslic3r/test_extrusion_entity.cpp
+++ b/src/test/libslic3r/test_extrusion_entity.cpp
@@ -2,6 +2,7 @@
 #include "ExtrusionEntityCollection.hpp"
 #include "ExtrusionEntity.hpp"
 #include "Point.hpp"
+#include <cstdlib>
 
 Point random_point(float LO=-50, float HI=50) {
     float x = LO + static_cast <float> (rand()) /( static_cast <float> (RAND_MAX/(HI-LO)));
@@ -28,6 +29,9 @@ ExtrusionPaths random_paths(size_t count=10, size_t length=20, float LO=-50, flo
 using namespace Slic3r;
 
 SCENARIO("ExtrusionEntityCollection: Polygon flattening") {
+    srand(0xDEADBEEF); // consistent seed for test reproducibility.
+
+    // Generate one specific random path set and save it for later comparison
     ExtrusionPaths nosort_path_set {random_paths()};
 
     ExtrusionEntityCollection sub_nosort;

--- a/src/test/libslic3r/test_extrusion_entity.cpp
+++ b/src/test/libslic3r/test_extrusion_entity.cpp
@@ -1,0 +1,75 @@
+#include <catch.hpp>
+#include "ExtrusionEntityCollection.hpp"
+#include "ExtrusionEntity.hpp"
+#include "Point.hpp"
+
+Point random_point(float LO=-50, float HI=50) {
+    float x = LO + static_cast <float> (rand()) /( static_cast <float> (RAND_MAX/(HI-LO)));
+    float y = LO + static_cast <float> (rand()) /( static_cast <float> (RAND_MAX/(HI-LO)));
+    return Point(x, y);
+}
+
+// build a sample extrusion entity collection with random start and end points.
+ExtrusionPath random_path(size_t length = 20, float LO=-50, float HI=50) {
+    ExtrusionPath t {erPerimeter, 1.0, 1.0, 1.0};
+    for (size_t j = 0; j < length; j++) {
+        t.polyline.append(random_point(LO, HI));
+    }
+    return t;
+}
+
+ExtrusionPaths random_paths(size_t count=10, size_t length=20, float LO=-50, float HI=50) {
+    ExtrusionPaths p;
+    for (size_t i = 0; i < count; i++)
+        p.push_back(random_path(length, LO, HI));
+    return p;
+}
+
+using namespace Slic3r;
+
+SCENARIO("ExtrusionEntityCollection: Polygon flattening") {
+    ExtrusionPaths nosort_path_set {random_paths()};
+
+    ExtrusionEntityCollection sub_nosort;
+    sub_nosort.append(nosort_path_set);
+    sub_nosort.no_sort = true;
+
+    ExtrusionEntityCollection sub_sort;
+    sub_sort.no_sort = false;
+    sub_sort.append(random_paths());
+
+
+    GIVEN("A Extrusion Entity Collection with a child that has one child that is marked as no-sort") {
+        ExtrusionEntityCollection sample;
+        ExtrusionEntityCollection output;
+
+        sample.append(sub_sort);
+        sample.append(sub_nosort);
+        sample.append(sub_sort);
+        WHEN("The EEC is flattened with default options (preserve_order=false)") {
+            sample.flatten(&output);
+            THEN("The output EEC contains no Extrusion Entity Collections") {
+                CHECK(std::count_if(output.entities.cbegin(), output.entities.cend(), [=](const ExtrusionEntity* e) {return e->is_collection();}) == 0);
+            }
+        }
+        WHEN("The EEC is flattened with preservation (preserve_order=true)") {
+            sample.flatten(&output, true);
+            THEN("The output EECs contains one EEC.") {
+                CHECK(std::count_if(output.entities.cbegin(), output.entities.cend(), [=](const ExtrusionEntity* e) {return e->is_collection();}) == 1);
+            }
+            AND_THEN("The ordered EEC contains the same order of elements than the original") {
+                // find the entity in the collection
+                for (auto e : output.entities) {
+                    if (!e->is_collection()) continue;
+                    ExtrusionEntityCollection* temp = dynamic_cast<ExtrusionEntityCollection*>(e);
+                    // check each Extrusion path against nosort_path_set to see if the first and last match the same
+                    CHECK(nosort_path_set.size() == temp->size());
+                    for (size_t i = 0; i < nosort_path_set.size(); i++) {
+                        CHECK(temp->entities[i]->first_point() == nosort_path_set[i].first_point());
+                        CHECK(temp->entities[i]->last_point() == nosort_path_set[i].last_point());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/xs/src/libslic3r/ExtrusionEntityCollection.hpp
+++ b/xs/src/libslic3r/ExtrusionEntityCollection.hpp
@@ -24,7 +24,7 @@ class ExtrusionEntityCollection : public ExtrusionEntity
     ExtrusionEntityCollection& operator= (const ExtrusionEntityCollection &other);
     ~ExtrusionEntityCollection();
 
-    /// Operator to convert and flatten this collection to a single vefctor of ExtrusionPaths.
+    /// Operator to convert and flatten this collection to a single vector of ExtrusionPaths.
     operator ExtrusionPaths() const;
    
     /// This particular ExtrusionEntity is a collection.
@@ -59,11 +59,14 @@ class ExtrusionEntityCollection : public ExtrusionEntity
     size_t items_count() const;
 
     /// Returns a single vector of pointers to all non-collection items contained in this one
-    void flatten(ExtrusionEntityCollection* retval) const;
+    /// \param retval a pointer to the output memory space.
+    /// \param preserve_ordering Flag to method that will flatten if and only if the underlying collection is sortable when True (default: False).
+    void flatten(ExtrusionEntityCollection* retval, bool preserve_ordering = false) const;
 
     /// Returns a flattened copy of this ExtrusionEntityCollection. That is, all of the items in its entities vector are not collections.
     /// You should be iterating over flatten().entities if you are interested in the underlying ExtrusionEntities (and don't care about hierarchy).
-    ExtrusionEntityCollection flatten() const;
+    /// \param preserve_ordering Flag to method that will flatten if and only if the underlying collection is sortable when True (default: False).
+    ExtrusionEntityCollection flatten(bool preserve_ordering = false) const;
 
 
     double min_mm3_per_mm() const;

--- a/xs/src/libslic3r/PrintGCode.cpp
+++ b/xs/src/libslic3r/PrintGCode.cpp
@@ -665,7 +665,7 @@ PrintGCode::process_layer(size_t idx, const Layer* layer, const Points& copies)
             // the ExtrusionPath objects of a certain infill "group" (also called "surface"
             // throughout the code). We can redefine the order of such Collections but we have to
             // do each one completely at once.
-            for(auto* fill : layerm->fills.flatten().entities) {
+            for(auto* fill : layerm->fills.flatten(true).entities) {
                 if(fill->length() == 0) continue;  // this shouldn't happen but first_point() would fail
 
                 auto extruder_id = fill->is_solid_infill()


### PR DESCRIPTION
Responding to comments in 6710b24 by @bubnikv and incorporating suggested changes made by @supermerill from #4553 as a single function with a flag instead of two methods.