### PR TITLE
Add a GUI Preference option to show the overwrite dialog

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -64,6 +64,9 @@ void AppConfig::set_defaults()
         if (get("freecad_path").empty())
             set("freecad_path", ".");
 
+        if (get("show_overwrite_dialog").empty())
+            set("show_overwrite_dialog", "1");
+
         if (get("tab_icon_size").empty())
             set("tab_icon_size", "32");
 

--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -123,6 +123,8 @@ public:
 	std::string 		get_last_output_dir(const std::string& alt, const bool removable = false) const;
 	void                update_last_output_dir(const std::string &dir, const bool removable = false);
 
+	bool                get_show_overwrite_dialog() const { return get("show_overwrite_dialog") != "0"; }
+
 	// reset the current print / filament / printer selections, so that 
 	// the  PresetBundle::load_selections(const AppConfig &config) call will select
 	// the first non-default preset when called.

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1654,7 +1654,7 @@ void MainFrame::quick_slice(const int qs)
         wxFileDialog dlg(this, from_u8((boost::format(_utf8(L("Save %s file as:"))) % ((qs & qsExportSVG) ? _L("SVG") : _L("G-code"))).str()),
             wxGetApp().app_config->get_last_output_dir(get_dir_name(output_file)), get_base_name(input_file), 
             qs & qsExportSVG ? file_wildcards(FT_SVG) : file_wildcards(FT_GCODE),
-            wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+            wxFD_SAVE | (wxGetApp().app_config->get_show_overwrite_dialog() ? wxFD_OVERWRITE_PROMPT : 0));
         if (dlg.ShowModal() != wxID_OK)
             return;
         output_file = dlg.GetPath();
@@ -1665,7 +1665,7 @@ void MainFrame::quick_slice(const int qs)
     else if (qs & qsExportPNG) {
         wxFileDialog dlg(this, _L("Save zip file as:"),
             wxGetApp().app_config->get_last_output_dir(get_dir_name(output_file)),
-            get_base_name(output_file), "*.sl1", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+            get_base_name(output_file), "*.sl1", wxFD_SAVE | (wxGetApp().app_config->get_show_overwrite_dialog() ? wxFD_OVERWRITE_PROMPT : 0));
         if (dlg.ShowModal() != wxID_OK)
             return;
         output_file = dlg.GetPath();
@@ -1726,7 +1726,7 @@ void MainFrame::repair_stl()
     {
         wxFileDialog dlg( this, L("Save OBJ file (less prone to coordinate errors than STL) as:"),
                                         get_dir_name(output_file), get_base_name(output_file, ".obj"),
-                                        file_wildcards(FT_OBJ), wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+                                        file_wildcards(FT_OBJ), wxFD_SAVE | (wxGetApp().app_config->get_show_overwrite_dialog() ? wxFD_OVERWRITE_PROMPT : 0));
         if (dlg.ShowModal() != wxID_OK)
             return;
         output_file = dlg.GetPath();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2742,7 +2742,7 @@ wxString Plater::priv::get_export_file(GUI::FileType file_type)
 
     wxFileDialog dlg(q, dlg_title,
         from_path(output_file.parent_path()), from_path(output_file.filename()),
-        wildcard, wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+        wildcard, wxFD_SAVE |(wxGetApp().app_config->get_show_overwrite_dialog() ? wxFD_OVERWRITE_PROMPT : 0) );
 
     if (dlg.ShowModal() != wxID_OK)
         return wxEmptyString;
@@ -5500,7 +5500,7 @@ void Plater::export_gcode(bool prefer_removable)
             start_dir,
             from_path(default_output_file.filename()),
             GUI::file_wildcards((printer_technology() == ptFFF) ? FT_GCODE : FT_PNGZIP, default_output_file.extension().string()),
-            wxFD_SAVE | wxFD_OVERWRITE_PROMPT
+            wxFD_SAVE | (wxGetApp().app_config->get_show_overwrite_dialog() ? wxFD_OVERWRITE_PROMPT : 0)
         );
         if (dlg.ShowModal() == wxID_OK)
             output_path = into_path(dlg.GetPath());

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -77,6 +77,15 @@ void PreferencesDialog::build()
 		option = Option(def, "remember_output_path");
 	m_optgroup_general->append_single_option_line(option);
 
+	ConfigOptionDef def;
+	Option option(def, "");
+	def.label = L("Show overwrite dialog.");
+	def.type = coBool;
+	def.tooltip = L("If this is enabled, Slic3r will prompt for when overwriting files from save dialogs.");
+	def.set_default_value(new ConfigOptionBool{ app_config->has("show_overwrite_dialog") ? app_config->get("show_overwrite_dialog") == "1" : true });
+		option = Option(def, "show_overwrite_dialog");
+	m_optgroup_general->append_single_option_line(option);
+
 	def.label = L("Auto-center parts");
 	def.type = coBool;
 	def.tooltip = L("If this is enabled, Slic3r will auto-center objects "


### PR DESCRIPTION
Add a new GUI Preferences option. Controls whether or not save dialogs in file output appear.

Defaults to "Yes"