### PR TITLE
Add G-code export for M3D Micro

### DIFF
--- a/xs/src/libslic3r/GCodeWriter.cpp
+++ b/xs/src/libslic3r/GCodeWriter.cpp
@@ -67,7 +67,9 @@ GCodeWriter::preamble()
     std::ostringstream gcode;
 
     if (FLAVOR_IS_NOT(gcfMakerWare)) {
-        gcode << "G21 ; set units to millimeters\n";
+        if (FLAVOR_IS_NOT(gcfM3dMicro)) {
+            gcode << "G21 ; set units to millimeters\n";
+        }
         gcode << "G90 ; use absolute coordinates\n";
     }
     if (FLAVOR_IS(gcfRepRap) || FLAVOR_IS(gcfTeacup) || FLAVOR_IS(gcfRepetier) || FLAVOR_IS(gcfSmoothie)) {

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -666,6 +666,7 @@ PrintConfigDef::PrintConfigDef()
     def->enum_values.push_back("mach3");
     def->enum_values.push_back("machinekit");
     def->enum_values.push_back("smoothie");
+    def->enum_values.push_back("m3dmicro");
     def->enum_values.push_back("no-extrusion");
     def->enum_labels.push_back("RepRap (Marlin/Sprinter)");
     def->enum_labels.push_back("Repetier");
@@ -675,6 +676,7 @@ PrintConfigDef::PrintConfigDef()
     def->enum_labels.push_back("Mach3/LinuxCNC");
     def->enum_labels.push_back("Machinekit");
     def->enum_labels.push_back("Smoothieware");
+    def->enum_labels.push_back("M3D Micro");
     def->enum_labels.push_back("No extrusion");
     def->default_value = new ConfigOptionEnum<GCodeFlavor>(gcfRepRap);
 

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -26,7 +26,7 @@
 namespace Slic3r {
 
 enum GCodeFlavor {
-    gcfRepRap, gcfTeacup, gcfMakerWare, gcfSailfish, gcfMach3, gcfMachinekit, gcfNoExtrusion, gcfSmoothie, gcfRepetier,
+    gcfRepRap, gcfTeacup, gcfMakerWare, gcfSailfish, gcfMach3, gcfMachinekit, gcfNoExtrusion, gcfSmoothie, gcfRepetier, gcfM3dMicro
 };
 
 enum HostType {
@@ -58,7 +58,8 @@ template<> inline t_config_enum_values ConfigOptionEnum<GCodeFlavor>::get_enum_v
     keys_map["mach3"]           = gcfMach3;
     keys_map["machinekit"]      = gcfMachinekit;
     keys_map["no-extrusion"]    = gcfNoExtrusion;
-    keys_map["smoothie"]    = gcfSmoothie;
+    keys_map["smoothie"]        = gcfSmoothie;
+    keys_map["m3dmicro"]        = gcfM3dMicro;
     return keys_map;
 }
 


### PR DESCRIPTION
Add a new printer profile for M3D Micro which needs minor differences to all the existing printer profiles to print the generated G-code. Builds with all existing tests passing on my Debian Buster. Have tested a few printouts which works on the M3D Micro.