### PR TITLE
cmake - Boost 1.70+ compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ endif(NOT GIT_VERSION STREQUAL "")
 
 find_package(Threads REQUIRED)
 
+set(Boost_NO_BOOST_CMAKE ON)
 find_package(Boost REQUIRED COMPONENTS system thread filesystem)
 
 set(LIBDIR ${CMAKE_CURRENT_SOURCE_DIR}/../xs/src/)


### PR DESCRIPTION
According to https://github.com/microsoft/vcpkg/issues/5936#issuecomment-479577971 Boost 1.70+ ships with their own cmake configuration, which is tried to be used. This failed the cmake configuration in Ubuntu 20.04 LTS with Boost 1.71.0 installed on the system unless this change is present.

Confirmed resolving building issues for the above system (Ubuntu 20.04 LTS / Boost 1.71.0)
Build still working for Windows (Win 10 64-bit / Boost 1.63.0), although I'm not sure whether this CMakeList is invoked then.
