### PR TITLE
Fedora patches for Boost 1.73 compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,7 +114,7 @@ endif(NOT GIT_VERSION STREQUAL "")
 
 find_package(Threads REQUIRED)
 
-find_package(Boost REQUIRED COMPONENTS system thread filesystem)
+find_package(Boost REQUIRED COMPONENTS system thread filesystem nowide)
 
 set(LIBDIR ${CMAKE_CURRENT_SOURCE_DIR}/../xs/src/)
 set(GUI_LIBDIR ${CMAKE_CURRENT_SOURCE_DIR}/GUI/)

--- a/xs/Build.PL
+++ b/xs/Build.PL
@@ -152,7 +152,7 @@ if (defined $ENV{BOOST_LIBRARYPATH}) {
 }
 # In order to generate the -l switches we need to know how Boost libraries are named
 my $have_boost = 0;
-my @boost_libraries = qw(system thread filesystem);  # we need these
+my @boost_libraries = qw(system thread filesystem nowide);  # we need these
 # check without explicit lib path (works on Linux)
 if (! $mswin) {
     $have_boost = 1

--- a/xs/src/libslic3r/ConfigBase.cpp
+++ b/xs/src/libslic3r/ConfigBase.cpp
@@ -16,7 +16,7 @@
 #include <boost/config.hpp>
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/nowide/cenv.hpp>
+#include <boost/nowide/cstdlib.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/xs/src/libslic3r/GCodeSender.hpp
+++ b/xs/src/libslic3r/GCodeSender.hpp
@@ -7,13 +7,16 @@
 #include <string>
 #include <vector>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 #include <boost/core/noncopyable.hpp>
 
 namespace Slic3r {
 
 namespace asio = boost::asio;
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 class GCodeSender : private boost::noncopyable {
     public:

--- a/xs/src/libslic3r/GCodeTimeEstimator.cpp
+++ b/xs/src/libslic3r/GCodeTimeEstimator.cpp
@@ -1,8 +1,11 @@
 #include "GCodeTimeEstimator.hpp"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <cmath>
 
 namespace Slic3r {
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 void
 GCodeTimeEstimator::parse(const std::string &gcode)

--- a/xs/src/libslic3r/PrintObject.cpp
+++ b/xs/src/libslic3r/PrintObject.cpp
@@ -4,11 +4,14 @@
 #include "Geometry.hpp"
 #include "Log.hpp"
 #include "TransformationMatrix.hpp"
+#include <boost/bind/bind.hpp>
 #include <algorithm>
 #include <vector>
 #include <limits>
 
 namespace Slic3r {
+
+using boost::placeholders::_1;
 
 PrintObject::PrintObject(Print* print, ModelObject* model_object, const BoundingBoxf3 &modobj_bbox)
 :   layer_height_spline(model_object->layer_height_spline),

--- a/xs/src/libslic3r/SLAPrint.cpp
+++ b/xs/src/libslic3r/SLAPrint.cpp
@@ -7,8 +7,11 @@
 #include <iostream>
 #include <complex>
 #include <cstdio>
+#include <boost/bind/bind.hpp>
 
 namespace Slic3r {
+
+using boost::placeholders::_1;
 
 void
 SLAPrint::slice()

--- a/xs/src/libslic3r/TriangleMesh.cpp
+++ b/xs/src/libslic3r/TriangleMesh.cpp
@@ -15,12 +15,15 @@
 #include <stdexcept>
 #include <boost/config.hpp>
 #include <boost/nowide/convert.hpp>
+#include <boost/bind/bind.hpp>
 
 #ifdef SLIC3R_DEBUG
 #include "SVG.hpp"
 #endif
 
 namespace Slic3r {
+
+using boost::placeholders::_1;
 
 TriangleMesh::TriangleMesh()
     : repaired(false)


### PR DESCRIPTION
Fixes https://github.com/slic3r/Slic3r/issues/4967

Those are 2 of 3 Fedora patches created to be able to build with Boost 1.73.

The third is obsoleted by already existing ce966c2450183dfc1c6415161463ea8d59dcccd5.
￼
Authored by @jwakely. Only tested on 1.3.0 (and I am afraid I won't be able to test this on master any time now, I've simply rebased it).