### PR TITLE
Use the constant for clipper offset scale

### DIFF
--- a/src/test/test_data.cpp
+++ b/src/test/test_data.cpp
@@ -201,7 +201,7 @@ TriangleMesh mesh(TestMesh m) {
 }
 
 
-shared_Print init_print(std::initializer_list<TestMesh> meshes, Slic3r::Model& model, config_ptr _config, bool comments) {
+shared_Print init_print(std::initializer_list<TestMesh> meshes, Slic3r::Model& model, config_ptr _config, bool comments, Slic3r::Pointf center) {
     auto config {Slic3r::Config::new_from_defaults()};
     config->apply(_config);
 
@@ -224,7 +224,7 @@ shared_Print init_print(std::initializer_list<TestMesh> meshes, Slic3r::Model& m
     }
 
     model.arrange_objects(print->config.min_object_distance());
-    model.center_instances_around_point(Slic3r::Pointf(100,100));
+    model.center_instances_around_point(center);
     for (auto* mo : model.objects) {
         print->auto_assign_extruders(mo);
         print->add_model_object(mo);
@@ -234,7 +234,7 @@ shared_Print init_print(std::initializer_list<TestMesh> meshes, Slic3r::Model& m
 
     return print;
 }
-shared_Print init_print(std::initializer_list<TriangleMesh> meshes, Slic3r::Model& model, config_ptr _config, bool comments) {
+shared_Print init_print(std::initializer_list<TriangleMesh> meshes, Slic3r::Model& model, config_ptr _config, bool comments, Slic3r::Pointf center) {
     auto config {Slic3r::Config::new_from_defaults()};
     config->apply(_config);
 
@@ -257,7 +257,7 @@ shared_Print init_print(std::initializer_list<TriangleMesh> meshes, Slic3r::Mode
     }
 
     model.arrange_objects(print->config.min_object_distance());
-    model.center_instances_around_point(Slic3r::Pointf(100,100));
+    model.center_instances_around_point(center);
     for (auto* mo : model.objects) {
         print->auto_assign_extruders(mo);
         print->add_model_object(mo);

--- a/src/test/test_data.hpp
+++ b/src/test/test_data.hpp
@@ -65,8 +65,8 @@ bool _equiv(const T& a, const T& b, double epsilon) { return abs(a - b) < epsilo
 
 Slic3r::Model model(const std::string& model_name, TriangleMesh&& _mesh);
 
-shared_Print init_print(std::initializer_list<TestMesh> meshes, Slic3r::Model& model, config_ptr _config = Slic3r::Config::new_from_defaults(), bool comments = false);
-shared_Print init_print(std::initializer_list<TriangleMesh> meshes, Slic3r::Model& model, config_ptr _config = Slic3r::Config::new_from_defaults(), bool comments = false);
+shared_Print init_print(std::initializer_list<TestMesh> meshes, Slic3r::Model& model, config_ptr _config = Slic3r::Config::new_from_defaults(), bool comments = false, Slic3r::Pointf center = Slic3r::Pointf(100,100));
+shared_Print init_print(std::initializer_list<TriangleMesh> meshes, Slic3r::Model& model, config_ptr _config = Slic3r::Config::new_from_defaults(), bool comments = false, Slic3r::Pointf center = Slic3r::Pointf(100,100));
 
 void gcode(std::stringstream& gcode, shared_Print print);
 

--- a/xs/src/libslic3r/Print.cpp
+++ b/xs/src/libslic3r/Print.cpp
@@ -1118,7 +1118,7 @@ Print::_make_brim()
     
     Polygons loops;
     const int num_loops = floor(this->config.brim_width / flow.width + 0.5);
-    for (int i = num_loops; i >= 1; --i) {
+    for (int i = num_loops+1; i >= 1; --i) {
         // JT_SQUARE ensures no vertex is outside the given offset distance
         // -0.5 because islands are not represented by their centerlines
         // (first offset more, then step back - reverse order than the one used for 
@@ -1127,7 +1127,7 @@ Print::_make_brim()
             islands,
             flow.scaled_width() + flow.scaled_spacing() * (i - 1.5 + 0.5),
             flow.scaled_spacing() * -0.525, // WORKAROUND for brim placement, original 0.5 leaves too much of a gap.
-            100000,
+            CLIPPER_OFFSET_SCALE,
             ClipperLib::jtSquare
         ));
     }


### PR DESCRIPTION
 (needed because we are passing jtSquare), fix an off-by-one error where the outermost loop was never generated.

Add a test to check the extents of the generated brim.

test util: Allow a different center to be specified when initializing test prints instead of 100,100.