### PR TITLE
Change [layer_num] to use layer.id()

### DIFF
--- a/src/test/libslic3r/test_printgcode.cpp
+++ b/src/test/libslic3r/test_printgcode.cpp
@@ -225,6 +225,25 @@ SCENARIO( "PrintGCode basic functionality") {
             }
         }
 
+        WHEN("layer_num represents the layer's index from z=0") {
+            config->set("layer_gcode", ";Layer:[layer_num] ([layer_z] mm)");
+            config->set("layer_height", 1.0);
+            config->set("first_layer_height", 1.0);
+
+            Slic3r::Model model;
+            auto print {Slic3r::Test::init_print({TestMesh::cube_20x20x20,TestMesh::cube_20x20x20}, model, config)};
+            Slic3r::Test::gcode(gcode, print);
+
+            auto exported {gcode.str()};
+            int count = 2;            
+            for(int pos = 0; pos != std::string::npos; count--) 
+                pos = exported.find(";Layer:38 (20 mm)", pos+1);
+
+            THEN("layer_num and layer_z are processed in the end gcode") {\
+                REQUIRE(count == -1);
+            }
+        }
+
         gcode.clear();
     }
 }

--- a/xs/src/libslic3r/PrintGCode.cpp
+++ b/xs/src/libslic3r/PrintGCode.cpp
@@ -477,7 +477,7 @@ PrintGCode::process_layer(size_t idx, const Layer* layer, const Points& copies)
     // set new layer - this will change Z and force a retraction if retract_layer_change is enabled
     if (_print.config.before_layer_gcode.getString().size() > 0) {
         PlaceholderParser pp { *_gcodegen.placeholder_parser };
-        pp.set("layer_num", _gcodegen.layer_index);
+        pp.set("layer_num", layer->id());
         pp.set("layer_z", layer->print_z);
         pp.set("current_retraction", _gcodegen.writer.extruder()->retracted);
 
@@ -487,7 +487,7 @@ PrintGCode::process_layer(size_t idx, const Layer* layer, const Points& copies)
     gcode += _gcodegen.change_layer(*layer);
     if (_print.config.layer_gcode.getString().size() > 0) {
         PlaceholderParser pp { *_gcodegen.placeholder_parser };
-        pp.set("layer_num", _gcodegen.layer_index);
+        pp.set("layer_num", layer->id());
         pp.set("layer_z", layer->print_z);
         pp.set("current_retraction", _gcodegen.writer.extruder()->retracted);
 


### PR DESCRIPTION
Fix for #4830.  

Tested by compiling the C++ binary and running:
`slic3r --gcode --load config.ini -m --dont-arrange <first stl> <second stl>`
where _config.ini_ contains 
`layer_gcode = ;Layer:[layer_num] ([layer_z] mm)`

When examining the output gcode, the _layer_num_ value will increase with layer_z.  