### PR TITLE
Display approx. print-time in hours

### DIFF
--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -2289,8 +2289,9 @@ sub on_export_completed {
         $estimator->parse_file($self->{export_gcode_output_file});
         my $time = $estimator->time;
         $self->{print_info_tim}->SetLabel(sprintf(
-            "%d minutes and %d seconds",
-            int($time / 60),
+            "%d hours, %d minutes and %d seconds",
+            int($time / 3600),
+            int(($time % 3600) / 60),
             int($time % 60),
         ));
     }


### PR DESCRIPTION
Display the approximate print time of the sliced object(s) in
“hour, minutes and seconds” instead of “minutes and seconds”.