### PR TITLE
Add brim_overlap option to allow control of brim bonding strength. Issue #4174.

### DIFF
--- a/lib/Slic3r/GUI/PresetEditor.pm
+++ b/lib/Slic3r/GUI/PresetEditor.pm
@@ -454,7 +454,7 @@ sub options {
         perimeter_acceleration infill_acceleration bridge_acceleration 
         first_layer_acceleration default_acceleration
         skirts skirt_distance skirt_height min_skirt_length
-        brim_connections_width brim_ears brim_ears_max_angle brim_width interior_brim_width
+        brim_connections_width brim_ears brim_ears_max_angle brim_overlap brim_width interior_brim_width
         support_material support_material_threshold support_material_max_layers support_material_enforce_layers
         raft_layers
         support_material_pattern support_material_spacing support_material_angle
@@ -596,6 +596,7 @@ sub build {
             $optgroup->append_single_option_line('brim_ears');
             $optgroup->append_single_option_line('brim_ears_max_angle');
             $optgroup->append_single_option_line('interior_brim_width');
+            $optgroup->append_single_option_line('brim_overlap');
             $optgroup->append_single_option_line('brim_connections_width');
         }
     }
@@ -953,6 +954,7 @@ sub _update {
     
     $self->get_field('brim_ears')->toggle($have_brim);
     $self->get_field('brim_ears_max_angle')->toggle($have_brim && $config->brim_ears);
+    $self->get_field('brim_overlap')->toggle($have_brim);
     
     my $have_support_material = $config->support_material || $config->raft_layers > 0;
     my $have_support_interface = $config->support_material_interface_layers > 0;

--- a/slic3r.pl
+++ b/slic3r.pl
@@ -554,6 +554,7 @@ $j
                         of filament on the first layer, for each extruder (mm, 0+, default: $config->{min_skirt_length})
     --brim-width        Width of the brim that will get added to each object to help adhesion
                         (mm, default: $config->{brim_width})
+    --brim-overlap      Overlap between perimeter and brim to control bonding strength (%, default: $config->{brim_overlap})
     --brim-ears         Print brim only on sharp corners.
     --brim-ears-max-angle Maximum angle considered for adding brim ears. (degrees, default: $config->{brim_ears_max_angle})
     --interior-brim-width  Width of the brim that will get printed inside object holes to help adhesion

--- a/src/test/libslic3r/test_skirt_brim.cpp
+++ b/src/test/libslic3r/test_skirt_brim.cpp
@@ -199,6 +199,23 @@ SCENARIO("Original Slic3r Skirt/Brim tests", "[!mayfail]") {
             }
         }
 
+        WHEN("brim overlap") {
+            config->set("skirts", 0);
+            config->set("first_layer_extrusion_width", 0.5);
+            config->set("brim_width", 1);
+            config->set("brim_overlap", 15);
+
+            Slic3r::Model model;
+            auto print {Slic3r::Test::init_print({TestMesh::cube_20x20x20}, model, config)};
+            print->process();
+
+            THEN("Gcode generates") {
+                Slic3r::Test::gcode(gcode, print);
+                auto exported {gcode.str()};
+                REQUIRE(exported.size() > 0);
+            }
+        }
+
         WHEN("Object is plated with overhang support and a brim") {
             config->set("layer_height", 0.4);
             config->set("first_layer_height", 0.4);

--- a/xs/src/libslic3r/Print.cpp
+++ b/xs/src/libslic3r/Print.cpp
@@ -351,6 +351,7 @@ Print::invalidate_state_by_config(const PrintConfigBase &config)
             || opt_key == "interior_brim_width"
             || opt_key == "brim_ears"
             || opt_key == "brim_ears_max_angle"
+            || opt_key == "brim_overlap"
             || opt_key == "brim_connections_width") {
             steps.insert(psBrim);
             steps.insert(psSkirt);
@@ -1115,18 +1116,19 @@ Print::_make_brim()
             }
         }
     }
-    
+
     Polygons loops;
     const int num_loops = floor(this->config.brim_width / flow.width + 0.5);
     for (int i = num_loops; i >= 1; --i) {
         // JT_SQUARE ensures no vertex is outside the given offset distance
         // -0.5 because islands are not represented by their centerlines
         // (first offset more, then step back - reverse order than the one used for 
-        // perimeters because here we're offsetting outwards)
+        // perimeters because here we're offsetting outwards)
         append_to(loops, offset2(
             islands,
-            flow.scaled_width() + flow.scaled_spacing() * (i - 1.5 + 0.5),
-            flow.scaled_spacing() * -0.525, // WORKAROUND for brim placement, original 0.5 leaves too much of a gap.
+            (flow.scaled_width() * 0.5 + flow.scaled_spacing() *
+             (i - 0.5 - this->config.brim_overlap.get_abs_value(1.0))),
+            flow.scaled_spacing() * -0.5,
             100000,
             ClipperLib::jtSquare
         ));

--- a/xs/src/libslic3r/PrintConfig.cpp
+++ b/xs/src/libslic3r/PrintConfig.cpp
@@ -177,6 +177,17 @@ PrintConfigDef::PrintConfigDef()
     def->max = 180;
     def->default_value = new ConfigOptionFloat(125);
 
+    def = this->add("brim_overlap", coPercent);
+    def->label = __TRANS("Brim/perimeter overlap");
+    def->gui_type = "f_enum_open";
+    def->category = __TRANS("Skirt and brim");
+    def->tooltip = __TRANS("Overlap between the perimeter and brim. Positive values stregthen and negative values weaken bonding.");
+    def->sidetext = "%";
+    def->cli = "brim-overlap=s";
+    def->enum_values.push_back("-3.13%");
+    def->enum_labels.push_back("default");
+    def->default_value = new ConfigOptionPercent(-3.13);
+
     def = this->add("brim_width", coFloat);
     def->label = __TRANS("Exterior brim width");
     def->category = __TRANS("Skirt and brim");

--- a/xs/src/libslic3r/PrintConfig.hpp
+++ b/xs/src/libslic3r/PrintConfig.hpp
@@ -437,6 +437,7 @@ class PrintConfig : public GCodeConfig
     ConfigOptionFloat               brim_connections_width;
     ConfigOptionBool                brim_ears;
     ConfigOptionFloat               brim_ears_max_angle;
+    ConfigOptionPercent             brim_overlap;
     ConfigOptionFloat               brim_width;
     ConfigOptionBool                complete_objects;
     ConfigOptionBool                cooling;
@@ -501,6 +502,7 @@ class PrintConfig : public GCodeConfig
         OPT_PTR(brim_connections_width);
         OPT_PTR(brim_ears);
         OPT_PTR(brim_ears_max_angle);
+        OPT_PTR(brim_overlap);
         OPT_PTR(brim_width);
         OPT_PTR(complete_objects);
         OPT_PTR(cooling);


### PR DESCRIPTION
This is my first pull request. Please let me know if there is anything in terms of content or protocol that I should do differently.

The value I have specified as the default (-3.13%) maintains the current brim distance although it's not a very round number.

![slic3r-branch-brim-overlap -3 13 default](https://user-images.githubusercontent.com/747308/79639815-48816480-818e-11ea-84d4-218f45b81422.png)

I have added a “default” option in `PrintConfig.cpp` but the default value still shows as `-3.13%` in the Print Settings panel. I'm not sure what I would have to change to make this show `default` instead.

![2020-04-18_16-05](https://user-images.githubusercontent.com/747308/79639944-158ba080-818f-11ea-9973-a9fc8a5ca65c.png)
