### PR TITLE
Allow for compiling with debug output turned on by default.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,9 +8,13 @@ option(SLIC3R_STATIC "Build and link Slic3r statically." ON)
 option(BUILD_EXTRUDE_TIN "Build and link the extrude-tin application." OFF)
 option(PROFILE "Build with gprof profiling output." OFF)
 option(COVERAGE "Build with gcov code coverage profiling." OFF)
+option(SLIC3R_DEBUG "Build with Slic3r's debug output" OFF)
 
 # only on newer GCCs: -ftemplate-backtrace-limit=0
 add_compile_options(-DNO_PERL -DM_PI=3.14159265358979323846 -DHAS_BOOL -DNOGDI -DBOOST_ASIO_DISABLE_KQUEUE)
+if(SLIC3R_DEBUG)
+    add_compile_options(-DSLIC3R_DEBUG)
+endif()
 
 if (MSVC)
     add_compile_options(-W3)

--- a/src/slic3r.cpp
+++ b/src/slic3r.cpp
@@ -34,6 +34,9 @@ main(int argc, char **argv) {
 #endif // BUILD_TEST
 
 int CLI::run(int argc, char **argv) {
+    #ifdef SLIC3R_DEBUG
+        slic3r_log->set_level(log_t::DEBUG);
+    #endif
     // Convert arguments to UTF-8 (needed on Windows).
     // argv then points to memory owned by a.
     boost::nowide::args a(argc, argv);

--- a/xs/src/libslic3r/Layer.cpp
+++ b/xs/src/libslic3r/Layer.cpp
@@ -2,6 +2,7 @@
 #include "ClipperUtils.hpp"
 #include "Geometry.hpp"
 #include "Print.hpp"
+#include "Log.hpp"
 
 namespace Slic3r {
 


### PR DESCRIPTION
Automatically log at the DEBUG level if this is done.
Fix compile issue where Log.hpp wasn't available.