### PR TITLE
Fix misc. typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,7 @@ When possible, please include the following information when [reporting an issue
     * STL, OBJ or AMF input file (please make sure the input file is not broken, e.g. non-manifold, before reporting a bug)
     * a screenshot of the G-code layer with the issue (e.g. using [Pronterface](https://github.com/kliment/Printrun) or preferably the internal preview tab in Slic3r).
 * If the issue is a request for a new feature, be ready to explain why you think it's needed.
-    * Doing more prepatory work on your end makes it more likely it'll get done. This includes the "how" it can be done in addition to the "what". 
+    * Doing more preparatory work on your end makes it more likely it'll get done. This includes the "how" it can be done in addition to the "what". 
     * Define the "What" as strictly as you can. Consider what might happen with different infills than simple rectilinear.
 
 Please make sure only to include one issue per report. If you encounter multiple, unrelated issues, please report them as such.

--- a/lib/Slic3r/GCode/MotionPlanner.pm
+++ b/lib/Slic3r/GCode/MotionPlanner.pm
@@ -14,7 +14,7 @@ use Slic3r::Geometry::Clipper qw(offset offset_ex diff_ex intersection_pl);
 has '_inner_margin' => (is => 'ro', default => sub { scale 1 });
 has '_outer_margin' => (is => 'ro', default => sub { scale 2 });
 
-# this factor weigths the crossing of a perimeter 
+# this factor weighs the crossing of a perimeter 
 # vs. the alternative path. a value of 5 means that
 # a perimeter will be crossed if the alternative path
 # is >= 5x the length of the straight line we could

--- a/lib/Slic3r/GCode/PressureRegulator.pm
+++ b/lib/Slic3r/GCode/PressureRegulator.pm
@@ -39,7 +39,7 @@ sub process {
             # This is a print move.
             my $F = $args->{F} // $reader->F;
             if ($F != $self->_last_print_F || ($F == $self->_last_print_F && $self->_advance == 0)) {
-                # We are setting a (potentially) new speed or a discharge event happend since the last speed change, so we calculate the new advance amount.
+                # We are setting a (potentially) new speed or a discharge event happened since the last speed change, so we calculate the new advance amount.
             
                 # First calculate relative flow rate (mm of filament over mm of travel)
                 my $rel_flow_rate = $info->{dist_E} / $info->{dist_XY};

--- a/lib/Slic3r/GUI/3DScene.pm
+++ b/lib/Slic3r/GUI/3DScene.pm
@@ -96,14 +96,14 @@ sub new {
     # wxWidgets expect the attrib list to be ended by zero.
     push(@$attrib, 0);
 
-    # we request a depth buffer explicitely because it looks like it's not created by 
+    # we request a depth buffer explicitly because it looks like it's not created by 
     # default on Linux, causing transparency issues
     my $self = $class->SUPER::new($parent, -1, Wx::wxDefaultPosition, Wx::wxDefaultSize, 0, "", $attrib);
 
     if (Wx::wxVERSION >= 3.000003) {
         # Wx 3.0.3 contains an ugly hack to support some advanced OpenGL attributes through the attribute list.
         # The attribute list is transferred between the wxGLCanvas and wxGLContext constructors using a single static array s_wglContextAttribs.
-        # Immediatelly force creation of the OpenGL context to consume the static variable s_wglContextAttribs.
+        # Immediately force creation of the OpenGL context to consume the static variable s_wglContextAttribs.
         $self->GetContext();
     }
 

--- a/lib/Slic3r/GUI/BedShapeDialog.pm
+++ b/lib/Slic3r/GUI/BedShapeDialog.pm
@@ -1,5 +1,5 @@
 # The bed shape dialog.
-# The dialog opens from Print Settins tab -> Bed Shape: Set...
+# The dialog opens from Print Settings tab -> Bed Shape: Set...
 
 package Slic3r::GUI::BedShapeDialog;
 use strict;

--- a/lib/Slic3r/GUI/ColorScheme.pm
+++ b/lib/Slic3r/GUI/ColorScheme.pm
@@ -13,8 +13,8 @@ our $DEFAULT_COLORSCHEME   = 1;
 our $SOLID_BACKGROUNDCOLOR = 0;
 our @SELECTED_COLOR   = (0, 1, 0);
 our @HOVER_COLOR      = (0.4, 0.9, 0);           # Hover over Model
-our @TOP_COLOR        = (10/255,98/255,144/255); # TOP Backgroud color
-our @BOTTOM_COLOR     = (0,0,0);                 # BOTTOM Backgroud color
+our @TOP_COLOR        = (10/255,98/255,144/255); # TOP Background color
+our @BOTTOM_COLOR     = (0,0,0);                 # BOTTOM Background color
 our @BACKGROUND_COLOR = @TOP_COLOR;              # SOLID background color
 our @GRID_COLOR       = (0.2, 0.2, 0.2, 0.4);    # Grid color
 our @GROUND_COLOR     = (0.8, 0.6, 0.5, 0.4);    # Ground or Plate color
@@ -130,7 +130,7 @@ sub getSolarized { # add this name to Preferences.pm
     @BED_SKIRT        = map { ceil($_ * 255) } @COLOR_BASE01;     # Brim/Skirt
     @BED_CLEARANCE    = map { ceil($_ * 255) } @COLOR_BLUE;       # not sure what that does
     @BED_DARK         = map { ceil($_ * 255) } @COLOR_BASE01;     # not sure what that does
-    @BACKGROUND255    = map { ceil($_ * 255) } @BACKGROUND_COLOR; # Backgroud color, this time RGB
+    @BACKGROUND255    = map { ceil($_ * 255) } @BACKGROUND_COLOR; # Background color, this time RGB
     
     # 2DToolpaths.pm colors : LAYERS Tab
     @TOOL_DARK        = @COLOR_BASE01;  # Brim/Skirt

--- a/lib/Slic3r/GUI/Plater.pm
+++ b/lib/Slic3r/GUI/Plater.pm
@@ -1500,7 +1500,7 @@ sub reset {
     my $current_model = $self->{model}->clone;
 
     if (!defined $dont_push) {
-        # Get the identifiers of the curent model objects.
+        # Get the identifiers of the current model objects.
         my $objects_identifiers = [];
         for (my $i = 0; $i <= $#{$self->{objects}}; $i++){
             push @{$objects_identifiers}, $self->{objects}->[$i]->identifier;
@@ -1929,7 +1929,7 @@ sub split_object {
     
     $self->pause_background_process;
 
-    # Save the curent model object for undo/redo operataions.
+    # Save the current model object for undo/redo operataions.
     my $org_object_model = Slic3r::Model->new;
     $org_object_model->add_object($current_model_object);
 
@@ -1955,7 +1955,7 @@ sub split_object {
     # remove the original object before spawning the object_loaded event, otherwise 
     # we'll pass the wrong $obj_idx to it (which won't be recognized after the
     # thumbnail thread returns)
-    $self->remove($obj_idx, 'true'); # Don't push to the undo stack it's considered a split opeation not a remove one.
+    $self->remove($obj_idx, 'true'); # Don't push to the undo stack it's considered a split operation not a remove one.
     $current_object = $obj_idx = undef;
 
     # Save the object identifiers used in undo/redo operations.

--- a/lib/Slic3r/GUI/Plater/2DToolpaths.pm
+++ b/lib/Slic3r/GUI/Plater/2DToolpaths.pm
@@ -172,7 +172,7 @@ sub new {
         $class->SUPER::new($parent, -1, Wx::wxDefaultPosition, Wx::wxDefaultSize, 0, "",
             [WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 24, 0]) :
         $class->SUPER::new($parent);
-    # Immediatelly force creation of the OpenGL context to consume the static variable s_wglContextAttribs.
+    # Immediately force creation of the OpenGL context to consume the static variable s_wglContextAttribs.
     $self->GetContext();
     $self->print($print);
     $self->_zoom(1);
@@ -356,7 +356,7 @@ sub Render {
     
     my $tess;
     if (!(&Wx::wxMSW && $OpenGL::VERSION < 0.6704)) {
-        # We can't use the GLU tesselator on MSW with older OpenGL versions
+        # We can't use the GLU tessellator on MSW with older OpenGL versions
         # because of an upstream bug:
         # http://sourceforge.net/p/pogl/bugs/16/
         $tess = gluNewTess();

--- a/package/linux/make_archive.sh
+++ b/package/linux/make_archive.sh
@@ -43,7 +43,7 @@ fi
 rm -rf $WD/_tmp
 mkdir -p $WD/_tmp
 
-# Set  the application folder infomation.
+# Set the application folder information.
 appfolder="$WD/${appname}"
 archivefolder=$appfolder
 resourcefolder=$appfolder

--- a/src/GUI/ColorScheme/Default.hpp
+++ b/src/GUI/ColorScheme/Default.hpp
@@ -9,8 +9,8 @@ public:
     const bool SOLID_BACKGROUNDCOLOR() const { return false; };
     const wxColour SELECTED_COLOR() const { return wxColour(0, 255, 0); };
     const wxColour HOVER_COLOR() const { return wxColour(255*0.4, 255*0.9, 0); };            //<Hover over Model
-    const wxColour TOP_COLOR() const { return wxColour(10,98,144); };    //<TOP Backgroud color
-    const wxColour BOTTOM_COLOR() const { return wxColour(0,0,0); };                 //<BOTTOM Backgroud color
+    const wxColour TOP_COLOR() const { return wxColour(10,98,144); };    //<TOP Background color
+    const wxColour BOTTOM_COLOR() const { return wxColour(0,0,0); };                 //<BOTTOM Background color
     const wxColour BACKGROUND_COLOR() const {return TOP_COLOR();}                      //< SOLID background color
     const wxColour GRID_COLOR() const { return wxColour(255*0.2, 255*0.2, 255*0.2, 255*0.4); };      //<Grid color
     const wxColour GROUND_COLOR() const { return wxColour(255*0.8, 255*0.6, 255*0.5, 255*0.4); };    //<Ground or Plate color

--- a/src/GUI/MainFrame.hpp
+++ b/src/GUI/MainFrame.hpp
@@ -39,7 +39,7 @@ public:
 private:
     wxDECLARE_EVENT_TABLE();
 
-    void init_menubar(); //< Routine to intialize all top-level menu items.
+    void init_menubar(); //< Routine to initialize all top-level menu items.
     void init_tabpanel(); //< Routine to initialize all of the tabs.
 
     bool loaded; //< Main frame itself has finished loading.

--- a/src/GUI/Plater/Plate2D.cpp
+++ b/src/GUI/Plater/Plate2D.cpp
@@ -262,7 +262,7 @@ void Plate2D::mouse_up(wxMouseEvent& e) {
         try {
             if (this->drag_object.obj != -1 && this->drag_object.inst != -1) this->on_instances_moved();
         } catch (std::bad_function_call &ex) {
-            Slic3r::Log::error(LogChannel, L"On_instances_moved was not intialized to a function.");
+            Slic3r::Log::error(LogChannel, L"On_instances_moved was not initialized to a function.");
         }
         this->drag_start_pos = wxPoint(-1, -1);
         this->drag_object = {-1, -1};

--- a/src/GUI/Plater/Plate3D.hpp
+++ b/src/GUI/Plater/Plate3D.hpp
@@ -28,7 +28,7 @@ public:
     void selection_changed(){Refresh();}
  protected:
     // Render each volume as a different color and check what color is beneath
-    // the mouse to detemine the hovered volume
+    // the mouse to determine the hovered volume
     void before_render();
 
     // Mouse events are needed to handle selecting and moving objects

--- a/src/GUI/Plater/Preview3D.cpp
+++ b/src/GUI/Plater/Preview3D.cpp
@@ -96,7 +96,7 @@ void Preview3D::load_print() {
         std::sort(layers_z.begin(),layers_z.end());
         slider->SetRange(0, layers_z.size()-1);
         z_idx = slider->GetValue();
-        // If invalide z_idx,  move the slider to the top
+        // If invalid z_idx,  move the slider to the top
         if (z_idx >= layers_z.size() || slider->GetValue() == 0) {
             slider->SetValue(layers_z.size()-1);
             //$z_idx = @{$self->{layer_z}} ? -1 : undef;

--- a/src/GUI/Preset.hpp
+++ b/src/GUI/Preset.hpp
@@ -106,7 +106,7 @@ public:
 private:
 
     /// store to keep config options for this preset
-    /// This is intented to be a "pristine" copy from the underlying
+    /// This is intended to be a "pristine" copy from the underlying
     /// file store.
     config_ptr  _config { nullptr };
 

--- a/src/test/libslic3r/test_config.cpp
+++ b/src/test/libslic3r/test_config.cpp
@@ -104,7 +104,7 @@ SCENARIO("Config accessor functions perform as expected.") {
             }
         }
         WHEN("A numeric option is set to a non-numeric value.") {
-            THEN("A BadOptionTypeException exception is thown.") {
+            THEN("A BadOptionTypeException exception is thrown.") {
                 REQUIRE_THROWS_AS(config->set("perimeter_speed", "zzzz"), BadOptionTypeException);
             }
             THEN("The value does not change.") {

--- a/src/test/libslic3r/test_geometry.cpp
+++ b/src/test/libslic3r/test_geometry.cpp
@@ -154,7 +154,7 @@ TEST_CASE("Bounding boxes are scaled appropriately"){
 }
 
 
-TEST_CASE("Offseting a line generates a polygon correctly"){
+TEST_CASE("Offsetting a line generates a polygon correctly"){
     auto line = Line(Point(10,10), Point(20,10));
     Polyline tmp(line);
     Polygon area = offset(tmp,5).at(0);

--- a/src/test/test_data.hpp
+++ b/src/test/test_data.hpp
@@ -36,7 +36,7 @@ enum class TestMesh {
     two_hollow_squares
 };
 
-// Neccessary for <c++17
+// Necessary for <c++17
 struct TestMeshHash {
     std::size_t operator()(TestMesh tm) const {
         return static_cast<std::size_t>(tm);

--- a/utils/zsh/functions/_slic3r
+++ b/utils/zsh/functions/_slic3r
@@ -72,7 +72,7 @@ _arguments -S \
     \
     '--retract-length[specify filament retraction length when pausing extrusion]:filament retraction length in mm' \
     '--retract-speed[specify filament retraction speed]:filament retraction speed in mm/s' \
-    '--retract-restart-extra[specify filament length to extrude for compensating retraction]: filament lenght in mm' \
+    '--retract-restart-extra[specify filament length to extrude for compensating retraction]: filament length in mm' \
     '--retract-before-travel[specify minimum travel length for activating retraction]:minimum travel length for activating retraction in mm' \
     '--retract-lift[specify Z-axis lift for use when retracting]:Z-axis lift in mm' \
     \

--- a/xs/src/BSpline/BSpline.h
+++ b/xs/src/BSpline/BSpline.h
@@ -138,7 +138,7 @@ template <class T> struct BSplineBaseP;
  * own instantiation.
  *
  * The algorithm is based on the cubic spline described by Katsuyuki Ooyama
- * in Montly Weather Review, Vol 115, October 1987.  This implementation
+ * in Monthly Weather Review, Vol 115, October 1987.  This implementation
  * has benefited from comparisons with a previous FORTRAN implementation by
  * James L. Franklin, NOAA/Hurricane Research Division.  In particular, the
  * algorithm in the Setup() method is based mostly on his implementation

--- a/xs/src/admesh/normals.c
+++ b/xs/src/admesh/normals.c
@@ -157,7 +157,7 @@ stl_fix_normal_directions(stl_file *stl) {
     /* Get next facet to fix from top of list. */
     if(head->next != tail) {
       facet_num = head->next->facet_num;
-      if(norm_sw[facet_num] != 1) { /* If facet is in list mutiple times */
+      if(norm_sw[facet_num] != 1) { /* If facet is in list multiple times */
         norm_sw[facet_num] = 1; /* Record this one as being fixed. */
         checked++;
       }

--- a/xs/src/admesh/stlinit.c
+++ b/xs/src/admesh/stlinit.c
@@ -211,7 +211,7 @@ stl_open_merge(stl_file *stl, ADMESH_CHAR *file_to_merge) {
   /* Record the file pointer too: */
   origFp=stl->fp;
 
-  /* Initialize the sturucture with zero stats, header info and sizes: */
+  /* Initialize the structure with zero stats, header info and sizes: */
   stl_initialize(&stl_to_merge);
   stl_count_facets(&stl_to_merge, file_to_merge);
 

--- a/xs/src/boost/nowide/args.hpp
+++ b/xs/src/boost/nowide/args.hpp
@@ -43,7 +43,7 @@ namespace nowide {
     public:
         
         ///
-        /// Fix command line agruments 
+        /// Fix command line arguments 
         ///
         args(int &argc,char **&argv) :
             old_argc_(argc),
@@ -56,7 +56,7 @@ namespace nowide {
             fix_args(argc,argv);
         }
         ///
-        /// Fix command line agruments and environment
+        /// Fix command line arguments and environment
         ///
         args(int &argc,char **&argv,char **&en) :
             old_argc_(argc),

--- a/xs/src/boost/nowide/cenv.hpp
+++ b/xs/src/boost/nowide/cenv.hpp
@@ -62,7 +62,7 @@ namespace nowide {
     ///
     /// \brief  UTF-8 aware setenv, \a key - the variable name, \a value is a new UTF-8 value,
     /// 
-    /// if override is not 0, that the old value is always overridded, otherwise,
+    /// if override is not 0, that the old value is always overridden, otherwise,
     /// if the variable exists it remains unchanged
     ///
     inline int setenv(char const *key,char const *value,int override)
@@ -83,7 +83,7 @@ namespace nowide {
         return -1;
     }
     ///
-    /// \brief Remove enviroment variable \a key
+    /// \brief Remove environment variable \a key
     ///
     inline int unsetenv(char const *key)
     {

--- a/xs/src/boost/nowide/filebuf.hpp
+++ b/xs/src/boost/nowide/filebuf.hpp
@@ -396,7 +396,7 @@ namespace nowide {
     };
     
     ///
-    /// \brief Convinience typedef
+    /// \brief Convenience typedef
     ///
     typedef basic_filebuf<char> filebuf;
     

--- a/xs/src/boost/nowide/fstream.hpp
+++ b/xs/src/boost/nowide/fstream.hpp
@@ -18,7 +18,7 @@
 
 namespace boost {
 ///
-/// \brief This namespace includes implementation of the standard library functios
+/// \brief This namespace includes implementation of the standard library functions
 /// such that they accept UTF-8 strings on Windows. On other platforms it is just an alias
 /// of std namespace (i.e. not on Windows)
 ///

--- a/xs/src/boost/nowide/integration/filesystem.hpp
+++ b/xs/src/boost/nowide/integration/filesystem.hpp
@@ -13,7 +13,7 @@
 namespace boost {
     namespace nowide {
         ///
-        /// Instal utf8_codecvt facet into  boost::filesystem::path such all char strings are interpreted as utf-8 strings
+        /// Install utf8_codecvt facet into  boost::filesystem::path such all char strings are interpreted as utf-8 strings
         ///
         inline void nowide_filesystem()
         {

--- a/xs/src/boost/nowide/stackstring.hpp
+++ b/xs/src/boost/nowide/stackstring.hpp
@@ -129,19 +129,19 @@ private:
 };  //basic_stackstring
 
 ///
-/// Convinience typedef
+/// Convenience typedef
 ///
 typedef basic_stackstring<wchar_t,char,256> wstackstring;
 ///
-/// Convinience typedef
+/// Convenience typedef
 ///
 typedef basic_stackstring<char,wchar_t,256> stackstring;
 ///
-/// Convinience typedef
+/// Convenience typedef
 ///
 typedef basic_stackstring<wchar_t,char,16> wshort_stackstring;
 ///
-/// Convinience typedef
+/// Convenience typedef
 ///
 typedef basic_stackstring<char,wchar_t,16> short_stackstring;
 

--- a/xs/src/boost/nowide/utf8_codecvt.hpp
+++ b/xs/src/boost/nowide/utf8_codecvt.hpp
@@ -145,14 +145,14 @@ protected:
                 r=std::codecvt_base::partial;
                 break;
             }
-            // Normal codepoints go direcly to stream
+            // Normal codepoints go directly to stream
             if(ch <= 0xFFFF) {
                 *to++=ch;
             }
             else {
                 // for  other codepoints we do following
                 //
-                // 1. We can't consume our input as we may find ourselfs
+                // 1. We can't consume our input as we may find ourselves
                 //    in state where all input consumed but not all output written,i.e. only
                 //    1st pair is written
                 // 2. We only write first pair and mark this in the state, we also revert back

--- a/xs/src/clipper.hpp
+++ b/xs/src/clipper.hpp
@@ -40,7 +40,7 @@
 //improve performance but coordinate values are limited to the range +/- 46340
 //#define use_int32
 
-//use_xyz: adds a Z member to IntPoint. Adds a minor cost to perfomance.
+//use_xyz: adds a Z member to IntPoint. Adds a minor cost to performance.
 //#define use_xyz
 
 //use_lines: Enables line clipping. Adds a very minor cost to performance.

--- a/xs/src/expat/expat.h
+++ b/xs/src/expat/expat.h
@@ -235,7 +235,7 @@ XML_ParserCreate_MM(const XML_Char *encoding,
                     const XML_Char *namespaceSeparator);
 
 /* Prepare a parser object to be re-used.  This is particularly
-   valuable when memory allocation overhead is disproportionatly high,
+   valuable when memory allocation overhead is disproportionately high,
    such as when a large number of small documnents need to be parsed.
    All handlers are cleared from the parser, except for the
    unknownEncodingHandler. The parser's external state is re-initialized

--- a/xs/src/exprtk/exprtk.hpp
+++ b/xs/src/exprtk/exprtk.hpp
@@ -10994,7 +10994,7 @@ namespace exprtk
       {
       public:
 
-         // Function of N paramters.
+         // Function of N parameters.
          typedef expression_node<T>* expression_ptr;
          typedef std::pair<expression_ptr,bool> branch_t;
          typedef IFunction ifunction;
@@ -20106,7 +20106,7 @@ namespace exprtk
          if (index < error_list_.size())
             return error_list_[index];
          else
-            throw std::invalid_argument("parser::get_error() - Invalid error index specificed");
+            throw std::invalid_argument("parser::get_error() - Invalid error index specified");
       }
 
       inline std::string error() const

--- a/xs/src/libslic3r/BridgeDetector.cpp
+++ b/xs/src/libslic3r/BridgeDetector.cpp
@@ -10,7 +10,7 @@ BridgeDetector::BridgeDetector(const ExPolygon &_expolygon, const ExPolygonColle
     : expolygon(_expolygon), extrusion_width(_extrusion_width),
         resolution(PI/36.0), angle(-1)
 {
-    /*  outset our bridge by an arbitrary amout; we'll use this outer margin
+    /*  outset our bridge by an arbitrary amount; we'll use this outer margin
         for detecting anchors */
     Polygons grown = offset(this->expolygon, this->extrusion_width);
     
@@ -163,7 +163,7 @@ BridgeDetector::detect_angle()
     std::sort(candidates.begin(), candidates.end());
     
     // if any other direction is within extrusion width of coverage, prefer it if shorter
-    // TODO: There are two options here - within width of the angle with most coverage, or within width of the currently perferred?
+    // TODO: There are two options here - within width of the angle with most coverage, or within width of the currently preferred?
     size_t i_best = 0;
     for (size_t i = 1; i < candidates.size() && candidates[i_best].coverage - candidates[i].coverage < this->extrusion_width; ++ i)
         if (candidates[i].max_length < candidates[i_best].max_length)

--- a/xs/src/libslic3r/ClipperUtils.cpp
+++ b/xs/src/libslic3r/ClipperUtils.cpp
@@ -299,7 +299,7 @@ _clipper_do(const ClipperLib::ClipType clipType, const Polygons &subject,
 // Namely, the function Clipper::JoinCommonEdges() has potentially a terrible time complexity if the output
 // of the operation is of the PolyTree type.
 // This function implements a following workaround:
-// 1) Peform the Clipper operation with the output to Paths. This method handles overlaps in a reasonable time.
+// 1) Perform the Clipper operation with the output to Paths. This method handles overlaps in a reasonable time.
 // 2) Run Clipper Union once again to extract the PolyTree from the result of 1).
 inline ClipperLib::PolyTree _clipper_do_polytree2(const ClipperLib::ClipType clipType, const Polygons &subject, 
     const Polygons &clip, const ClipperLib::PolyFillType fillType, const bool safety_offset_)

--- a/xs/src/libslic3r/ConfigBase.hpp
+++ b/xs/src/libslic3r/ConfigBase.hpp
@@ -792,7 +792,7 @@ class ConfigBase
     /// @param other configuration store to apply from
     /// @param opt_keys Vector of string keys to apply one to the other
     /// @param ignore_nonexistant if true, don't throw an exception if the key is not known to Slic3r
-    /// @default nonexistant Set the configuration option to its default if it is not found in other.
+    /// @default nonexistent Set the configuration option to its default if it is not found in other.
     void apply_only(const ConfigBase &other, const t_config_option_keys &opt_keys, bool ignore_nonexistent = false, bool default_nonexistent = false);
     bool equals(const ConfigBase &other) const;
     t_config_option_keys diff(const ConfigBase &other) const;

--- a/xs/src/libslic3r/ExPolygon.cpp
+++ b/xs/src/libslic3r/ExPolygon.cpp
@@ -273,7 +273,7 @@ ExPolygon::medial_axis(const ExPolygon &bounds, double max_width, double min_wid
                 //assert polyline.size == best_candidate->size (see selection loop, an 'if' takes care of that)
 
                 //iterate the points
-                // as voronoi should create symetric thing, we can iterate synchonously
+                // as voronoi should create symmetric thing, we can iterate synchonously
                 unsigned int idx_point = 1;
                 while (idx_point < polyline.points.size() && polyline.points[idx_point].distance_to(best_candidate->points[idx_point]) < max_width) {
                     //fusion

--- a/xs/src/libslic3r/ExPolygon.hpp
+++ b/xs/src/libslic3r/ExPolygon.hpp
@@ -57,7 +57,7 @@ class ExPolygon
     std::string dump_perl() const;
 };
 
-// Count a nuber of polygons stored inside the vector of expolygons.
+// Count a number of polygons stored inside the vector of expolygons.
 // Useful for allocating space for polygons when converting expolygons to polygons.
 inline size_t number_polygons(const ExPolygons &expolys)
 {

--- a/xs/src/libslic3r/Fill/Fill.hpp
+++ b/xs/src/libslic3r/Fill/Fill.hpp
@@ -35,7 +35,7 @@ public:
     /// in radians, ccw, 0 = East
     float       angle;
     
-    /// In scaled coordinates. Maximum lenght of a perimeter segment connecting two infill lines.
+    /// In scaled coordinates. Maximum length of a perimeter segment connecting two infill lines.
     /// Used by the FillRectilinear2, FillGrid2, FillTriangles, FillStars and FillCubic.
     /// If left to zero, the links will not be limited.
     coord_t     link_max_length;

--- a/xs/src/libslic3r/Fill/Fill3DHoneycomb.cpp
+++ b/xs/src/libslic3r/Fill/Fill3DHoneycomb.cpp
@@ -9,7 +9,7 @@ namespace Slic3r {
 /*
 Creates a contiguous sequence of points at a specified height that make
 up a horizontal slice of the edges of a space filling truncated
-octahedron tesselation. The octahedrons are oriented so that the
+octahedron tessellation. The octahedrons are oriented so that the
 square faces are in the horizontal plane with edges parallel to the X
 and Y axes.
 

--- a/xs/src/libslic3r/GCode.cpp
+++ b/xs/src/libslic3r/GCode.cpp
@@ -613,7 +613,7 @@ GCode::_extrude(ExtrusionPath path, std::string description, double speed)
 std::string
 GCode::travel_to(const Point &point, ExtrusionRole role, std::string comment)
 {    
-    /*  Define the travel move as a line between current position and the taget point.
+    /*  Define the travel move as a line between current position and the target point.
         This is expressed in print coordinates, so it will need to be translated by
         this->origin in order to get G-code coordinates.  */
     Polyline travel;

--- a/xs/src/libslic3r/IO/AMF.cpp
+++ b/xs/src/libslic3r/IO/AMF.cpp
@@ -125,7 +125,7 @@ struct AMFParserContext
     std::vector<AMFNodeType> m_path;
     // Current object allocated for an amf/object XML subtree.
     ModelObject             *m_object;
-    // Map from obect name to object idx & instances.
+    // Map from object name to object idx & instances.
     std::map<std::string, Object> m_object_instances_map;
     // Vertices parsed for the current m_object.
     std::vector<float>       m_object_vertices;

--- a/xs/src/libslic3r/Layer.cpp
+++ b/xs/src/libslic3r/Layer.cpp
@@ -267,7 +267,7 @@ Layer::make_fills()
 /// Initially all slices are of type S_TYPE_INTERNAL.
 /// Slices are compared against the top / bottom slices and regions and classified to the following groups:
 /// S_TYPE_TOP - Part of a region, which is not covered by any upper layer. This surface will be filled with a top solid infill.
-/// S_TYPE_BOTTOM | S_TYPE_BRIDGE - Part of a region, which is not fully supported, but it hangs in the air, or it hangs losely on a support or a raft.
+/// S_TYPE_BOTTOM | S_TYPE_BRIDGE - Part of a region, which is not fully supported, but it hangs in the air, or it hangs loosely on a support or a raft.
 /// S_TYPE_BOTTOM - Part of a region, which is not supported by the same region, but it is supported either by another region, or by a soluble interface layer.
 /// S_TYPE_INTERNAL - Part of a region, which is supported by the same region type.
 /// If a part of a region is of S_TYPE_BOTTOM and S_TYPE_TOP, the S_TYPE_BOTTOM wins.
@@ -417,7 +417,7 @@ Layer::detect_surfaces_type()
         #endif
     
         {
-            /*  Fill in layerm->fill_surfaces by trimming the layerm->slices by the cummulative layerm->fill_surfaces.
+            /*  Fill in layerm->fill_surfaces by trimming the layerm->slices by the cumulative layerm->fill_surfaces.
                 Note: this method should be idempotent, but fill_surfaces gets modified
                 in place. However we're now only using its boundaries (which are invariant)
                 so we're safe. This guarantees idempotence of prepare_infill() also in case

--- a/xs/src/libslic3r/LayerRegion.cpp
+++ b/xs/src/libslic3r/LayerRegion.cpp
@@ -59,7 +59,7 @@ LayerRegion::make_perimeters(const SurfaceCollection &slices, SurfaceCollection*
     );
     
     if (this->layer()->lower_layer != NULL)
-        // Cummulative sum of polygons over all the regions.
+        // Cumulative sum of polygons over all the regions.
         g.lower_slices = &this->layer()->lower_layer->slices;
     
     g.layer_id              = this->layer()->id();

--- a/xs/src/libslic3r/Model.hpp
+++ b/xs/src/libslic3r/Model.hpp
@@ -565,7 +565,7 @@ class ModelVolume
 
     /// Add a new ModelMaterial to this ModelVolume
     /// \param material_id t_model_material_id the id of the material to be added
-    /// \param material ModelMaterial the material to be coppied
+    /// \param material ModelMaterial the material to be copied
     void set_material(t_model_material_id material_id, const ModelMaterial &material);
 
     /// Add a unique ModelMaterial to the current ModelVolume

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -105,7 +105,7 @@ template<> inline t_config_enum_values ConfigOptionEnum<SeamPosition>::get_enum_
     return keys_map;
 }
 
-// Defines each and every confiuration option of Slic3r, including the properties of the GUI dialogs.
+// Defines each and every configuration option of Slic3r, including the properties of the GUI dialogs.
 // Does not store the actual values, but defines default values.
 class PrintConfigDef : public ConfigDef
 {

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -678,9 +678,9 @@ std::vector<coordf_t> PrintObject::generate_object_layers(coordf_t first_layer_h
                 // we need to thicken last layer
                 coordf_t new_h = result[last_layer] - result[last_layer-1];
                 if(this->config.adaptive_slicing.value) { // use min/max layer_height values from adaptive algo.
-                    new_h = std::min(max_layer_height, new_h - diff); // add (negativ) diff value
+                    new_h = std::min(max_layer_height, new_h - diff); // add (negative) diff value
                 }else{
-                    new_h = std::min(min_nozzle_diameter, new_h - diff); // add (negativ) diff value
+                    new_h = std::min(min_nozzle_diameter, new_h - diff); // add (negative) diff value
                 }
                 result[last_layer] = result[last_layer-1] + new_h;
             } else {

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -487,7 +487,7 @@ PrintObject::bridge_over_infill()
             printf("Bridging %zu internal areas at layer %zu\n", to_bridge.size(), layer->id());
             #endif
             
-            // compute the remaning internal solid surfaces as difference
+            // compute the remaining internal solid surfaces as difference
             const ExPolygons not_to_bridge = diff_ex(internal_solid, to_polygons(to_bridge), true);
             
             // build the new collection of fill_surfaces
@@ -1625,7 +1625,7 @@ PrintObject::_discover_neighbor_horizontal_shells(LayerRegion* layerm, const siz
                         append_to(tmp, (Polygons)s);
                 const auto grown = intersection(
                     offset(too_narrow, +margin),
-                    // Discard bridges as they are grown for anchoring and we cant
+                    // Discard bridges as they are grown for anchoring and we can't
                     // remove such anchors. (This may happen when a bridge is being 
                     // anchored onto a wall where little space remains after the bridge
                     // is grown, and that little space is an internal solid shell so 

--- a/xs/src/libslic3r/Surface.hpp
+++ b/xs/src/libslic3r/Surface.hpp
@@ -109,7 +109,7 @@ inline ExPolygons to_expolygons(const SurfacesPtr &src)
 }
 
 
-// Count a nuber of polygons stored inside the vector of expolygons.
+// Count a number of polygons stored inside the vector of expolygons.
 // Useful for allocating space for polygons when converting expolygons to polygons.
 inline size_t number_polygons(const Surfaces &surfaces)
 {

--- a/xs/src/libslic3r/TriangleMesh.cpp
+++ b/xs/src/libslic3r/TriangleMesh.cpp
@@ -1600,7 +1600,7 @@ TriangleMeshSlicer<A>::TriangleMeshSlicer(TriangleMesh* _mesh) : mesh(_mesh), v_
     
     {
         t_edges edges;
-        // reserve() instad of resize() because otherwise we couldn't read .size() below to assign edge_idx
+        // reserve() instead of resize() because otherwise we couldn't read .size() below to assign edge_idx
         edges.reserve(this->mesh->stl.stats.number_of_facets * 3);  // number of edges = number of facets * 3
         t_edges_map edges_map;
         for (int facet_idx = 0; facet_idx < this->mesh->stl.stats.number_of_facets; facet_idx++) {

--- a/xs/src/miniz/miniz.h
+++ b/xs/src/miniz/miniz.h
@@ -9,7 +9,7 @@
    * Change History
      10/13/13 v1.15 r4 - Interim bugfix release while I work on the next major release with Zip64 support (almost there!):
        - Critical fix for the MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY bug (thanks kahmyong.moon@hp.com) which could cause locate files to not find files. This bug
-        would only have occured in earlier versions if you explicitly used this flag, OR if you used mz_zip_extract_archive_file_to_heap() or mz_zip_add_mem_to_archive_file_in_place()
+        would only have occurred in earlier versions if you explicitly used this flag, OR if you used mz_zip_extract_archive_file_to_heap() or mz_zip_add_mem_to_archive_file_in_place()
         (which used this flag). If you can't switch to v1.15 but want to fix this bug, just remove the uses of this flag from both helper funcs (and of course don't use the flag).
        - Bugfix in mz_zip_reader_extract_to_mem_no_alloc() from kymoon when pUser_read_buf is not NULL and compressed size is > uncompressed size
        - Fixing mz_zip_reader_extract_*() funcs so they don't try to extract compressed data from directory entries, to account for weird zipfiles which contain zero-size compressed data on dir entries.

--- a/xs/src/poly2tri/common/shapes.h
+++ b/xs/src/poly2tri/common/shapes.h
@@ -257,7 +257,7 @@ inline bool operator !=(const Point& a, const Point& b)
   return !(a.x == b.x) && !(a.y == b.y);
 }
 
-/// Peform the dot product on two vectors.
+/// Perform the dot product on two vectors.
 inline double Dot(const Point& a, const Point& b)
 {
   return a.x * b.x + a.y * b.y;

--- a/xs/src/poly2tri/common/utils.h
+++ b/xs/src/poly2tri/common/utils.h
@@ -49,7 +49,7 @@ const double EPSILON = 1e-12;
 enum Orientation { CW, CCW, COLLINEAR };
 
 /**
- * Forumla to calculate signed area<br>
+ * Formula to calculate signed area<br>
  * Positive if CCW<br>
  * Negative if CW<br>
  * 0 if collinear<br>

--- a/xs/src/poly2tri/sweep/sweep_context.h
+++ b/xs/src/poly2tri/sweep/sweep_context.h
@@ -38,7 +38,7 @@
 
 namespace p2t {
 
-// Inital triangle factor, seed triangle will extend 30% of
+// Initial triangle factor, seed triangle will extend 30% of
 // PointSet width to both left and right.
 const double kAlpha = 0.3;
 

--- a/xs/src/tiny_obj_loader.h
+++ b/xs/src/tiny_obj_loader.h
@@ -394,7 +394,7 @@ struct vertex_index_t {
 // index + smoothing group.
 struct face_t {
   unsigned int
-      smoothing_group_id;  // smoothing group id. 0 = smoothing groupd is off.
+      smoothing_group_id;  // smoothing group id. 0 = smoothing group id is off.
   int pad_;
   std::vector<vertex_index_t> vertex_indices;  // face vertex indices.
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./t,./xs/t,./xs/xsp -L ot,uin`