### PR TITLE
Added missing bounds check to TriangleMesh constructor

### DIFF
--- a/xs/src/libslic3r/IO.cpp
+++ b/xs/src/libslic3r/IO.cpp
@@ -143,10 +143,12 @@ OBJ::read(std::string input_file, Model* model)
             ));
         }
         
-        TriangleMesh mesh(points, facets);
-        mesh.check_topology();
-        ModelVolume* volume = object->add_volume(mesh);
-        volume->name        = object->name;
+        if (points.size() > 0) {
+          TriangleMesh mesh(points, facets);
+          mesh.check_topology();
+          ModelVolume* volume = object->add_volume(mesh);
+          volume->name        = object->name;
+        }
     }
     
     return true;

--- a/xs/src/libslic3r/IO.cpp
+++ b/xs/src/libslic3r/IO.cpp
@@ -143,12 +143,10 @@ OBJ::read(std::string input_file, Model* model)
             ));
         }
         
-        if (points.size() > 0) {
-          TriangleMesh mesh(points, facets);
-          mesh.check_topology();
-          ModelVolume* volume = object->add_volume(mesh);
-          volume->name        = object->name;
-        }
+        TriangleMesh mesh(points, facets);
+        mesh.check_topology();
+        ModelVolume* volume = object->add_volume(mesh);
+        volume->name        = object->name;
     }
     
     return true;

--- a/xs/src/libslic3r/TriangleMesh.cpp
+++ b/xs/src/libslic3r/TriangleMesh.cpp
@@ -37,7 +37,7 @@ TriangleMesh::TriangleMesh()
     stl_initialize(&this->stl);
 }
 
-TriangleMesh::TriangleMesh(const Pointf3* points, const Point3* facets, size_t n_facets) 
+TriangleMesh::TriangleMesh(const Pointf3* points, size_t n_points, const Point3* facets, size_t n_facets) 
     : repaired(false)
 {
     stl_initialize(&this->stl);
@@ -51,6 +51,13 @@ TriangleMesh::TriangleMesh(const Pointf3* points, const Point3* facets, size_t n
     stl_allocate(&stl);
 
     for (int i = 0; i < stl.stats.number_of_facets; i++) {
+
+        if (facets[i].x >= n_points ||
+            facets[i].y >= n_points ||
+            facets[i].z >= n_points) {
+          throw std::runtime_error("Invalid facet");
+        }
+
         stl_facet facet;
         facet.normal.x = 0;
         facet.normal.y = 0;

--- a/xs/src/libslic3r/TriangleMesh.hpp
+++ b/xs/src/libslic3r/TriangleMesh.hpp
@@ -42,7 +42,7 @@ class TriangleMesh
     /// First argument is a container (either vector or array) of Pointf3 for the vertex data.
     /// Second argument is container of facets (currently Point3).
     template <typename Vertex_Cont, typename Facet_Cont>
-    TriangleMesh(const Vertex_Cont& vertices, const Facet_Cont& facets) : TriangleMesh(vertices.data(), facets.data(), facets.size()) {}
+    TriangleMesh(const Vertex_Cont& vertices, const Facet_Cont& facets) : TriangleMesh(vertices.data(), vertices.size(), facets.data(), facets.size()) {}
 
     TriangleMesh(const TriangleMesh &other);
     ///  copy assignment
@@ -163,7 +163,7 @@ class TriangleMesh
     /// Private constructor that is called from the public sphere. 
     /// It doesn't do any bounds checking on points and operates on raw pointers, so we hide it. 
     /// Other constructors can call this one!
-    TriangleMesh(const Pointf3* points, const Point3* facets, size_t n_facets); 
+    TriangleMesh(const Pointf3* points, size_t n_points, const Point3* facets, size_t n_facets); 
 
     /// Perform the mechanics of a stl copy
     void clone(const TriangleMesh& other);


### PR DESCRIPTION
This fixes issue #5115 and the long-standing CVE-2020-28590.