### PR TITLE
Don't disable bridge_speed in GUI when no infill configured.

### DIFF
--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -919,7 +919,7 @@ sub _update {
 
     if (any { /$opt_key/ } qw(all_keys top_solid_layers bottom_solid_layers fill_density)) {
         $self->get_field($_)->toggle($have_infill || $have_solid_infill)
-            for qw(fill_angle infill_extrusion_width infill_speed bridge_speed);
+            for qw(fill_angle infill_extrusion_width infill_speed);
     }
 
     if (any { /$opt_key/ } qw(all_keys fill_density perimeters)) {


### PR DESCRIPTION
Bridge speed is still used when overhang perimeters are present, which means that it cannot be disabled if there is no infill. 
Fixes #4842